### PR TITLE
Revert PR #43: parser changes didn't verify

### DIFF
--- a/formal/fstar/Parser.NQuads.fst
+++ b/formal/fstar/Parser.NQuads.fst
@@ -68,8 +68,6 @@ let parse_opt_graph_label : parser (option iri) =
           | ParseOk g pos2 -> ParseOk (Some g) pos2
           | ParseFail msg fpos -> ParseFail msg fpos
           end
-        else if code = 0x22 then // '"' — literal not allowed as graph name
-          ParseFail "literal not allowed as graph name" pos1
         else
           ParseOk None pos1
     | ParseFail msg fpos -> ParseFail msg fpos

--- a/formal/fstar/Parser.NTriples.fst
+++ b/formal/fstar/Parser.NTriples.fst
@@ -17,14 +17,6 @@ let hex_val (c:FStar.Char.char) : int =
   else if code >= 0x61 && code <= 0x66 then code - 0x61 + 10  (* a-f *)
   else 0
 
-// hex_val_opt: returns None for non-hex characters instead of silently returning 0
-let hex_val_opt (c:FStar.Char.char) : option int =
-  let code = FStar.Char.int_of_char c in
-  if code >= 0x30 && code <= 0x39 then Some (code - 0x30)
-  else if code >= 0x41 && code <= 0x46 then Some (code - 0x41 + 10)
-  else if code >= 0x61 && code <= 0x66 then Some (code - 0x61 + 10)
-  else None
-
 (* Convert a code point integer to a single-character string.
    F* Char supports full Unicode via FStar.Char.char_of_int. *)
 // Valid Unicode scalar value: excludes surrogates U+D800..U+DFFF
@@ -32,9 +24,9 @@ let valid_codepoint (cp:int) : bool =
   cp >= 0 && (cp < 0xD800 || (cp >= 0xE000 && cp <= 0x10FFFF))
 
 // Safe char_of_int: validates codepoint, returns U+FFFD replacement for invalid
-// Excludes surrogates U+D800..U+DFFF per Unicode
+// Note: F* char_of_int uses cp < 0xD7FF (slightly more restrictive than Unicode)
 let safe_char_of_int (cp:int) : FStar.Char.char =
-  if cp >= 0 && (cp < 0xD800 || (cp >= 0xE000 && cp <= 0x10FFFF)) then
+  if cp >= 0 && (cp < 0xD7FF || (cp >= 0xE000 && cp <= 0x10FFFF)) then
     let n : nat = cp in
     FStar.Char.char_of_int n
   else
@@ -84,36 +76,32 @@ let rec parse_iri_body_acc (input:string) (pos:nat) (acc:list char) (fuel:nat)
           if ncode = 0x75 then (* 'u' - \uXXXX *)
             if pos + 6 > len then ParseFail "incomplete \\u escape in IRI" pos
             else
-              match hex_val_opt (String.index input (pos + 2)),
-                    hex_val_opt (String.index input (pos + 3)),
-                    hex_val_opt (String.index input (pos + 4)),
-                    hex_val_opt (String.index input (pos + 5)) with
-              | Some h0, Some h1, Some h2, Some h3 ->
-                let cp = ((h0 `op_Multiply` 4096) + (h1 `op_Multiply` 256) + (h2 `op_Multiply` 16) + h3) in
-                if not (valid_codepoint cp) then ParseFail "surrogate codepoint in \\u escape" pos
-                else
-                  let c = safe_char_of_int cp in
-                  parse_iri_body_acc input (pos + 6) (c :: acc) (fuel - 1)
-              | _ -> ParseFail "invalid hex digit in \\u escape" pos
+              let h0 = hex_val (String.index input (pos + 2)) in
+              let h1 = hex_val (String.index input (pos + 3)) in
+              let h2 = hex_val (String.index input (pos + 4)) in
+              let h3 = hex_val (String.index input (pos + 5)) in
+              let cp = ((h0 `op_Multiply` 4096) + (h1 `op_Multiply` 256) + (h2 `op_Multiply` 16) + h3) in
+              if not (valid_codepoint cp) then ParseFail "surrogate codepoint in \\u escape" pos
+              else
+                let c = safe_char_of_int cp in
+                parse_iri_body_acc input (pos + 6) (c :: acc) (fuel - 1)
           else if ncode = 0x55 then (* 'U' - \UXXXXXXXX *)
             if pos + 10 > len then ParseFail "incomplete \\U escape in IRI" pos
             else
-              match hex_val_opt (String.index input (pos + 2)),
-                    hex_val_opt (String.index input (pos + 3)),
-                    hex_val_opt (String.index input (pos + 4)),
-                    hex_val_opt (String.index input (pos + 5)),
-                    hex_val_opt (String.index input (pos + 6)),
-                    hex_val_opt (String.index input (pos + 7)),
-                    hex_val_opt (String.index input (pos + 8)),
-                    hex_val_opt (String.index input (pos + 9)) with
-              | Some h0, Some h1, Some h2, Some h3, Some h4, Some h5, Some h6, Some h7 ->
-                let cp = ((h0 `op_Multiply` 268435456) + (h1 `op_Multiply` 16777216) + (h2 `op_Multiply` 1048576) + (h3 `op_Multiply` 65536)
-                       + (h4 `op_Multiply` 4096) + (h5 `op_Multiply` 256) + (h6 `op_Multiply` 16) + h7) in
-                if not (valid_codepoint cp) then ParseFail "surrogate codepoint in \\U escape" pos
-                else
-                  let c = safe_char_of_int cp in
-                  parse_iri_body_acc input (pos + 10) (c :: acc) (fuel - 1)
-              | _ -> ParseFail "invalid hex digit in \\U escape" pos
+              let h0 = hex_val (String.index input (pos + 2)) in
+              let h1 = hex_val (String.index input (pos + 3)) in
+              let h2 = hex_val (String.index input (pos + 4)) in
+              let h3 = hex_val (String.index input (pos + 5)) in
+              let h4 = hex_val (String.index input (pos + 6)) in
+              let h5 = hex_val (String.index input (pos + 7)) in
+              let h6 = hex_val (String.index input (pos + 8)) in
+              let h7 = hex_val (String.index input (pos + 9)) in
+              let cp = ((h0 `op_Multiply` 268435456) + (h1 `op_Multiply` 16777216) + (h2 `op_Multiply` 1048576) + (h3 `op_Multiply` 65536)
+                     + (h4 `op_Multiply` 4096) + (h5 `op_Multiply` 256) + (h6 `op_Multiply` 16) + h7) in
+              if not (valid_codepoint cp) then ParseFail "surrogate codepoint in \\U escape" pos
+              else
+                let c = safe_char_of_int cp in
+                parse_iri_body_acc input (pos + 10) (c :: acc) (fuel - 1)
           else
             ParseFail "invalid escape in IRI" pos
       else if code <= 0x20 then (* control chars and space not allowed in IRIs *)
@@ -259,36 +247,32 @@ let rec parse_string_body (input:string) (pos:nat) (acc:list char) (fuel:nat)
           else if esc_code = 0x75 then (* \uXXXX *)
             if pos + 6 > len then ParseFail "incomplete \\u escape" pos
             else
-              match hex_val_opt (String.index input (pos + 2)),
-                    hex_val_opt (String.index input (pos + 3)),
-                    hex_val_opt (String.index input (pos + 4)),
-                    hex_val_opt (String.index input (pos + 5)) with
-              | Some h0, Some h1, Some h2, Some h3 ->
-                let cp = ((h0 `op_Multiply` 4096) + (h1 `op_Multiply` 256) + (h2 `op_Multiply` 16) + h3) in
-                if not (valid_codepoint cp) then ParseFail "surrogate codepoint in \\u escape" pos
-                else
-                  let c = safe_char_of_int cp in
-                  parse_string_body input (pos + 6) (c :: acc) (fuel - 1)
-              | _ -> ParseFail "invalid hex digit in \\u escape" pos
+              let h0 = hex_val (String.index input (pos + 2)) in
+              let h1 = hex_val (String.index input (pos + 3)) in
+              let h2 = hex_val (String.index input (pos + 4)) in
+              let h3 = hex_val (String.index input (pos + 5)) in
+              let cp = ((h0 `op_Multiply` 4096) + (h1 `op_Multiply` 256) + (h2 `op_Multiply` 16) + h3) in
+              if not (valid_codepoint cp) then ParseFail "surrogate codepoint in \\u escape" pos
+              else
+                let c = safe_char_of_int cp in
+                parse_string_body input (pos + 6) (c :: acc) (fuel - 1)
           else if esc_code = 0x55 then (* \UXXXXXXXX *)
             if pos + 10 > len then ParseFail "incomplete \\U escape" pos
             else
-              match hex_val_opt (String.index input (pos + 2)),
-                    hex_val_opt (String.index input (pos + 3)),
-                    hex_val_opt (String.index input (pos + 4)),
-                    hex_val_opt (String.index input (pos + 5)),
-                    hex_val_opt (String.index input (pos + 6)),
-                    hex_val_opt (String.index input (pos + 7)),
-                    hex_val_opt (String.index input (pos + 8)),
-                    hex_val_opt (String.index input (pos + 9)) with
-              | Some h0, Some h1, Some h2, Some h3, Some h4, Some h5, Some h6, Some h7 ->
-                let cp = ((h0 `op_Multiply` 268435456) + (h1 `op_Multiply` 16777216) + (h2 `op_Multiply` 1048576) + (h3 `op_Multiply` 65536)
-                       + (h4 `op_Multiply` 4096) + (h5 `op_Multiply` 256) + (h6 `op_Multiply` 16) + h7) in
-                if not (valid_codepoint cp) then ParseFail "surrogate codepoint in \\U escape" pos
-                else
-                  let c = safe_char_of_int cp in
-                  parse_string_body input (pos + 10) (c :: acc) (fuel - 1)
-              | _ -> ParseFail "invalid hex digit in \\U escape" pos
+              let h0 = hex_val (String.index input (pos + 2)) in
+              let h1 = hex_val (String.index input (pos + 3)) in
+              let h2 = hex_val (String.index input (pos + 4)) in
+              let h3 = hex_val (String.index input (pos + 5)) in
+              let h4 = hex_val (String.index input (pos + 6)) in
+              let h5 = hex_val (String.index input (pos + 7)) in
+              let h6 = hex_val (String.index input (pos + 8)) in
+              let h7 = hex_val (String.index input (pos + 9)) in
+              let cp = ((h0 `op_Multiply` 268435456) + (h1 `op_Multiply` 16777216) + (h2 `op_Multiply` 1048576) + (h3 `op_Multiply` 65536)
+                     + (h4 `op_Multiply` 4096) + (h5 `op_Multiply` 256) + (h6 `op_Multiply` 16) + h7) in
+              if not (valid_codepoint cp) then ParseFail "surrogate codepoint in \\U escape" pos
+              else
+                let c = safe_char_of_int cp in
+                parse_string_body input (pos + 10) (c :: acc) (fuel - 1)
           else
             ParseFail (String.concat "" ["invalid escape: \\"; String.string_of_char esc]) pos
       else if code = 0x0A || code = 0x0D then
@@ -321,11 +305,6 @@ let is_lang_char (c:FStar.Char.char) : bool =
   (code >= 0x30 && code <= 0x39) ||  (* 0-9 *)
   code = 0x2D                         (* - *)
 
-// Language tag must start with a letter per BCP 47
-let is_lang_start (c:FStar.Char.char) : bool =
-  let code = FStar.Char.int_of_char c in
-  (code >= 0x41 && code <= 0x5A) || (code >= 0x61 && code <= 0x7A)
-
 let parse_lang_tag : parser string =
   fun input pos ->
     let len = String.length input in
@@ -333,16 +312,9 @@ let parse_lang_tag : parser string =
     else
       let ch = String.index input pos in
       if FStar.Char.int_of_char ch = 0x40 then (* '@' *)
-        let after_at = pos + 1 in
-        if after_at >= len then ParseFail "expected language tag after '@'" after_at
-        else
-          let first = String.index input after_at in
-          if not (is_lang_start first) then
-            ParseFail "language tag must start with a letter" after_at
-          else
-            match ptake_while1 is_lang_char input after_at with
-            | ParseOk lang pos' -> ParseOk lang pos'
-            | ParseFail _ fpos -> ParseFail "expected language tag after '@'" fpos
+        match ptake_while1 is_lang_char input (pos + 1) with
+        | ParseOk lang pos' -> ParseOk lang pos'
+        | ParseFail _ fpos -> ParseFail "expected language tag after '@'" fpos
       else
         ParseFail "expected '@'" pos
 

--- a/formal/fstar/SPARQL11.Parser.fst
+++ b/formal/fstar/SPARQL11.Parser.fst
@@ -3654,10 +3654,7 @@ let parse_inline_data (pm : prefix_map) (ts : token_stream)
             | Tok_RBRACE :: rest -> ParseOk (vars, List.Tot.rev acc) rest
             | Tok_LPAREN :: rest ->
               (match parse_values_row_multi pm rest vars [] with
-               | ParseOk row rest' ->
-                 if List.Tot.length row = List.Tot.length vars
-                 then parse_multi_rows rest' (row :: acc)
-                 else ParseErr "VALUES row has wrong number of values"
+               | ParseOk row rest' -> parse_multi_rows rest' (row :: acc)
                | ParseErr msg -> ParseErr msg)
             | _ -> ParseErr "expected ( or } in VALUES data"
           in parse_multi_rows rest'' []
@@ -3977,10 +3974,6 @@ let parse_query_impl (pm : prefix_map) (fuel : nat) (ts : token_stream)
               let (gc, r') = parse_group_conditions pm r [] in
               (Some gc, r')
             | _ -> (None, rest''') in
-          // SELECT * not allowed with GROUP BY
-          if Select_All? sc && Some? group_by
-          then ParseErr "SELECT * not allowed with GROUP BY"
-          else
           let (having, rest5) = match rest4 with
             | Tok_HAVING :: r ->
               let (hc, r') = parse_having_conditions pm r [] in
@@ -4094,20 +4087,9 @@ let parse_int_string (s : string) : option int = parse_int_string s
 
 (* Parse a SPARQL query string into a query AST.
    This is the main function that replaces sparql_parser.ml. *)
-// Check that remaining tokens are empty or just EOF
-let rec tokens_only_eof (ts : token_stream) : bool =
-  match ts with
-  | [] -> true
-  | Tok_EOF :: rest -> tokens_only_eof rest
-  | _ -> false
-
 let parse_sparql (input : string) : parse_result query =
   let tokens = tokenize input in
   let (pm, base, tokens') = parse_prologue [] None tokens in
-  match parse_query_impl pm default_fuel tokens' with
-  | ParseOk q rest ->
-    if tokens_only_eof rest then ParseOk q rest
-    else ParseErr "unexpected tokens after query"
-  | ParseErr msg -> ParseErr msg
+  parse_query_impl pm default_fuel tokens'
 
 #pop-options


### PR DESCRIPTION
## Summary
- Reverts PR #43 ("Parser hardening: hex validation, language tags, SPARQL negative syntax")
- The changes contained F* verification errors (duplicate top-level names, nat subtyping failures) that were masked by `build-ocaml.sh` continuing past extraction failures
- The fixes will be re-submitted as separate, smaller PRs that each verify cleanly

## What went wrong
A subagent wrote a second parallel parser implementation inside SPARQL11.Parser.fst with duplicate function names and unverified code. This broke `fstar.exe --codegen OCaml` extraction, but `build-ocaml.sh` silently used stale `.ml` files from the previous successful extraction.

## Next steps
- Split NTriples fixes (hex_val_opt, lang tag validation) into own PR
- Split NQuads fix (reject literal graph names) into own PR  
- SPARQL parser changes need rework by a subagent to avoid duplicate definitions
- Add verification gate to CI (fail if any F* module has extraction errors)

https://claude.ai/code/session_01LtDGUVVKCJtM2342GL6N6k