### PR TITLE
CI: fail on F* extraction errors, add PR gate

### DIFF
--- a/.github/workflows/check-extraction.yml
+++ b/.github/workflows/check-extraction.yml
@@ -1,0 +1,50 @@
+name: Check F* Extraction
+
+on:
+  pull_request:
+    paths:
+      - 'formal/fstar/*.fst'
+      - 'formal/fstar/build-ocaml.sh'
+      - 'formal/fstar/ocaml-patches.sh'
+
+permissions:
+  contents: read
+
+jobs:
+  verify-extract:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Cache opam
+        uses: actions/cache@v4
+        with:
+          path: ~/.opam
+          key: opam-fstar-${{ runner.os }}-v3
+          restore-keys: |
+            opam-fstar-${{ runner.os }}-
+
+      - name: Install system deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y opam libgmp-dev pkg-config
+
+      - name: Setup opam + F*
+        run: |
+          if [ ! -d ~/.opam ]; then
+            opam init -y --disable-sandboxing
+            opam switch create fstar ocaml-base-compiler.4.14.1
+          fi
+          eval $(opam env --switch=fstar)
+          opam install -y fstar z3 zarith sha digestif
+          echo "OPAMSWITCH=fstar" >> $GITHUB_ENV
+
+      - name: Verify + Extract + Compile
+        run: |
+          eval $(opam env --switch=fstar)
+          cd formal/fstar
+          # build-ocaml.sh now fails if any module doesn't extract
+          ./build-ocaml.sh extract
+          ./build-ocaml.sh compile

--- a/formal/fstar/build-ocaml.sh
+++ b/formal/fstar/build-ocaml.sh
@@ -35,7 +35,9 @@ if [[ "$STEP" == "all" || "$STEP" == "extract" ]]; then
   mkdir -p "$OUTDIR"
 
   # All modules extracted with full verification (no --lax)
+  # Extraction MUST succeed for every module — no silent failures
   echo "  Extracting all F* modules (verified)..."
+  EXTRACT_FAILED=0
   for fst in RDF.Graph.Executable.fst SPARQL11.Algebra.fst \
              Parser.Combinators.fst SPARQL11.Parser.fst \
              Parser.NTriples.fst Parser.Turtle.fst \
@@ -44,9 +46,17 @@ if [[ "$STEP" == "all" || "$STEP" == "extract" ]]; then
              Parser.SRX.fst Parser.CSVResults.fst; do
     if [ -f "$fst" ]; then
       echo "    $fst"
-      fstar.exe --codegen OCaml --odir "$OUTDIR" "$fst" 2>&1 | grep -E "Extracted|Error|error" || true
+      if ! fstar.exe --codegen OCaml --odir "$OUTDIR" "$fst" 2>&1 | tee /dev/stderr | grep -q "^Extracted module"; then
+        echo "  ERROR: $fst failed to extract!"
+        EXTRACT_FAILED=1
+      fi
     fi
   done
+  if [ "$EXTRACT_FAILED" -ne 0 ]; then
+    echo ""
+    echo "FATAL: One or more F* modules failed extraction. Fix errors before proceeding."
+    exit 1
+  fi
   echo "  RDF:    $(wc -l < "$OUTDIR/RDF_Graph_Executable.ml") lines"
   echo "  SPARQL: $(wc -l < "$OUTDIR/SPARQL11_Algebra.ml") lines"
 
@@ -73,14 +83,14 @@ if [[ "$STEP" == "all" || "$STEP" == "compile" ]]; then
   ocamlfind ocamlopt -package fstar.lib,str,zarith,sha,digestif.c -linkpkg -w -8-14-26 \
     $COMMON_MODULES \
     w3c_runner.ml \
-    -o w3c_runner 2>&1 | grep -i error || true
+    -o w3c_runner
   echo "  Built: w3c_runner ($(wc -c < w3c_runner) bytes)"
 
   # factoidal CLI (SPARQL query + RDF parsing tool)
   ocamlfind ocamlopt -package fstar.lib,str,zarith,sha,digestif.c -linkpkg -w -8-14-26 \
     $COMMON_MODULES \
     factoidal_cli.ml \
-    -o factoidal 2>&1 | grep -i error || true
+    -o factoidal
   echo "  Built: factoidal ($(wc -c < factoidal) bytes)"
 
   cd ..


### PR DESCRIPTION
## Summary
- **build-ocaml.sh**: Remove `|| true` from extraction and compilation. Script now exits with error if any F* module fails to extract or compile.
- **check-extraction.yml**: New PR check workflow — runs `extract` + `compile` on any PR touching `.fst` files. Blocks merge if extraction fails.

## What this prevents
PR #43 merged code that failed F* verification. `build-ocaml.sh` silently used stale `.ml` files from a prior extraction because `|| true` swallowed the error. The test results looked fine but were running old code.

## Test plan
- [ ] Existing modules still extract and compile (no false failures)
- [ ] A PR with a broken .fst file triggers check-extraction and blocks merge

https://claude.ai/code/session_01LtDGUVVKCJtM2342GL6N6k