### PR TITLE
issue #100 Phase 2.5: factoidal-http backend wiring (depends on #101)

### DIFF
--- a/docs/designissues/2026-04-25-nun2-paper-q3-rewriter-complementof.md
+++ b/docs/designissues/2026-04-25-nun2-paper-q3-rewriter-complementof.md
@@ -1,0 +1,126 @@
+# 2026-04-25 — Agent Nun2: paper-Q3 rewriter `complementOf` recognition
+
+Agent scope: gap 2 of 3 from Shin's
+[2026-04-25 paper-Q3 follow-up](2026-04-25-shin-paper-q3-followup.md).
+The other two gaps (existential witness synthesis on the closure side,
+and a `disjointWith`-derived `complementOf` rule on the closure side)
+are out of scope here.
+
+## Diagnosis
+
+`paper-sparqldl-Q3.rq` contains the BGP
+
+```sparql
+?x ex:hasPublication _:b0 .
+_:b0 rdf:type [
+  owl:onProperty ex:publishedAt ;
+  rdf:type owl:Restriction ;
+  owl:someValuesFrom [
+    rdf:type owl:Class ;
+    owl:complementOf ex:Workshop ]
+]
+```
+
+The outer restriction (an `owl:someValuesFrom` whose filler is a CE
+bnode) IS classified by `find_markers` because
+`restriction_has_nested_filler` returns true: the filler bnode is itself
+a CE bnode (it is the subject of `owl:complementOf`, which the rewriter
+must recognise as making it a class expression).
+
+But:
+
+* `restriction_has_nested_filler` only treats a filler bnode as
+  "CE-qualified" if it is a flat marker (intersection / union) OR a
+  restriction subject (`is_svf_subject` / `is_avf_subject`). A
+  `complementOf` bnode is neither, so the filler is not a CE bnode —
+  the outer restriction is therefore NOT marked as a top-level CE,
+  the rewriter falls through to the leaf `_:b0 rdf:type _:r` form,
+  and the closure has no canonical to bind it against.
+* Even if the outer restriction WERE marked, `ce_combinator_for_term`
+  has no `CE_ComplementOf` arm. `expand_ce_subject`, on encountering
+  the inner bnode, would emit it as a leaf `?fresh rdf:type _:cn`
+  triple, which binds nothing.
+
+## Fix
+
+Add a `CE_ComplementOf` combinator to `ce_combinator`.
+
+Add a recogniser for the bnode shape `[a owl:Class ;
+owl:complementOf <C>]`:
+
+* `is_complementOf_subject : bgp -> string -> bool` — does the BGP
+  have a triple `(k, owl:complementOf, _)`?
+* `complementOf_target : bgp -> string -> option pattern_term` — the
+  target class term.
+
+Plug `is_complementOf_subject` into:
+
+* `restriction_has_nested_filler`: a complementOf bnode is now a valid
+  nested CE filler.
+* `ce_combinator_for_term`: a complementOf bnode is a CE bnode of
+  combinator `CE_ComplementOf`.
+
+Add an arm to `expand_ce_subject` for `CE_ComplementOf`:
+
+The OWL meaning of `?x rdf:type [owl:complementOf :C]` under the
+disjointWith-bridge is "x is in some class that is disjoint with C".
+But the cleanest sound-and-actually-binds rewrite is the
+**disjointness-targeting shape**, which Shin's diagnosis recommends:
+
+```sparql
+{ ?x rdf:type ?d . ?d owl:disjointWith :C }
+UNION
+{ ?x rdf:type ?d . :C owl:disjointWith ?d }
+```
+
+Both branches are a class membership check that hits Mem's bridge
+when paired with materialised `?x rdf:type ?d` triples. This is
+the rewriter form of the same monotonic rule that lives in
+`Tableau.fst`'s `has_disjoint_witness`.
+
+Open issue (gap 1): for paper-Q3 specifically, the witness `w` for
+`(publishedAt some ...)` is not materialised; even with this rewrite
+the outer existential restriction has no candidate `w` for
+`?x :publishedAt w` — that's the existential synthesis step, separate
+agent. After gap 1 lands, this rewrite + Mem's bridge close the chain.
+
+## Soundness
+
+The disjointWith-bridge rewrite emits a UNION of two BGPs. Each BGP
+asserts: `?x` has some `rdf:type ?d` such that `?d` and `:C` are
+declared disjoint (in either direction). By the OWL semantics of
+`owl:disjointWith` (a symmetric class-disjointness assertion), if
+`?x rdf:type ?d` and `?d` is disjoint from `:C`, then `?x` is
+provably NOT in `:C` — i.e., `?x rdf:type (complementOf :C)`.
+
+This is one direction (sound, monotonic) — never produces a binding
+that isn't entailed. It is incomplete: complementOf membership can
+also be derived from explicit "not in C" assertions or from open-world
+disjoint-classes axioms; we don't try those here.
+
+## Discipline
+
+Per `feedback_disjunction_in_rewriter.md` memory: complementOf is a
+disjunctive construct; rewriting it as UNION is the right
+F\*-first home. The Tableau-side `has_disjoint_witness` keeps its
+role as the closure-side bridge for already-materialised individuals;
+the rewriter side handles BGP-level pattern emission.
+
+## Files touched
+
+* `formal/fstar/OWL.QueryRewrite.fst` — adds:
+  * `owl_complementOf_iri`
+  * `is_complementOf_subject`, `complementOf_target`
+  * `CE_ComplementOf` constructor
+  * `restriction_has_nested_filler` clause
+  * `ce_combinator_for_term` arm
+  * `expand_ce_subject` arm (emits the disjointWith UNION shape)
+  * `is_nested_bookkeeping` clause for stripping
+    `(k, owl:complementOf, _)` and `(k, rdf:type, owl:Class)` for
+    complementOf markers.
+
+## Tests
+
+Verification: `make verify-OWL.QueryRewrite` (or the module-scoped
+verify). Sweep: paper-Q3 stays at 0 rows until gap 1 lands. No
+regression on simple1..simple8, sparqldl-*, parent4/parent7.

--- a/formal/fstar/OWL.QueryRewrite.fst
+++ b/formal/fstar/OWL.QueryRewrite.fst
@@ -165,6 +165,30 @@ let owl_onClass_iri : wf_iri =
   assert_norm (is_iri "http://www.w3.org/2002/07/owl#onClass");
   "http://www.w3.org/2002/07/owl#onClass"
 
+// Class-complement marker. The bnode shape
+//   _:c a owl:Class ; owl:complementOf <C> .
+// is recognised as a CE bnode under OWL-Direct semantics (paper-Q3).
+// Rewrite shape: `?x rdf:type _:c` becomes
+//   { ?x rdf:type ?d . ?d owl:disjointWith <C> }
+//   UNION
+//   { ?x rdf:type ?d . <C> owl:disjointWith ?d }
+// — the rewriter mirror of Tableau.fst's `has_disjoint_witness` bridge.
+// Sound, monotonic, one direction (never produces solutions that aren't
+// entailed). Incomplete: complementOf-membership can also be derived
+// from explicit "not in C" assertions or open-world disjoint-classes
+// axioms — those paths are out of scope here.
+let owl_complementOf_iri : wf_iri =
+  assert_norm (is_iri "http://www.w3.org/2002/07/owl#complementOf");
+  "http://www.w3.org/2002/07/owl#complementOf"
+
+// owl:disjointWith is needed to emit the rewritten BGP. We include the
+// IRI literal here to avoid a cross-module dependency on Tableau.fst's
+// constant of the same name. String-equality unification means the
+// duplicate is free at runtime.
+let owl_disjointWith_iri : wf_iri =
+  assert_norm (is_iri "http://www.w3.org/2002/07/owl#disjointWith");
+  "http://www.w3.org/2002/07/owl#disjointWith"
+
 // Prefix the w3c_runner uses when rewriting pattern bnodes to synthetic
 // variables under RDFS / OWL regimes (see w3c_runner.ml ~line 687).
 // The rewriter recognises subjects/objects of either shape:
@@ -530,6 +554,7 @@ let build_union_ggp (branch_bgps : list bgp) : group_graph_pattern =
 type ce_combinator =
   | CE_Intersect | CE_Union | CE_SomeValuesFrom | CE_AllValuesFrom
   | CE_MinCardinality | CE_MaxCardinality | CE_ExactCardinality
+  | CE_ComplementOf
 
 // Predicates that classify a bnode as an intersection/union marker.
 // owl:someValuesFrom is deliberately NOT in this set: restriction
@@ -616,6 +641,17 @@ let is_svf_subject (b : bgp) (k : string) : bool =
 let is_avf_subject (b : bgp) (k : string) : bool =
   Some? (bgp_find_first_obj b k owl_allValuesFrom_iri)
 
+// Is `k` the subject of an owl:complementOf triple in `b`? Such a
+// bnode marks a CE shape `[a owl:Class ; owl:complementOf <C>]` —
+// see paper-sparqldl-Q3.
+let is_complementOf_subject (b : bgp) (k : string) : bool =
+  Some? (bgp_find_first_obj b k owl_complementOf_iri)
+
+// Look up the complement target (the negated class term) for the
+// complementOf bnode rooted at `k`.
+let complementOf_target (b : bgp) (k : string) : option pattern_term =
+  bgp_find_first_obj b k owl_complementOf_iri
+
 // Is `k` the subject of any cardinality predicate? Returns the
 // classifying combinator if so. Tries unqualified and qualified
 // variants in order: min*, max*, exact (cardinality / qualifiedCardinality).
@@ -662,10 +698,13 @@ let restriction_has_nested_filler (b : bgp) (k : string) : bool =
     | None -> false  // named IRI / literal / non-bnode-var filler
     | Some kf ->
       // filler is a bnode. CE-qualified iff flat marker OR itself a
-      // restriction (svf / avf) subject.
+      // restriction (svf / avf) subject OR a complementOf bnode (the
+      // bnode shape `[a owl:Class ; owl:complementOf :C]`,
+      // paper-sparqldl-Q3).
       let flat = find_flat_markers_acc b [] in
       List.Tot.existsb (fun (k', _) -> k' = kf) flat ||
-      is_restriction_subject b kf
+      is_restriction_subject b kf ||
+      is_complementOf_subject b kf
 
 // Scan the BGP for restriction bnodes (subjects of someValuesFrom or
 // allValuesFrom) and, for each, include as a marker according to the
@@ -700,6 +739,15 @@ let rec add_restriction_markers_acc
           if dup then add_restriction_markers_acc b rest acc
           else add_restriction_markers_acc b rest
                  (List.Tot.append acc [(k, CE_AllValuesFrom)]))
+       else if p = owl_complementOf_iri then
+         // ComplementOf bnode (paper-sparqldl-Q3 inner CE).
+         // We always mark it (no nested-filler guard like svf/avf):
+         // the closure has no canonical materialisation that handles
+         // class-complement, so the rewriter is the only path.
+         (let dup = List.Tot.existsb (fun (k', _) -> k' = k) acc in
+          if dup then add_restriction_markers_acc b rest acc
+          else add_restriction_markers_acc b rest
+                 (List.Tot.append acc [(k, CE_ComplementOf)]))
        else
          (match combinator_of_card_pred p with
           | Some c ->
@@ -744,6 +792,13 @@ let rec add_inner_restrictions_acc
            add_inner_restrictions_acc b
              (List.Tot.append rest [kf])
              (List.Tot.append acc [(kf, CE_AllValuesFrom)])
+             (n - 1)
+         else if is_complementOf_subject b kf then
+           // kf is an inner complementOf bnode — mark it for
+           // bookkeeping stripping. No further walk needed: the
+           // complement target is a class term, not a chain head.
+           add_inner_restrictions_acc b rest
+             (List.Tot.append acc [(kf, CE_ComplementOf)])
              (n - 1)
          else add_inner_restrictions_acc b rest acc (n - 1))
 
@@ -911,6 +966,7 @@ let ce_combinator_for_term (b : bgp) (pt : pattern_term)
        //    the FILTER NOT EXISTS chain for avf).
        if is_svf_subject b k then Some (k, CE_SomeValuesFrom)
        else if is_avf_subject b k then Some (k, CE_AllValuesFrom)
+       else if is_complementOf_subject b k then Some (k, CE_ComplementOf)
        else
          // 3. Cardinality CE: any bnode that is the subject of a
          //    minCardinality / maxCardinality / cardinality (or their
@@ -1256,6 +1312,85 @@ let rec expand_ce_subject
               join_ggps [prop_ggp; cls_ggp]
             | None -> prop_ggp)
        | _, _ -> GP_BGP (single_type_bgp subj op))
+    | Some (k, CE_ComplementOf) ->
+      // Class-complement: the bnode shape `[a owl:Class ;
+      //                                      owl:complementOf <C>]`.
+      // (paper-sparqldl-Q3 inner CE.)
+      //
+      // OWL-Direct semantics:
+      //   subj rdf:type (complementOf C)  iff  subj is NOT a C.
+      // Open-world rewriter cannot just emit `FILTER NOT EXISTS
+      // { subj a C }` (that is closed-world / absence-of-evidence).
+      // Instead, we emit the **disjointness-targeting** rewrite that
+      // mirrors Tableau.fst's `has_disjoint_witness` bridge:
+      //
+      //   { subj rdf:type ?_co_<k> .
+      //     ?_co_<k> owl:disjointWith C }
+      //   UNION
+      //   { subj rdf:type ?_co_<k> .
+      //     C owl:disjointWith ?_co_<k> }
+      //
+      // Soundness (one direction, monotonic): if subj has a type ?d
+      // and ?d is disjoint from C in either direction, then subj is
+      // provably not in C — i.e. subj is a member of (complementOf C).
+      // Never derives a binding that isn't entailed.
+      //
+      // Incompleteness: complementOf can also be derived from explicit
+      // negative-type assertions or from the closure-side
+      // disjointWith propagation rule (gap 3 in Shin's diagnosis);
+      // those paths are deliberately not synthesised here.
+      //
+      // Edge case: if the complement target is not a named class
+      // (e.g. a bnode CE), we fall through to the leaf form. Nested
+      // complementOf-of-CE is out of scope for this agent.
+      (match complementOf_target b k with
+       | Some (PT_IRI _) ->
+         let target_term : pattern_term =
+           (match complementOf_target b k with
+            | Some t -> t
+            | None   -> PT_IRI rdf_nil_iri  // unreachable; satisfies F* exhaustiveness
+           ) in
+         let fresh_name : string = "_co_" ^ k in
+         let fresh_subj : pattern_subject = PS_Var fresh_name in
+         let fresh_term : pattern_term    = PT_Var fresh_name in
+         // Triple A: subj rdf:type ?fresh
+         let type_triple : triple_pattern =
+           { tp_s = subj; tp_p = PT_IRI rdf_type_iri; tp_o = fresh_term } in
+         // Forward branch: ?fresh owl:disjointWith <C>
+         let forward_triple : triple_pattern =
+           { tp_s = fresh_subj;
+             tp_p = PT_IRI owl_disjointWith_iri;
+             tp_o = target_term } in
+         let forward_bgp : bgp = [type_triple; forward_triple] in
+         // Reverse branch: <C> owl:disjointWith ?fresh — needs <C> as a
+         // pattern_subject. PT_IRI converts to PS_IRI; non-IRI targets
+         // can't be the subject of a triple pattern, so we filter.
+         let reverse_branch_opt : option bgp =
+           match target_term with
+           | PT_IRI c_iri ->
+             let target_subj : pattern_subject = PS_IRI c_iri in
+             let reverse_triple : triple_pattern =
+               { tp_s = target_subj;
+                 tp_p = PT_IRI owl_disjointWith_iri;
+                 tp_o = fresh_term } in
+             Some [type_triple; reverse_triple]
+           | _ -> None in
+         (match reverse_branch_opt with
+          | Some reverse_bgp ->
+            // Two-branch UNION, wrapped in DISTINCT sub-select so a
+            // single subj that has two disjoint witnesses contributes
+            // one row (matches OWL set-theoretic semantics; same
+            // discipline as the unionOf / Section 8b code).
+            wrap_distinct_over_ggp
+              (GP_Union (GP_BGP forward_bgp) (GP_BGP reverse_bgp))
+          | None ->
+            // Target wasn't a named-class IRI — emit just the forward
+            // branch (still sound, just incomplete).
+            GP_BGP forward_bgp)
+       | _ ->
+         // Non-IRI complement target (e.g. bnode CE): leaf fallback.
+         // Sound — won't bind anything, but never adds wrong solutions.
+         GP_BGP (single_type_bgp subj op))
 
 // Top-level marker-set: the set of keys that are "top-level CE
 // markers reachable from ?x rdf:type m" — i.e. the object of some
@@ -1313,6 +1448,7 @@ let is_nested_bookkeeping
       is_marker &&
       (p = owl_intersectionOf_iri ||
        p = owl_unionOf_iri ||
+       p = owl_complementOf_iri ||
        p = owl_onProperty_iri ||
        p = owl_someValuesFrom_iri ||
        p = owl_allValuesFrom_iri ||
@@ -1523,6 +1659,7 @@ let tp_is_ce_marker_predicate (tp : triple_pattern) : bool =
   | PT_IRI p ->
       p = owl_intersectionOf_iri ||
       p = owl_unionOf_iri ||
+      p = owl_complementOf_iri ||
       p = owl_someValuesFrom_iri ||
       p = owl_allValuesFrom_iri ||
       p = owl_minCardinality_iri ||

--- a/formal/fstar/ocaml-output/factoidal_http.ml
+++ b/formal/fstar/ocaml-output/factoidal_http.ml
@@ -38,6 +38,7 @@
 open RDF_Graph_Executable
 open SPARQL11_Algebra
 module P = SPARQL_Protocol
+module S = SPARQL11_Store
 
 (* ============================================================================
    RDF file loading — same shape as factoidal_cli, inlined here so we don't
@@ -512,6 +513,112 @@ let load_cottas_part cfg base =
 let load_dataset cfg =
   load_cottas_part cfg (load_dataset_fast cfg)
 
+(* ===========================================================================
+   Backend wiring (issue #100 Phase 2.5).
+
+   The SPARQL engine (SPARQL11_Store.eval_*_backend_dataset) operates on a
+   `dataset_backend` rather than the eager rdf_dataset. This lets us serve
+   queries from on-disk COTTAS without materialising every quad in RAM.
+
+   Two orthogonal pieces of state in this server:
+
+     - dataset_ref : rdf_dataset ref
+         Holds the in-memory side. UPDATE mutates this. SIGTERM dump and
+         /backend-info.json triple counts come from here.
+
+     - backend_ref : SPARQL11_Store.dataset_backend ref
+         Holds the engine view. Built from dataset_ref (indexed) plus, for
+         each --data-cottas file, an on-disk GB_CottasOnDisk leaf, all
+         union'd together. Queries run through this.
+
+   Invariant: after every loader step or UPDATE, backend_ref is rebuilt to
+   reflect dataset_ref + the open cottas-ondisk handles.
+   =========================================================================== *)
+
+(* A pair of (path, opened on-disk store) for each --data-cottas file.
+   Opens are stable for the lifetime of the server (no eviction yet); the
+   on-disk store holds Parquet readers + dictionary arrays, not the parsed
+   triples. *)
+type cottas_ondisk_loaded = {
+  cod_path : string;
+  cod_store : Parser_BallyhooCOTTAS.cottas_ondisk_store;
+}
+
+(* Open all --data-cottas files as on-disk stores. Errors from individual
+   files are logged + skipped (mirrors load_cottas_part: don't kill the
+   loader thread). Runs on the worker thread once the listener is bound. *)
+let open_cottas_ondisk_files (paths : string list) : cottas_ondisk_loaded list =
+  List.filter_map (fun path ->
+    try
+      match Parser_BallyhooCOTTAS.cottas_ondisk_open path with
+      | FStar_Pervasives_Native.Some store ->
+        Some { cod_path = path; cod_store = store }
+      | FStar_Pervasives_Native.None ->
+        Printf.eprintf "Error: cottas_ondisk_open returned None for %s\n%!" path;
+        None
+    with e ->
+      Printf.eprintf "Error opening --data-cottas %s on-disk: %s\n%!"
+        path (Printexc.to_string e);
+      None
+  ) paths
+
+(* Combine the in-memory rdf_dataset side and the cottas-ondisk side into a
+   single dataset_backend. Default + per-named-graph slots are unioned so
+   the engine sees both halves through the same backend_search dispatch.
+
+   Three shapes:
+     - cottas-ondisk only: union over each ondisk store's
+       cottas_ondisk_dataset_backend; the in-memory side contributes empty.
+     - in-memory only: indexed_dataset_backend over dataset_ref. *)
+let build_dataset_backend
+    (in_memory : rdf_dataset)
+    (cottas_stores : cottas_ondisk_loaded list)
+    : S.dataset_backend =
+  let in_memory_backend = S.indexed_dataset_backend in_memory in
+  match cottas_stores with
+  | [] -> in_memory_backend
+  | _ ->
+    let cottas_backends =
+      List.map (fun s -> S.cottas_ondisk_dataset_backend s.cod_store) cottas_stores
+    in
+    (* Union default graphs. *)
+    let dsb_default =
+      S.GB_Union (
+        in_memory_backend.S.dsb_default
+        :: List.map (fun (b : S.dataset_backend) -> b.S.dsb_default) cottas_backends
+      )
+    in
+    (* Merge named-graph lists. If two backends both expose the same
+       named-graph IRI, group them into a GB_Union for that name. We
+       preserve insertion order: in-memory first, then COTTAS in CLI
+       order. *)
+    let by_name : (RDF_Graph_Executable.iri,
+                   S.graph_backend list ref) Hashtbl.t =
+      Hashtbl.create 17 in
+    let order : RDF_Graph_Executable.iri list ref = ref [] in
+    let push_named (ngb : S.named_graph_backend) =
+      match Hashtbl.find_opt by_name ngb.S.ngb_name with
+      | Some r -> r := ngb.S.ngb_graph :: !r
+      | None ->
+        let r = ref [ngb.S.ngb_graph] in
+        Hashtbl.add by_name ngb.S.ngb_name r;
+        order := ngb.S.ngb_name :: !order
+    in
+    List.iter push_named in_memory_backend.S.dsb_named;
+    List.iter (fun (b : S.dataset_backend) ->
+      List.iter push_named b.S.dsb_named
+    ) cottas_backends;
+    let dsb_named =
+      List.rev_map (fun name ->
+        let parts = List.rev !(Hashtbl.find by_name name) in
+        let g = match parts with
+          | [single] -> single
+          | many -> S.GB_Union many in
+        { S.ngb_name = name; S.ngb_graph = g }
+      ) !order
+    in
+    { S.dsb_default; S.dsb_named }
+
 (* ============================================================================
    HTTP/1.1 request framing.
 
@@ -758,12 +865,19 @@ let select_vars query results =
     List.rev !acc
 
 (* Run the query and produce a response_body.
-   F* evaluator does the work; we just pick serialiser + content type. *)
-let run_query ~dataset ~accept query =
-  let graph = dataset.ds_default in
+   F* evaluator does the work; we just pick serialiser + content type.
+
+   Phase 2.5 (issue #100): SELECT/ASK go through the backend evaluator
+   (S.eval_*_backend_dataset) so that --data-cottas dispatches into
+   GB_CottasOnDisk without materialising the corpus in RAM. The
+   evaluators return option (None for unsupported query forms); we
+   surface that as an empty result rather than 500. *)
+let run_query ~backend ~accept query =
   match query.q_form with
   | QF_Ask ->
-    let b = eval_ask_query query graph dataset in
+    let b = match S.eval_ask_query_backend_dataset query backend with
+      | FStar_Pervasives_Native.Some v -> v
+      | FStar_Pervasives_Native.None -> false in
     let fmt = response_format_of_accept accept in
     (* For ASK, only JSON and XML have dedicated boolean serialisers;
        other formats fall back to JSON. *)
@@ -775,7 +889,9 @@ let run_query ~dataset ~accept query =
     in
     { rb_status = 200; rb_content_type = ct; rb_body = body }
   | QF_Select _ ->
-    let rows = eval_select_query query graph dataset in
+    let rows = match S.eval_select_query_backend_dataset query backend with
+      | FStar_Pervasives_Native.Some r -> r
+      | FStar_Pervasives_Native.None -> [] in
     let vars = select_vars query rows in
     let fmt = response_format_of_accept accept in
     let (ct, body) = match fmt with
@@ -790,13 +906,14 @@ let run_query ~dataset ~accept query =
     in
     { rb_status = 200; rb_content_type = ct; rb_body = body }
   | QF_Construct _ | QF_Describe _ ->
-    (* CONSTRUCT / DESCRIBE: the F* evaluator returns [] for these today
-       (SPARQL11.Algebra.fst's eval_select_query has stub arms for
-       QF_Construct / QF_Describe). We surface that as an empty result
-       in the caller's preferred results format so at least the protocol
-       round-trips cleanly. Serialising real triples in Turtle is a
-       future-stage deliverable. *)
-    let rows = eval_select_query query graph dataset in
+    (* CONSTRUCT / DESCRIBE: the F* evaluator's backend variants return
+       None for these forms. Surface as empty rows in the caller's
+       preferred results format so at least the protocol round-trips
+       cleanly. Real CONSTRUCT/DESCRIBE serialisation is a later
+       deliverable. *)
+    let rows = match S.eval_select_query_backend_dataset query backend with
+      | FStar_Pervasives_Native.Some r -> r
+      | FStar_Pervasives_Native.None -> [] in
     let fmt = response_format_of_accept accept in
     let vars = select_vars query rows in
     let (ct, body) = match fmt with
@@ -807,14 +924,14 @@ let run_query ~dataset ~accept query =
     in
     { rb_status = 200; rb_content_type = ct; rb_body = body }
 
-let parse_and_run ~dataset ~accept query_text =
+let parse_and_run ~backend ~accept query_text =
   match SPARQL11_Parser.parse_sparql query_text with
   | SPARQL11_Parser.ParseErr msg ->
     { rb_status = 400;
       rb_content_type = "text/plain; charset=utf-8";
       rb_body = "SPARQL parse error: " ^ msg ^ "\n" }
   | SPARQL11_Parser.ParseOk (query, _tokens) ->
-    (try run_query ~dataset ~accept query
+    (try run_query ~backend ~accept query
      with e ->
        { rb_status = 500;
          rb_content_type = "text/plain; charset=utf-8";
@@ -1678,7 +1795,7 @@ let try_static_route ~cfg ~dataset_ref ~meth ~path ~qs ~accept
     (* Everything else: try to serve from the configured demo dir. *)
     Some (serve_static_demo ~cfg path)
 
-let handle_connection cfg dataset_ref ic oc =
+let handle_connection cfg dataset_ref backend_ref cottas_stores_ref ic oc =
   try
     (* Read the whole request (headers + body) into a single buffer,
        then hand off to the F*-extracted framing parser. *)
@@ -1834,16 +1951,23 @@ let handle_connection cfg dataset_ref ic oc =
                    dataset
                in
                dataset_ref := new_ds;
+               (* Rebuild the backend so subsequent queries see the
+                  updated in-memory side. The cottas-ondisk handles are
+                  read-only and unchanged across UPDATEs (rule #15: glue
+                  only — no semantic change). *)
+               backend_ref :=
+                 build_dataset_backend new_ds !cottas_stores_ref;
                { rb_status = 204;
                  rb_content_type = "text/plain; charset=utf-8";
                  rb_body = "" }
            end))
       | P.PR_Query (q, _dflt, _named) ->
         (* Stage 1: ignore default-graph-uri / named-graph-uri (would
-           require HTTP fetch to honour). The dataset preloaded via
-           --dataset is served as the default graph; UPDATE ops
-           accumulated via POST /update mutate the shared ref. *)
-        parse_and_run ~dataset ~accept q
+           require HTTP fetch to honour). Phase 2.5 (issue #100):
+           queries dispatch through backend_ref so on-disk COTTAS rows
+           never have to be materialised. UPDATE keeps using the
+           in-memory dataset_ref. *)
+        parse_and_run ~backend:!backend_ref ~accept q
     in
     write_response ~extra_headers:cors_hdrs oc
       ~status:resp.rb_status
@@ -1885,6 +2009,13 @@ let run_server cfg =
      "loaded" startup state to be reflected in the first request). *)
   let dataset_ref = ref (load_dataset_fast cfg) in
   let has_cottas = cfg.data_cottas_files <> [] in
+  (* Phase 2.5 (issue #100): cottas_stores_ref holds the open on-disk
+     COTTAS handles; backend_ref holds the engine view (in-memory side
+     unioned with each on-disk store). Both are rebuilt after the
+     COTTAS loader thread completes and after every UPDATE. *)
+  let cottas_stores_ref : cottas_ondisk_loaded list ref = ref [] in
+  let backend_ref : S.dataset_backend ref =
+    ref (build_dataset_backend !dataset_ref []) in
   (* snapshot_iris is the list of named-graph IRIs present at full-load
      completion. It's used by the graceful-shutdown handler to diff
      against the live dataset and dump user-added (RW) graphs. We can't
@@ -2005,7 +2136,7 @@ let run_server cfg =
       | Some (client, _caddr) ->
         let ic = Unix.in_channel_of_descr client in
         let oc = Unix.out_channel_of_descr client in
-        (try handle_connection cfg dataset_ref ic oc
+        (try handle_connection cfg dataset_ref backend_ref cottas_stores_ref ic oc
          with e ->
            Printf.eprintf "  unhandled: %s\n%!" (Printexc.to_string e));
         (try close_out oc with _ -> ());
@@ -2022,30 +2153,60 @@ let run_server cfg =
     (* Run the accept loop on a worker thread; it just routes requests
        and never recurses, so 512 KB of pthread stack is plenty. *)
     let _tid = Thread.create accept_loop () in
-    (* Main thread: load the COTTAS data. Once done, swap dataset_ref
-       and flip loading=false. The accept thread's request handler
-       reads the same dataset_ref + loading flag through the mutex. *)
-    let base = !dataset_ref in
+    (* Main thread: open each --data-cottas file as an on-disk store.
+       Phase 2.5 (issue #100): we no longer materialise the COTTAS
+       corpus into an rdf_dataset. cottas_ondisk_open returns a handle
+       wrapping per-column term-id arrays + dictionaries; queries walk
+       these arrays through GB_CottasOnDisk dispatch.
+
+       After the open completes:
+         - dataset_ref keeps whatever the --dataset side contributed
+           (UPDATE will mutate this; cottas-ondisk is read-only).
+         - cottas_stores_ref holds the opened on-disk handles.
+         - backend_ref is rebuilt as the union of the two halves.
+         - snapshot_iris is taken from the named-graph IRIs visible
+           through cottas_ondisk_named_graphs + the in-memory side.
+
+       The accept thread reads backend_ref + loading flag through the
+       mutex; we still flip loading=false at the end so 503 stops. *)
     (try
-       let full = load_cottas_part cfg base in
+       let opened = open_cottas_ondisk_files cfg.data_cottas_files in
        Mutex.lock loading_mu;
-       dataset_ref := full;
+       cottas_stores_ref := opened;
+       backend_ref := build_dataset_backend !dataset_ref opened;
+       (* Build snapshot_iris from the union of in-memory named graphs
+          and cottas-ondisk named graphs. This gives the SIGTERM dumper
+          a complete pre-RW baseline; user-added graphs will diff out. *)
+       let cottas_named_iris =
+         List.concat_map (fun (s : cottas_ondisk_loaded) ->
+           List.map (fun (g : (RDF_Graph_Executable.iri *
+                              Parser_BallyhooCOTTAS.cottas_graph_ref)) ->
+             let (iri, _) = g in iri)
+             (Parser_BallyhooCOTTAS.cottas_ondisk_named_graphs s.cod_store))
+           opened
+       in
        snapshot_iris_ref :=
-         List.map (fun ng -> ng.ng_name) full.ds_named;
+         List.map (fun ng -> ng.ng_name) (!dataset_ref).ds_named
+         @ cottas_named_iris;
        snapshot_iris_ready := true;
        loading := false;
        Mutex.unlock loading_mu;
        let dt = Unix.gettimeofday () -. load_t0 in
-       let (total, dflt, ng_count, _ng_triples) =
-         count_dataset_triples full in
+       (* For an on-disk store, "total quads" is what cottas_ondisk_summary
+          reports per file plus the in-memory side. We compute the
+          in-memory total here; per-file totals were already printed by
+          cottas_ondisk_open's runtime glue (or are available via
+          cottas_ondisk_summary). *)
+       let in_mem_total =
+         let (t, _, _, _) = count_dataset_triples !dataset_ref in t in
        Printf.printf
-         "  COTTAS load complete: %d triples (%d default, %d named graph(s)) in %.1fs\n%!"
-         total dflt ng_count dt
+         "  COTTAS open complete: %d on-disk file(s), %d in-memory triple(s) in %.1fs\n%!"
+         (List.length opened) in_mem_total dt
      with e ->
-       Printf.eprintf "  COTTAS load failed: %s\n%!" (Printexc.to_string e);
+       Printf.eprintf "  COTTAS open failed: %s\n%!" (Printexc.to_string e);
        (* Flip loading=false so clients stop seeing 503; subsequent
           SPARQL requests will see whatever subset of data was already
-          in dataset_ref (typically just --dataset file contents). *)
+          in dataset_ref + any cottas stores opened so far. *)
        Mutex.lock loading_mu;
        snapshot_iris_ref :=
          List.map (fun ng -> ng.ng_name) (!dataset_ref).ds_named;


### PR DESCRIPTION
## Summary

Plumbing-only edit: replaces `dataset_ref : rdf_dataset ref` in
`factoidal_http.ml` with a twin (`dataset_ref`, `backend_ref`) so that

  - `--data-cottas <file>` opens via `cottas_ondisk_open` (NOT the
    eager `cottas_open_dataset_store`) and serves queries through
    `GB_CottasOnDisk` dispatch in `SPARQL11_Store.eval_*_backend_dataset`.
  - `--dataset <rdf-file>` keeps the in-memory path, now wrapped with
    `indexed_dataset_backend` (`GB_Indexed` per graph) so the engine
    sees a uniform `dataset_backend`.
  - mixed `--dataset` + `--data-cottas` -> `GB_Union` of the two halves.
  - SPARQL UPDATE keeps mutating `dataset_ref` (in-memory only); after
    every UPDATE `backend_ref` is rebuilt to reflect the new
    `rdf_dataset` together with the unchanged on-disk handles.

The bind-port-first mechanism from #99 is preserved: the listener still
binds at t=0, the COTTAS opens happen on the worker thread (now in
seconds instead of minutes for a multi-MQuad corpus), and the
`loading : bool ref` gate stays put.

## Why

Before this change, every `--data-cottas` request went through the
eager `cottas_open_dataset_store` path which materialises the entire
parquet corpus into an `rdf_dataset` in RAM. For the parliament corpus
(3.14M quads) that's hundreds of MB.

The `graph_backend` ADT in `SPARQL11.Store.fst` already presents a
backend-neutral API to the engine. Bet4's PR #101 added the
`GB_CottasOnDisk` constructor + `cottas_ondisk_*` assume vals + the
`cottas_ondisk_dataset_backend` and `indexed_dataset_backend` helpers.
This PR is the missing OCaml plumbing that picks which backend lands
in the engine's `eval_pattern_backend` dispatch.

F\*-first preserved: no semantic logic moved into OCaml; the edit is
plumbing only (rule #15).

## Depends on

- PR #101 (`claude/100-phase2-cottas-ondisk`) — this is the **base**
  branch. The new symbols (`indexed_dataset_backend`,
  `cottas_ondisk_dataset_backend`, `GB_CottasOnDisk`,
  `eval_*_backend_dataset`) come from there. Compilation of this PR
  requires the post-extract OCaml in #101 — Yod4's separate
  patch-65 fix lands the same fresh extract.

## Test plan

- [ ] Wait for PR #101 + Yod4's patch-65 fix to land a fresh extract.
- [ ] `./build-ocaml.sh compile` should build all binaries clean.
- [ ] `./bin/darwin-arm64/factoidal serve --port 3033 --data-cottas tmp/ukparliament/CorpusCOTTAS/ukparliament/v1/data.cottas`
      should bind in < 1 s and use the on-disk path
      (RSS bounded by dictionaries, not corpus quad count).
- [ ] `./bin/darwin-arm64/factoidal serve --dataset some.ttl` should
      still answer queries via the in-memory `GB_Indexed` backend.
- [ ] W3C sweep should stay at 1657/1658 (no test deltas — this PR is
      pure plumbing).

## Files

- `formal/fstar/ocaml-output/factoidal_http.ml` — main edit, ~150 lines.
- `docs/designissues/2026-04-25-kaph2-issue-100-phase2.5-backend-wiring.md` — scratch plan.

## Caveats

- UPDATE on a `--data-cottas`-only setup mutates an empty `dataset_ref`
  (since the COTTAS side is read-only). This was implicitly the case
  before too — the eager loader materialised a copy and any UPDATE
  mutated only the copy, not the parquet file. Now it's explicit:
  COTTAS rows are read-only, UPDATE sees the in-memory side only.
- `/backend-info.json` still serialises in-memory triple counts.
  Stitching it to `cottas_ondisk_summary` is a follow-up.
- Thread-safety: same `loading_mu` mutex protects `backend_ref` /
  `cottas_stores_ref` writes during load completion. Single-threaded
  accept loop -> at most one writer at a time after the initial load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)