### PR TITLE
Fix test-results page: correct data and visual bars

### DIFF
--- a/docs/test-results/index.html
+++ b/docs/test-results/index.html
@@ -6,99 +6,70 @@
   <style>
     body { font-family: monospace; max-width: 900px; margin: 2em auto; padding: 0 1em; }
     h1 { border-bottom: 2px solid #333; }
+    h2 { margin-top: 2em; }
     .pass { color: green; font-weight: bold; }
-    .fail { color: red; font-weight: bold; }
+    .fail { color: red; }
     .skip { color: gray; }
     pre { background: #f5f5f5; padding: 1em; overflow-x: auto; border: 1px solid #ddd; }
-    table { border-collapse: collapse; width: 100%; }
+    table { border-collapse: collapse; width: 100%; margin: 1em 0; }
     th, td { border: 1px solid #ddd; padding: 4px 8px; text-align: left; }
     th { background: #f0f0f0; }
     .timestamp { color: #666; font-size: 0.9em; }
+    .summary { background: #e8f5e9; border: 1px solid #4caf50; padding: 1em; margin: 1em 0; }
+    .bar { display: inline-block; height: 14px; }
+    .bar-pass { background: #4caf50; }
+    .bar-fail { background: #f44336; }
+    .bar-skip { background: #9e9e9e; }
+    a { color: #1565c0; }
   </style>
 </head>
 <body>
 <h1>Factoidal W3C Test Results</h1>
-<p class='timestamp'>Last updated: 2026-03-10T14:04:08Z</p>
+<p class="timestamp">Last updated: 2026-03-10</p>
+<p><a href="/factoidal/">&larr; Back to Factoidal</a></p>
+
+<div class="summary">
+  <strong>SPARQL 1.1:</strong> 303 pass, 105 fail, 205 skip, 18 unsupported (631 total &mdash; 74% of applicable)<br>
+  <strong>RDF 1.1:</strong> 644 pass, 387 fail (1031 total &mdash; 62%)
+</div>
+
 <h2>SPARQL 1.1</h2>
-<pre>
-  add                                 pass:0 fail:0 skip:8 unsupported:0
-  aggregates                          pass:30 fail:14 skip:0 unsupported:3
-  basic-update                        pass:0 fail:0 skip:13 unsupported:0
-  bind                                pass:10 fail:0 skip:0 unsupported:0
-  bindings                            pass:10 fail:0 skip:0 unsupported:1
-  cast                                pass:0 fail:6 skip:0 unsupported:0
-  clear                               pass:0 fail:0 skip:4 unsupported:0
-  construct                           pass:2 fail:0 skip:0 unsupported:5
-  copy                                pass:0 fail:0 skip:6 unsupported:0
-  csv-tsv-res                         pass:0 fail:0 skip:0 unsupported:6
-  delete                              pass:0 fail:0 skip:19 unsupported:0
-  delete-data                         pass:0 fail:0 skip:6 unsupported:0
-  delete-insert                       pass:8 fail:0 skip:9 unsupported:0
-  delete-where                        pass:0 fail:0 skip:6 unsupported:0
-  drop                                pass:0 fail:0 skip:4 unsupported:0
-  entailment                          pass:27 fail:43 skip:0 unsupported:0
-  exists                              pass:5 fail:1 skip:0 unsupported:0
-  functions                           pass:42 fail:33 skip:0 unsupported:0
-  grouping                            pass:6 fail:0 skip:0 unsupported:0
-  http-rdf-update                     pass:0 fail:0 skip:19 unsupported:0
-  json-res                            pass:0 fail:0 skip:0 unsupported:4
-  move                                pass:0 fail:0 skip:6 unsupported:0
-  negation                            pass:11 fail:1 skip:0 unsupported:0
-  project-expression                  pass:3 fail:4 skip:0 unsupported:0
-  property-path                       pass:31 fail:2 skip:0 unsupported:0
-  protocol                            pass:0 fail:0 skip:34 unsupported:0
-  service                             pass:0 fail:7 skip:0 unsupported:0
-  service-description                 pass:0 fail:0 skip:3 unsupported:0
-  subquery                            pass:9 fail:3 skip:0 unsupported:2
-  syntax-fed                          pass:3 fail:0 skip:0 unsupported:0
-  syntax-query                        pass:94 fail:0 skip:0 unsupported:0
-  syntax-update-1                     pass:0 fail:0 skip:54 unsupported:0
-  syntax-update-2                     pass:0 fail:0 skip:1 unsupported:0
-  update-silent                       pass:0 fail:0 skip:13 unsupported:0
-</pre>
-<p><strong>========================================</strong></p>
+<table>
+<tr><th>Suite</th><th>Pass</th><th>Fail</th><th>Skip</th><th>Unsup.</th><th>Coverage</th></tr>
+<tr><td>aggregates</td><td class="pass">38</td><td class="fail">6</td><td class="skip">0</td><td>3</td><td><span class="bar bar-pass" style="width:86px"></span><span class="bar bar-fail" style="width:14px"></span></td></tr>
+<tr><td>bind</td><td class="pass">9</td><td class="fail">1</td><td class="skip">0</td><td>0</td><td><span class="bar bar-pass" style="width:90px"></span><span class="bar bar-fail" style="width:10px"></span></td></tr>
+<tr><td>bindings</td><td class="pass">10</td><td class="fail">1</td><td class="skip">0</td><td>0</td><td><span class="bar bar-pass" style="width:91px"></span><span class="bar bar-fail" style="width:9px"></span></td></tr>
+<tr><td>cast</td><td class="pass">1</td><td class="fail">5</td><td class="skip">0</td><td>0</td><td><span class="bar bar-pass" style="width:17px"></span><span class="bar bar-fail" style="width:83px"></span></td></tr>
+<tr><td>construct</td><td class="pass">1</td><td class="fail">3</td><td class="skip">0</td><td>3</td><td><span class="bar bar-pass" style="width:25px"></span><span class="bar bar-fail" style="width:75px"></span></td></tr>
+<tr><td>entailment</td><td class="pass">26</td><td class="fail">44</td><td class="skip">0</td><td>0</td><td><span class="bar bar-pass" style="width:37px"></span><span class="bar bar-fail" style="width:63px"></span></td></tr>
+<tr><td>exists</td><td class="pass">5</td><td class="fail">1</td><td class="skip">0</td><td>0</td><td><span class="bar bar-pass" style="width:83px"></span><span class="bar bar-fail" style="width:17px"></span></td></tr>
+<tr><td>functions</td><td class="pass">71</td><td class="fail">4</td><td class="skip">0</td><td>0</td><td><span class="bar bar-pass" style="width:95px"></span><span class="bar bar-fail" style="width:5px"></span></td></tr>
+<tr><td>grouping</td><td class="pass">4</td><td class="fail">2</td><td class="skip">0</td><td>0</td><td><span class="bar bar-pass" style="width:67px"></span><span class="bar bar-fail" style="width:33px"></span></td></tr>
+<tr><td>negation</td><td class="pass">11</td><td class="fail">1</td><td class="skip">0</td><td>0</td><td><span class="bar bar-pass" style="width:92px"></span><span class="bar bar-fail" style="width:8px"></span></td></tr>
+<tr><td>project-expression</td><td class="pass">7</td><td class="fail">0</td><td class="skip">0</td><td>0</td><td><span class="bar bar-pass" style="width:100px"></span></td></tr>
+<tr><td>property-path</td><td class="pass">31</td><td class="fail">2</td><td class="skip">0</td><td>0</td><td><span class="bar bar-pass" style="width:94px"></span><span class="bar bar-fail" style="width:6px"></span></td></tr>
+<tr><td>service</td><td class="pass">0</td><td class="fail">7</td><td class="skip">0</td><td>0</td><td><span class="bar bar-fail" style="width:100px"></span></td></tr>
+<tr><td>subquery</td><td class="pass">9</td><td class="fail">3</td><td class="skip">0</td><td>2</td><td><span class="bar bar-pass" style="width:75px"></span><span class="bar bar-fail" style="width:25px"></span></td></tr>
+<tr><td>syntax-query</td><td class="pass">72</td><td class="fail">22</td><td class="skip">0</td><td>0</td><td><span class="bar bar-pass" style="width:77px"></span><span class="bar bar-fail" style="width:23px"></span></td></tr>
+<tr><td>delete-insert</td><td class="pass">8</td><td class="fail">9</td><td class="skip">0</td><td>0</td><td><span class="bar bar-pass" style="width:47px"></span><span class="bar bar-fail" style="width:53px"></span></td></tr>
+<tr><td colspan="6" style="color:gray"><em>Skipped suites (205 tests): add, basic-update, clear, copy, delete, delete-data, delete-where, drop, move, http-rdf-update, protocol, service-description, syntax-update-1/2, update-silent (all UPDATE/Protocol)</em></td></tr>
+<tr><td colspan="6" style="color:gray"><em>Unsupported formats (18 tests): json-res (4), csv-tsv-res (6), aggregates/construct/subquery Turtle results (8)</em></td></tr>
+</table>
+
 <h2>RDF 1.1</h2>
-<pre>
-  add                                 pass:0 fail:0 skip:8 unsupported:0
-  aggregates                          pass:30 fail:14 skip:0 unsupported:3
-  basic-update                        pass:0 fail:0 skip:13 unsupported:0
-  bind                                pass:10 fail:0 skip:0 unsupported:0
-  bindings                            pass:10 fail:0 skip:0 unsupported:1
-  cast                                pass:0 fail:6 skip:0 unsupported:0
-  clear                               pass:0 fail:0 skip:4 unsupported:0
-  construct                           pass:2 fail:0 skip:0 unsupported:5
-  copy                                pass:0 fail:0 skip:6 unsupported:0
-  csv-tsv-res                         pass:0 fail:0 skip:0 unsupported:6
-  delete                              pass:0 fail:0 skip:19 unsupported:0
-  delete-data                         pass:0 fail:0 skip:6 unsupported:0
-  delete-insert                       pass:8 fail:0 skip:9 unsupported:0
-  delete-where                        pass:0 fail:0 skip:6 unsupported:0
-  drop                                pass:0 fail:0 skip:4 unsupported:0
-  entailment                          pass:27 fail:43 skip:0 unsupported:0
-  exists                              pass:5 fail:1 skip:0 unsupported:0
-  functions                           pass:42 fail:33 skip:0 unsupported:0
-  grouping                            pass:6 fail:0 skip:0 unsupported:0
-  http-rdf-update                     pass:0 fail:0 skip:19 unsupported:0
-  json-res                            pass:0 fail:0 skip:0 unsupported:4
-  move                                pass:0 fail:0 skip:6 unsupported:0
-  negation                            pass:11 fail:1 skip:0 unsupported:0
-  project-expression                  pass:3 fail:4 skip:0 unsupported:0
-  property-path                       pass:31 fail:2 skip:0 unsupported:0
-  protocol                            pass:0 fail:0 skip:34 unsupported:0
-  service                             pass:0 fail:7 skip:0 unsupported:0
-  service-description                 pass:0 fail:0 skip:3 unsupported:0
-  subquery                            pass:9 fail:3 skip:0 unsupported:2
-  syntax-fed                          pass:3 fail:0 skip:0 unsupported:0
-  syntax-query                        pass:94 fail:0 skip:0 unsupported:0
-  syntax-update-1                     pass:0 fail:0 skip:54 unsupported:0
-  syntax-update-2                     pass:0 fail:0 skip:1 unsupported:0
-  update-silent                       pass:0 fail:0 skip:13 unsupported:0
-  rdf-mt                              pass:33 fail:6 skip:0 unsupported:0
-  rdf-n-quads                         pass:53 fail:34 skip:0 unsupported:0
-  rdf-n-triples                       pass:41 fail:29 skip:0 unsupported:0
-  rdf-trig                            pass:237 fail:119 skip:0 unsupported:0
-  rdf-turtle                          pass:217 fail:96 skip:0 unsupported:0
-  rdf-xml                             pass:91 fail:75 skip:0 unsupported:0
-</pre>
-<p><strong>========================================</strong></p>
+<table>
+<tr><th>Suite</th><th>Pass</th><th>Fail</th><th>Total</th><th>Coverage</th></tr>
+<tr><td>N-Triples</td><td class="pass">41</td><td class="fail">29</td><td>70</td><td><span class="bar bar-pass" style="width:59px"></span><span class="bar bar-fail" style="width:41px"></span></td></tr>
+<tr><td>Turtle</td><td class="pass">203</td><td class="fail">110</td><td>313</td><td><span class="bar bar-pass" style="width:65px"></span><span class="bar bar-fail" style="width:35px"></span></td></tr>
+<tr><td>N-Quads</td><td class="pass">53</td><td class="fail">34</td><td>87</td><td><span class="bar bar-pass" style="width:61px"></span><span class="bar bar-fail" style="width:39px"></span></td></tr>
+<tr><td>TriG</td><td class="pass">223</td><td class="fail">133</td><td>356</td><td><span class="bar bar-pass" style="width:63px"></span><span class="bar bar-fail" style="width:37px"></span></td></tr>
+<tr><td>RDF/XML</td><td class="pass">91</td><td class="fail">75</td><td>166</td><td><span class="bar bar-pass" style="width:55px"></span><span class="bar bar-fail" style="width:45px"></span></td></tr>
+<tr><td>rdf-mt (Model Theory)</td><td class="pass">33</td><td class="fail">6</td><td>39</td><td><span class="bar bar-pass" style="width:85px"></span><span class="bar bar-fail" style="width:15px"></span></td></tr>
+</table>
+
+<h2>About These Tests</h2>
+<p>Tests are run against the official <a href="https://github.com/w3c/rdf-tests">W3C RDF/SPARQL conformance suites</a>.
+The SPARQL evaluator and all RDF parsers are written in <a href="https://fstar-lang.org/">F*</a> and extracted to OCaml.
+See <a href="https://github.com/danbri/factoidal">the repository</a> for details.</p>
+
 </body></html>


### PR DESCRIPTION
## Summary

- RDF 1.1 section was showing duplicated SPARQL data — now shows actual per-suite RDF parser results
- Added visual coverage bar charts for each suite
- Updated scores to match current CLAUDE.md numbers
- Added summary box at top with overall pass rates (SPARQL 74%, RDF 62%)
- Added nav link back to main site

https://claude.ai/code/session_01LtDGUVVKCJtM2342GL6N6k