### PR TITLE
F*-purity CI gate expansion + code-name glossary + 2026-05-06 drift recheck

### DIFF
--- a/.claude/skills/fstar-env/SKILL.md
+++ b/.claude/skills/fstar-env/SKILL.md
@@ -1,0 +1,273 @@
+---
+name: fstar-env
+description: Set up or repair the F* / opam / z3 toolchain for the Factoidal project. Use when the user asks to install or set up F*, when `fstar.exe` is missing from PATH, when z3 has the wrong version (must be 4.13.3), when `make verify` or `build-ocaml.sh` fails with toolchain errors, when starting on a fresh clone that hasn't been bootstrapped, or when an agent has been "burning time on partial builds" because the opam switch isn't activated.
+---
+
+# F\* / opam / z3 environment setup
+
+The Factoidal project verifies F\* specs and extracts OCaml from them. Without
+a correctly configured F\*/opam/z3 toolchain, **nothing in `formal/fstar/`
+works** — verification fails, extraction fails, and the OCaml binaries can't
+be rebuilt. This skill handles first-time setup, repair, and diagnosis.
+
+The authoritative source for setup details is `CLAUDE.md` in the project root
+(the "Setup" section). This skill is the operational distillation; if the two
+ever drift, CLAUDE.md wins and this skill should be updated to match.
+
+## When to use this skill
+
+Run this skill when any of the following are true:
+
+- `fstar.exe --version` errors with "command not found".
+- `z3 --version` shows anything other than `4.13.3`.
+- `make verify` in `formal/fstar/` fails with a missing-binary error.
+- `./build-ocaml.sh` (any subcommand) fails before producing output.
+- The user asks to "set up F\*", "install F\*", "fix the F\* env", etc.
+- A fresh clone hasn't yet had the toolchain bootstrapped.
+
+## Iron rules (these are not optional)
+
+1. **Never use `--lax`.** The flag is banned project-wide. If verification
+   fails, fix the spec or install the missing tool — do not work around the
+   failure with `--lax`.
+2. **Always activate the opam switch before any F\* work.** Every shell
+   that invokes `fstar.exe`, `make verify`, or `build-ocaml.sh` must run
+   `eval $(opam env --switch=fstar)` first. If `fstar.exe` is missing from
+   PATH, stop and activate the switch rather than burning time on partial
+   builds.
+3. **z3 must be exactly 4.13.3.** Other versions silently produce wrong
+   answers or refuse proofs that should go through. The `apt-get install z3`
+   version is too old; the `opam install z3` build often fails. Use the
+   pre-built binary from the Z3Prover GitHub release (see §3).
+
+## Quick diagnostic
+
+Before installing anything, check what's already there:
+
+```bash
+# What's installed?
+opam --version 2>&1 || echo "opam: missing"
+opam switch show 2>&1 | grep -q fstar && echo "fstar switch: present" || echo "fstar switch: missing"
+which fstar.exe 2>&1 || echo "fstar.exe: not on PATH (switch may not be activated)"
+z3 --version 2>&1 || echo "z3: missing"
+```
+
+If `fstar switch` is present but `fstar.exe` is not on PATH, **the switch
+just needs activation** — see §4. Don't reinstall anything.
+
+If `z3 --version` shows something other than 4.13.3, replace it (§3). Wrong
+versions of z3 are a top-three time-sink in this project.
+
+## §1. System prerequisites
+
+Linux (Debian/Ubuntu):
+
+```bash
+sudo apt-get update
+sudo apt-get install -y opam libgmp-dev pkg-config unzip curl
+```
+
+macOS (Homebrew):
+
+```bash
+brew install opam gmp pkg-config
+```
+
+Both need: `unzip`, `curl` for fetching the z3 binary release.
+
+## §2. opam + F\* toolchain
+
+First-time only:
+
+```bash
+opam init -y
+opam switch create fstar ocaml-base-compiler.4.14.1
+eval $(opam env --switch=fstar)
+opam install -y fstar z3 js_of_ocaml js_of_ocaml-compiler zarith_stubs_js
+```
+
+The `opam install` line installs F\* itself plus the JS extraction
+toolchain. The `z3` opam package is installed too, but the build often
+fails or produces the wrong version — §3 replaces the binary on PATH.
+
+## §3. Install z3 4.13.3 (CRITICAL)
+
+The opam-built or apt-installed z3 will not work. Install the pre-built
+binary from the official Z3 release:
+
+### Linux x86-64
+
+```bash
+cd /tmp
+curl -sL "https://github.com/Z3Prover/z3/releases/download/z3-4.13.3/z3-4.13.3-x64-glibc-2.35.zip" -o z3.zip
+unzip -q z3.zip
+sudo cp z3-4.13.3-x64-glibc-2.35/bin/z3 /usr/local/bin/z3-4.13.3
+sudo chmod +x /usr/local/bin/z3-4.13.3
+sudo ln -sf /usr/local/bin/z3-4.13.3 /usr/local/bin/z3
+```
+
+### macOS arm64 (Apple Silicon)
+
+```bash
+cd /tmp
+curl -sL "https://github.com/Z3Prover/z3/releases/download/z3-4.13.3/z3-4.13.3-arm64-osx-13.7.zip" -o z3.zip
+unzip -q z3.zip
+sudo cp z3-4.13.3-arm64-osx-13.7/bin/z3 /usr/local/bin/z3-4.13.3
+sudo chmod +x /usr/local/bin/z3-4.13.3
+sudo ln -sf /usr/local/bin/z3-4.13.3 /usr/local/bin/z3
+```
+
+### macOS via Homebrew (fallback, may not pin version)
+
+```bash
+brew install z3
+```
+
+Verify the version after install:
+
+```bash
+z3 --version    # must show "Z3 version 4.13.3"
+z3-4.13.3 --version    # also must show "Z3 version 4.13.3"
+```
+
+If either is missing or shows a different version, do not proceed —
+debug the install before continuing.
+
+## §4. Activate the switch in this shell
+
+This is the single most common reason F\* commands fail in a session
+where everything was previously working:
+
+```bash
+eval $(opam env --switch=fstar)
+```
+
+Add this to the user's shell rc file (`~/.bashrc`, `~/.zshrc`) for
+persistence, or run it at the start of every Factoidal-related shell.
+
+After activation:
+
+```bash
+which fstar.exe         # should resolve under ~/.opam/fstar/bin/
+fstar.exe --version     # should print a version string
+```
+
+## §5. Verify the install end-to-end
+
+```bash
+cd /path/to/factoidal
+eval $(opam env --switch=fstar)
+cd formal/fstar
+make verify
+```
+
+`make verify` should walk the `MODULES` list in the Makefile and emit a
+per-module `.verified` marker file. Any failure here is either:
+
+- A bug in the spec (rare during setup; common during development).
+- A missing/wrong-version z3 (most likely cause during setup).
+- A missing `fstar.exe` (switch not activated).
+
+If you suspect z3 is at fault, run a single module by hand and read the
+solver output:
+
+```bash
+fstar.exe RDF.Graph.Executable.fst
+```
+
+z3 errors will appear in the F\* output verbatim.
+
+## §6. Submodules (test data)
+
+Factoidal vendors W3C test files as a git submodule. Without them,
+`./w3c_runner` has no test data:
+
+```bash
+cd /path/to/factoidal
+git submodule update --init --recursive
+```
+
+`third_party/testing/w3c/` should be populated after this.
+
+## §7. Build the OCaml binaries
+
+Once verification works:
+
+```bash
+cd formal/fstar
+eval $(opam env --switch=fstar)   # always
+./build-ocaml.sh                  # full extract + compile cycle
+```
+
+The script auto-detects the platform and writes binaries to
+`bin/<platform>/`, with symlinks under `ocaml-output/`. Pre-built
+binaries for `darwin-arm64` and `linux-x86_64` live in the repo and can
+be used directly without an F\* toolchain — but only if the spec
+hasn't changed since the last commit.
+
+`build-ocaml.sh extract` re-extracts (use after editing `.fst` files
+or after a fresh checkout). `build-ocaml.sh compile` compiles
+without re-extracting. **Important: `compile` does not apply
+`ocaml-patches.sh`** — use `extract` after pulling fresh sources.
+
+## §8. Common failure modes
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `fstar.exe: command not found` | Switch not activated | `eval $(opam env --switch=fstar)` |
+| `Z3 version 4.8.x` etc. | Wrong z3 binary | Reinstall per §3 |
+| `make verify` hangs > 5 min on one module | z3 timeout / wrong solver | Check z3 version, then look for a deep proof obligation |
+| Mysterious "Syntax error" far from real issue | Reserved word (`total`, `in_mem`, …) or `*)` inside a comment | Check the line *above* the reported one; grep for parens-stars in comments |
+| `./build-ocaml.sh` fails with linking error | OCaml stdlib mismatch from old switch | `opam reinstall fstar.lib zarith` |
+| Extracted code calls `failwith "Not yet implemented"` | An `assume val` wasn't patched | Check `ocaml-patches.sh` ran; cross-reference glue files in `minimal_regrettable_glue_code_each_with_an_open_issue/` |
+
+## §9. CI / Claude Code on the web
+
+For Claude Code on the web sessions, the toolchain isn't pre-installed
+in the sandbox. Two options:
+
+1. Use the committed pre-built binaries in `bin/<platform>/` for runtime
+   tests; only run `./w3c_runner` and similar, not `fstar.exe` /
+   `build-ocaml.sh`.
+2. Run a `SessionStart` hook (see the `session-start-hook` skill) that
+   installs opam + the fstar switch + z3 4.13.3 from the binary release.
+
+Option 1 is faster (seconds vs minutes) and adequate for any work that
+doesn't change `.fst` files or extracted `.ml` files. Option 2 is needed
+for end-to-end verification or extraction work.
+
+## §10. Sanity test for "is the env working?"
+
+A one-shot sanity check that exercises the full pipeline:
+
+```bash
+cd /path/to/factoidal
+eval $(opam env --switch=fstar)
+z3 --version | grep -q 4.13.3 || { echo "z3 wrong version"; exit 1; }
+fstar.exe --version | head -1 || { echo "fstar broken"; exit 1; }
+cd formal/fstar
+make verify >/dev/null && echo "verify OK"
+echo "env appears healthy"
+```
+
+If all three of the version check, `make verify`, and the final echo
+succeed, the toolchain is good.
+
+## What this skill does NOT do
+
+- It does not run `make verify` or `build-ocaml.sh` for the user — those
+  are user-driven actions, not setup steps.
+- It does not modify `~/.bashrc` / `~/.zshrc` — that's a user choice.
+- It does not install KaRaMeL (needed for C extraction). KaRaMeL is a
+  separate setup; only relevant when extracting C/WASM, not for the
+  default OCaml path.
+- It does not install OCaml-side ecosystem tools (dune, etc.) beyond
+  what `opam install` brought in.
+
+## Cross-references
+
+- `CLAUDE.md` § "Setup" — authoritative source for these instructions.
+- `docs/skills/testing.md` — what to do once the env works.
+- `docs/skills/measuring.md` — performance measurement setup.
+- `experimental/roaring-fstar/src/Makefile` — example of a standalone
+  `make verify` target outside the main F\* tree.

--- a/.github/workflows/check-fstar-purity.yml
+++ b/.github/workflows/check-fstar-purity.yml
@@ -1,11 +1,19 @@
 # Phase 2.8 Layer 3: rule #11 recurrence guard.
 #
-# This workflow detects net-new semantic logic added to the OCaml glue
-# directory `formal/fstar/experimental_ocaml_glue/`. It does NOT block
-# the existing accumulated drift (~3094 LoC inventoried in
-# docs/designissues/fstar-purity-unwind.md) — those are grandfathered in
-# and are being retired phase-by-phase. The guard only fires on NEW
-# additions in a PR diff.
+# This workflow detects net-new semantic logic added to:
+#
+#   - formal/fstar/experimental_ocaml_glue/*.sh   (the original scope,
+#     2026-04-26; CLAUDE.md rule #11 region).
+#   - formal/fstar/ocaml-output/factoidal_http.ml (extended 2026-05-06
+#     per the boundary audit's 2026-05-01 status update — still has
+#     S-class timeout/cap/sandbox logic).
+#   - formal/fstar/ocaml-output/factoidal_explain.ml (extended
+#     2026-05-06 — currently reimplements F* planner per audit #2).
+#
+# It does NOT block the existing accumulated drift (~3094 LoC
+# inventoried in docs/designissues/fstar-purity-unwind.md) — those
+# are grandfathered in and are being retired phase-by-phase. The
+# guard only fires on NEW additions in a PR diff.
 #
 # Soft-mode by default: emits ::warning:: annotations and a job-summary
 # block, but exits 0. To make it blocking, set repo variable
@@ -75,6 +83,16 @@ jobs:
           set -euo pipefail
           BASE_REF='${{ steps.base.outputs.base_ref }}'
           GLUE_GLOB='formal/fstar/experimental_ocaml_glue/*.sh'
+          # File list extended 2026-05-06 to also watch the two
+          # hand-written OCaml output files flagged in the audit's
+          # 2026-05-01 status update as still containing S-class
+          # logic. The COTTAS-on-disk runtime (RDF_CottasStore.ml) is
+          # extracted from F* and is checked separately by
+          # check-extraction.yml; we skip it here.
+          HAND_WRITTEN=(
+            'formal/fstar/ocaml-output/factoidal_http.ml'
+            'formal/fstar/ocaml-output/factoidal_explain.ml'
+          )
 
           # The diff we care about: only added lines in glue files.
           # `git diff -U0` collapses context to focus on adds/dels.
@@ -84,7 +102,7 @@ jobs:
           # we care about is rc>1 (real error).
           DIFF_FILE=$(mktemp)
           DIFF_RC=0
-          git diff -U0 "$BASE_REF"...HEAD -- $GLUE_GLOB > "$DIFF_FILE" || DIFF_RC=$?
+          git diff -U0 "$BASE_REF"...HEAD -- $GLUE_GLOB "${HAND_WRITTEN[@]}" > "$DIFF_FILE" || DIFF_RC=$?
           if [ "$DIFF_RC" -gt 1 ]; then
             echo "::error::git diff failed with rc=$DIFF_RC"
             exit "$DIFF_RC"
@@ -92,7 +110,7 @@ jobs:
 
           # Defensive: if there are no changed glue files, exit clean.
           if [ ! -s "$DIFF_FILE" ]; then
-            echo "No diff in $GLUE_GLOB versus $BASE_REF — clean."
+            echo "No diff in $GLUE_GLOB or factoidal_http/explain.ml versus $BASE_REF — clean."
             echo "violations=0" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -160,6 +178,73 @@ jobs:
               VIOLATIONS=$((VIOLATIONS+1))
               printf -- '- %s: owl/entailment-regime branch in OCaml glue\n    %s\n' \
                 "$FILE" "${LINE:0:200}" >> "$REPORT"
+            fi
+          done < "$FILE_MAP"
+
+          # Pattern 4 (added 2026-05-06): re-introduction of functions
+          # that were migrated from factoidal_http.ml to F* per the
+          # audit's 2026-05-01 status update. If any of these
+          # definitions reappears in factoidal_http.ml we want to know
+          # — it would mean a migration regressed.
+          #
+          # Migrated and watched:
+          #   json_escape           PR #126 (merged) → SPARQL.JSON.Escape.fst
+          #   status_text           PR #127 (open)   → SPARQL.HTTP.Response.fst
+          #   cors_headers          PR #127 (open)   → SPARQL.HTTP.Response.fst
+          #   cors_policy           PR #127 (open)   → SPARQL.HTTP.Response.fst
+          #   parliament_label      PR #129 (open)   → SPARQL.HTTP.QueriesIndex.fst
+          #   render_queries_index  PR #129 (open)   → SPARQL.HTTP.QueriesIndex.fst
+          #   sandbox_op            sandbox branch   → SPARQL.Update.Sandbox.fst
+          #   sandbox_update        sandbox branch   → SPARQL.Update.Sandbox.fst
+          #   expand_user_graph     sandbox branch   → SPARQL.Update.Sandbox.fst
+          #
+          # Pattern: a top-level `let NAME` (not `let _ = ...` or pattern
+          # binding) reappearing in factoidal_http.ml.
+          MIGRATED='json_escape|status_text|cors_headers|cors_policy|parliament_label|render_queries_index|sandbox_op|sandbox_update|expand_user_graph'
+          while IFS=$'\t' read -r FILE LINE; do
+            if [ "$FILE" != "formal/fstar/ocaml-output/factoidal_http.ml" ]; then
+              continue
+            fi
+            if echo "$LINE" | grep -Eq "^\\+let[[:space:]]+($MIGRATED)\\b"; then
+              VIOLATIONS=$((VIOLATIONS+1))
+              MATCHED=$(echo "$LINE" | sed -E "s/^\\+let[[:space:]]+(($MIGRATED))\\b.*/\\1/")
+              printf -- '- %s: re-introduction of migrated function `%s`\n    %s\n' \
+                "$FILE" "$MATCHED" "${LINE:0:200}" >> "$REPORT"
+            fi
+          done < "$FILE_MAP"
+
+          # Pattern 5 (added 2026-05-06): re-introducing SIGALRM-based
+          # query timeout. The audit's §A flagged the SIGALRM approach
+          # as architecturally wrong (process-global, doesn't compose
+          # with concurrent queries). The replacement is a
+          # `time_budget : nat` + `assume val cancellation_polled :
+          # unit -> bool` discipline; until that lands, the existing
+          # `with_query_timeout` wrapper is grandfathered in
+          # factoidal_http.ml. New uses of `Sys.set_signal Sys.sigalrm`
+          # in any watched file are flagged.
+          while IFS=$'\t' read -r FILE LINE; do
+            if echo "$LINE" | grep -Eq 'Sys\.set_signal[[:space:]]+Sys\.sigalrm'; then
+              VIOLATIONS=$((VIOLATIONS+1))
+              printf -- '- %s: new Sys.set_signal Sys.sigalrm — process-global timeout policy (audit §A)\n    %s\n' \
+                "$FILE" "${LINE:0:200}" >> "$REPORT"
+            fi
+          done < "$FILE_MAP"
+
+          # Pattern 6 (added 2026-05-06): planner-shape additions to
+          # factoidal_explain.ml. Per the audit (#2 in unwind
+          # inventory), factoidal_explain.ml currently reimplements
+          # `choose_best_tp_backend` rather than calling F*'s real
+          # planner. New planner-shaped functions are flagged so we
+          # don't compound the duplication.
+          while IFS=$'\t' read -r FILE LINE; do
+            if [ "$FILE" != "formal/fstar/ocaml-output/factoidal_explain.ml" ]; then
+              continue
+            fi
+            if echo "$LINE" | grep -Eq '^\+let[[:space:]]+(choose_best_tp|estimate_pattern|order_patterns|plan_bgp)\b'; then
+              VIOLATIONS=$((VIOLATIONS+1))
+              MATCHED=$(echo "$LINE" | sed -E 's/^\+let[[:space:]]+([A-Za-z_]+).*/\1/')
+              printf -- '- %s: planner-shaped function `%s` in OCaml explain (should call F* planner)\n    %s\n' \
+                "$FILE" "$MATCHED" "${LINE:0:200}" >> "$REPORT"
             fi
           done < "$FILE_MAP"
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -407,6 +407,10 @@ load into every session's context. They're now separate:
 - [`docs/claude-rules/current-state.md`](docs/claude-rules/current-state.md)
   — Current State (Honest Assessment): F\* inventory, `assume val` table,
   verification gaps, W3C suite scores, phased plan.
+- [`docs/code-name-glossary.md`](docs/code-name-glossary.md) — when you see
+  `Yod6`, `Tet3`, `Lamed3`, `Mem5`, `Pe5`, `Vav3`, `Bet7`, `Tav5`, `Heth3`,
+  etc. in a doc / commit / trace tag and don't know what it means, look
+  it up here. **No new short-codes** — name new things descriptively.
 
 See also [`docs/claude-rules/README.md`](docs/claude-rules/README.md) for
 an index and for the relationship between this file and the expanded docs.

--- a/docs/code-name-glossary.md
+++ b/docs/code-name-glossary.md
@@ -1,0 +1,83 @@
+# Code-name glossary
+
+The project's design docs and code comments are full of cryptic
+short-codes (`Yod6`, `Tet3`, `Lamed3`, `Mem5`, `Pe5`, `Vav3`,
+`Bet7`, …). They originated as **subagent task names** when work
+was dispatched to multiple agents in parallel, then calcified
+into pseudo-jargon used in commits, traces, and design docs.
+They communicate nothing to anyone who wasn't in the room when
+the agent was dispatched.
+
+This file maps each code to a one-line description and a primary
+artefact reference. **New code added to this project should use
+descriptive names, not new short-codes.** When editing existing
+docs, replace cryptic codes with descriptive phrases; keep the
+short-code in parentheses on first occurrence if it's already
+widely used.
+
+When you see one of these in a commit message or comment, look
+it up here. When in doubt, the doc references are authoritative.
+
+---
+
+## COTTAS / on-disk backend optimisations
+
+| Short-code | Plain description | Primary artefact |
+|-----|-----|-----|
+| **Mem4** | Cross-query F\* page cache for DLBA column decode (avoids per-cell `Array.of_list`). | `RDF.CottasStore.PageCache.fst` |
+| **Mem5** | Estimate-via-presence-bitmap fast path; per-rg cardinality from `.presence` without column decode. | `RDF.CottasStore.fst:cottas_ondisk_estimate` |
+| **Pe4** | Per-row-group search trace stats (timings, candidate count). Emits `[pe4-trace]` to stderr. | `RDF_CottasStore.ml:891` |
+| **Pe5** | `factoidal --explain` mode: plan-only dump of algebra + cardinality estimates, no execution. | `factoidal_explain.ml`; `2026-04-26-pe5-explain-mode.md` |
+| **Vav3** | Persistent companion files (`.dict`, `.presence`, …) replacing the 107s / 1.4 GB in-memory pre-warm. mmap'd on demand. | `RDF.CottasStore.OnDiskIndex.fst` |
+| **Psi3** | F\*-source-of-truth read API for presence-bitmap companion files. | `RDF.CottasStore.PresenceBitmap.fst` |
+| **Mim2** | First iteration of mmap'd companion-file readers (pre-Vav3). | (mostly retired) |
+| **Mim3** | Pre-warm lazy-fallback warning log line. Emits `[mim3-trace]`. | `RDF_CottasStore.ml` |
+| **Bet5** | Earlier hashtable-cache iteration (largely retired by Vav3). | (historical) |
+| **Bet7** | Lazy populate of in-RAM Hashtbls when companion files are absent / fail. Emits `[bet7-trace]`. | `cottas_ondisk_z_lazy_open.sh` (glue, retired in spirit) |
+| **Tau3** | Audit doc reviewing whether Bet7 can be retired. | `2026-04-26-tau3-bet7-retire-audit.md` |
+| **Yod6** | Predicate-presence row-group prune. Bitmap says "predicate X *might* appear in row-group Y"; lets the evaluator skip RGs that can't match. | `cottas_ondisk_zzz_yod6_pred_presence_prune.sh`; F\* equivalent in `RDF.CottasStore.fst:480-525` |
+| **Tet3** | Subject + object presence row-group prune (analogous to Yod6 for S and O columns). | `cottas_ondisk_zzzz_tet3_subj_obj_prune.sh` |
+| **Lamed3** | Per-row-group predicate row-offset index (`.p.offsets` mmap'd file). Goal: `?s rdf:type ?o LIMIT 5` from 6s → <200ms. | `cottas_ondisk_zzzzzz_lamed3_offset_idx.sh` |
+| **Qof3** | Distinct count discovery per dictionary column. Emits `[qof3-trace]`. | `RDF_CottasStore.ml` |
+| **Aleph6** | Streaming COUNT(\*) + LIMIT pushdown fast paths. | `cottas_ondisk_zz_aleph6_count_limit.sh` |
+| **Resh3** | Migration of `cottas_ondisk_search` / `_estimate` / `_search_limited` from OCaml glue back to F\* (Phases 2.5 of the purity unwind). | `2026-04-25-resh3-phase-A-fstar-purity.md`; PR #122 |
+
+## HTTP server policy
+
+| Short-code | Plain description | Primary artefact |
+|-----|-----|-----|
+| **Tav5** | Result-row cap circuit breaker. `--max-rows N`. Emits `[tav5-trace]` when triggered. | `factoidal_http.ml` |
+| **Heth3** | SIGALRM-based per-query timeout (`--query-timeout SECS`, default 120s). Process-global; flagged in audit §A as architecturally wrong, retire-pending. | `factoidal_http.ml:with_query_timeout` |
+
+## CI / process
+
+| Short-code | Plain description | Primary artefact |
+|-----|-----|-----|
+| **Omega3** | The F\*-purity CI workflow (rule #11 recurrence guard) — soft-mode, scans diffs in OCaml glue + watched hand-written .ml files for net-new semantic logic. | `.github/workflows/check-fstar-purity.yml`; `2026-04-26-omega3-ci-purity-check.md` |
+
+---
+
+## Going forward
+
+1. **No new short-codes.** Name new things descriptively. If the
+   thing is too long for a function name, the codebase will accept
+   `predicate_presence_prune_v2` over `Kaph7`. Future readers will
+   thank us.
+2. **In existing docs**, when you touch a section that uses a
+   short-code, expand it on first occurrence: "Yod6 (predicate-
+   presence prune)". Don't churn-rewrite docs that aren't being
+   touched.
+3. **In new commit messages**, always say what changed, not which
+   short-code it pertains to. "fix predicate-presence prune for
+   compound (s,p) bindings" beats "fix Yod6 for compound bindings".
+4. **In F\* / OCaml comments**, prefer the descriptive name.
+   Cross-reference the short-code only if needed for git-archaeology
+   ("originally landed as Yod6").
+5. **In trace tags** (the `[yod6-trace]`-style stderr lines),
+   keep the short-codes for backward compatibility with existing
+   greps and dashboards. Trace tags are an exception because
+   third-party tooling may already match on them.
+
+If a short-code is missing from the table above and you can't
+figure out what it means from context, that's a bug — file a PR
+adding it.

--- a/docs/designissues/2026-05-06-fstar-drift-recheck.md
+++ b/docs/designissues/2026-05-06-fstar-drift-recheck.md
@@ -1,0 +1,202 @@
+# F\*/OCaml boundary audit — drift recheck 2026-05-06
+
+**Status:** spot-check, no new violations found.
+**Companion:** `fstar-ocaml-boundary-audit.md` (full audit + 2026-05-01 status).
+**Code-names:** `docs/code-name-glossary.md`.
+
+> Plain-language note: this doc is part of the F\*/OCaml boundary
+> audit (making sure load-bearing logic stays in F\*, not creeping
+> into OCaml). It does not introduce new code; it walks the recent
+> commits looking for that drift, and tightens a CI gate.
+
+This is a scheduled-style recheck of `claude/main` against the audit's
+2026-05-01 status update, plus a small expansion of the
+`check-fstar-purity` CI gate's coverage. Nothing here changes the
+audit's substantive conclusions; it's a clean checkpoint with two
+specific changes.
+
+---
+
+## 1. Recent commits to claude/main since 2026-05-01
+
+Walked the commits from 2026-05-01 forward (`git log --since 2026-05-01
+origin/claude/main`). Material changes that could affect the audit:
+
+### PR #136 — per-stage query timing (commit `8422f69`)
+
+Added Server-Timing header + `/admin/recent.json` + an `admin/`
+landing page to `factoidal_http.ml`. New definitions in OCaml:
+
+- `query_timing` record + `zero_timing`.
+- `recent_queries` ring buffer (`Mutex.create ()` + `ref []` capped
+  at 50).
+- Process-global counters `total_queries_seen`, `total_query_wall_ms`,
+  `queries_status_2xx/4xx/5xx`, with their own mutex.
+- `parse_and_run_timed` wrapping `parse_and_run`.
+- `with_query_timeout` (the SIGALRM-based per-query timeout
+  wrapper — pre-existing, not new).
+- JSON renderer + admin HTML serving glue.
+
+**Audit assessment:** acceptable per rule-#11(c) "thin glue" — these
+are observability and HTTP-rendering plumbing, exactly the kind of
+runtime mutable state the audit explicitly classifies as *reasonable
+OCaml glue* ("threading runtime mutable state (refs, mutexes) through
+request handlers"). The S-class items (timeout, cap, 503 retry-after)
+remain blocked on new F\*-typed infrastructure (`time_budget : nat` +
+`assume val cancellation_polled : unit -> bool`) per audit §A; this
+PR did not regress that — the existing `with_query_timeout` was
+extended in shape but not in policy.
+
+**Caveat:** this is a watch-this-space item. The query-timing
+record carries an `eval_ms` field that, once the F\* evaluator is
+itself instrumented, should be sourced from F\*-side instrumentation
+rather than wrapped at the OCaml layer. Filing as deferred per audit
+§A; not net-new drift.
+
+### PR #135 — inmem-cottas Phase A.5 re-scope (commit `e2ad715`)
+
+Phase A.5 dispatch had a "encode bytes + intercept parquet_read_*"
+plan; the agent timed out and **explicitly reported back that the
+plan would have required ~6 distinct parquet probes patched in OCaml,
+several of which would qualify as semantic glue rather than pure I/O
+routing.**
+
+Recommended re-scope: a new `GB_InMem` graph_backend F\* variant,
+~200–400 LoC, F\*-first.
+
+**Audit assessment:** **good signal.** The dispatch process caught
+the drift before any patches landed. This is exactly the
+audit-by-process intent of the boundary audit — agents explicitly
+classify proposed work as "semantic-must-migrate" vs "acceptable
+glue" before writing code. Doc landed at
+`docs/designissues/in-memory-cottas-phase-a5-block.md`.
+
+### PR #132 — streaming-count-group ORDER BY support
+
+Added support for ORDER BY in the streaming COUNT/GROUP BY fast path.
+Implementation lives in F\* (algebra-side). No OCaml-side semantic
+additions noted. Not a drift concern.
+
+### PR #131/#133 + lessons note (commit `741a8d7`)
+
+Q01 perf hunt 2026-05-01. The lessons note documents that the fast
+path was correct on the wrong layer — the actual bottleneck is
+`indexed_dataset_backend`'s `bucket_replace_acc`. No code in this
+commit; just diagnosis. Not a drift concern.
+
+### `inmem-cottas: Phase A scaffold` (commit `42af49d`)
+
+Stub returning `None`. No semantic content. Not a drift concern.
+
+### Background ci(linux-x86_64) shadow-build commits
+
+CI artifact bumps. Not a drift concern.
+
+---
+
+## 2. State of in-flight migration PRs
+
+Per audit's 2026-05-01 update:
+
+- **#126 — `json_escape` → SPARQL.JSON.Escape.fst** — merged.
+- **#127 — `status_text` + `cors_*` → SPARQL.HTTP.Response.fst** — open.
+- **#128 — `/backend-info.json` → SPARQL.HTTP.BackendInfo.fst** — open.
+- **#129 — `parliament_label` + `render_queries_index` → SPARQL.HTTP.QueriesIndex.fst** — open.
+- **`claude/http-update-sandbox-to-fstar`** — in flight; ~170 LoC of
+  update-policy semantics → SPARQL.Update.Sandbox.fst.
+
+Not landed since 2026-05-01. PR statuses not re-checked in this
+recheck (no GitHub access this session); the audit number 2026-05-01
+remains the canonical source until those merge.
+
+---
+
+## 3. CI purity gate expansion (this commit)
+
+Updated `.github/workflows/check-fstar-purity.yml` to:
+
+### 3a. Watch additional files
+
+Added `formal/fstar/ocaml-output/factoidal_http.ml` and
+`formal/fstar/ocaml-output/factoidal_explain.ml` to the diff scope.
+Previously the gate only watched
+`formal/fstar/experimental_ocaml_glue/*.sh`, leaving the audit's
+"factoidal_http.ml has S-class drift" surface uncovered.
+
+### 3b. Pattern 4: re-introduction of migrated functions
+
+If any of the following names re-appears as a top-level `let` in
+`factoidal_http.ml`, the gate flags it (soft-mode warning):
+
+```
+json_escape  status_text  cors_headers  cors_policy
+parliament_label  render_queries_index
+sandbox_op  sandbox_update  expand_user_graph
+```
+
+These are the functions migrated to F\* (PR #126 merged) or in
+flight to F\* (#127 / #129 / sandbox branch) per the 2026-05-01
+status. Re-defining them in OCaml would mean a migration regressed.
+
+### 3c. Pattern 5: SIGALRM regression
+
+The audit's §A flagged `Sys.set_signal Sys.sigalrm` based query
+timeouts as process-global (a SIGALRM in one query interrupts every
+query running in the process) and therefore architecturally wrong.
+The existing `with_query_timeout` is grandfathered until the F\*
+`time_budget` / `cancellation_polled` infrastructure lands. **New** uses of
+`Sys.set_signal Sys.sigalrm` in any watched file are flagged.
+
+### 3d. Pattern 6: planner-shape duplication in explain
+
+Audit #2 in unwind inventory: `factoidal_explain.ml` reimplements
+`choose_best_tp_backend` rather than calling F\*'s planner. New
+planner-shape `let` definitions in `factoidal_explain.ml`
+(`choose_best_tp_*`, `estimate_pattern*`, `order_patterns*`,
+`plan_bgp*`) are flagged so duplication doesn't compound.
+
+### What the gate still does NOT catch (deliberately)
+
+- Generic `let` definitions in `factoidal_http.ml` that don't match
+  the migrated-function or SIGALRM patterns. Adding observability
+  glue, mutable refs, mutexes, JSON renderers — all explicitly
+  acceptable per audit's "thin glue" classification — does not
+  trigger.
+- Any change to `RDF_CottasStore.ml`. That file is extracted from
+  F\*; the existing `check-extraction.yml` workflow covers
+  extraction sanity. Glue patches that mutate it post-extraction
+  are caught via the `experimental_ocaml_glue/*.sh` watch.
+- Anything in `bin/<platform>/`, generated JS / WASM, or vendored
+  third-party. Those are checked by `check-derived-files.yml`.
+
+### Mode
+
+Soft-mode preserved (`exit 0` even on violations; PR comment
+posted). Repo variable `FSTAR_PURITY_HARD=1` flips to blocking. The
+audit's 2026-05-01 update doesn't make a recommendation on
+flipping; this recheck doesn't either.
+
+---
+
+## 4. Recommendation
+
+Status: **clean**. No fresh drift detected since 2026-05-01. Two
+positive signals:
+
+1. PR #136 (timing) stayed within the rule-#11(c) "thin glue"
+   surface; the audit's classification absorbs it cleanly.
+2. PR #135 (inmem-cottas re-scope) demonstrates the audit's
+   process-level review actually *prevented* drift — the agent
+   recognised the proposed plan as semantic-glue and reported back
+   rather than landing patches.
+
+The expanded CI gate (this commit) tightens coverage for the next
+recheck cycle.
+
+**Next recheck**: when #127 / #128 / #129 / sandbox land, or in 2
+weeks (whichever comes first). After those land, the
+`render_queries_index` / `cors_*` / `parliament_label` /
+`sandbox_op` patterns in the gate become guards rather than
+optimistic warnings — re-introduction would be a real regression.
+
+**No action required from the user beyond this commit.**


### PR DESCRIPTION
Three independent improvements to the F\*-purity audit / boundary-classification process. None of them changes any F\* or OCaml runtime code.

> Qualifier per CLAUDE.md rule #11: parser and algebra spec verified in F\*; on-disk backend currently has unverified OCaml-side caching/optimisation layers being migrated back to F\* (see `docs/designissues/fstar-purity-unwind.md`). This PR tightens the *process* around that audit; it does not alter the verification surface itself.

## 1. F\*-purity CI gate expansion

`.github/workflows/check-fstar-purity.yml`. Previously the gate only watched `formal/fstar/experimental_ocaml_glue/*.sh`. Per the audit's 2026-05-01 status update, drift extends to `factoidal_http.ml` (still has S-class timeout/cap/sandbox logic) and `factoidal_explain.ml` (currently reimplements F\*'s planner per audit #2). The gate now also watches both, with three new patterns:

- **Pattern 4** — re-introduction of functions migrated to F\*. If any of `json_escape`, `status_text`, `cors_headers`, `cors_policy`, `parliament_label`, `render_queries_index`, `sandbox_op`, `sandbox_update`, `expand_user_graph` reappears as a top-level `let` in `factoidal_http.ml`, flagged. (PR #126 merged json_escape; #127 / #128 / #129 / sandbox-branch are in flight to migrate the rest.)
- **Pattern 5** — new `Sys.set_signal Sys.sigalrm` uses anywhere in watched files. The audit §A flags the SIGALRM-based timeout as architecturally wrong (process-global; one query's SIGALRM interrupts every concurrent query). The existing `with_query_timeout` is grandfathered until F\* `time_budget` / `cancellation_polled` infrastructure lands; new uses get flagged.
- **Pattern 6** — planner-shape additions to `factoidal_explain.ml` (`choose_best_tp_*`, `estimate_pattern*`, `order_patterns*`, `plan_bgp*`). Existing duplication of F\*'s planner is grandfathered; new ones flagged so duplication doesn't compound.

Stays in soft-mode (`exit 0` even on violations; PR comment posted). Repo variable `FSTAR_PURITY_HARD=1` flips to blocking. Dry-run against the last 25 commits on `claude/main`: zero false positives. Specifically:

- **PR #136** (per-stage query timing — Server-Timing + `/admin/recent.json`) added several `let` definitions (`query_timing`, `recent_queries`, mutexes, counters, `parse_and_run_timed`, `with_query_timeout`) but none match the migrated-function or SIGALRM-introduction patterns. The gate correctly does not flag observability glue.

## 2. Code-name glossary

`docs/code-name-glossary.md` + a pointer added to `CLAUDE.md`'s "Expanded Docs" section.

The project's docs are full of cryptic short-codes (`Yod6`, `Tet3`, `Lamed3`, `Mem5`, `Pe5`, `Vav3`, `Bet7`, `Tav5`, `Heth3`, …) that originated as subagent task names and calcified into pseudo-jargon nobody can decode without `git log -G`. The glossary maps each to a one-line description and primary-artefact reference, plus a going-forward policy:

- No new short-codes for new things. Use descriptive names.
- When touching a doc that uses a short-code, expand on first occurrence: "Yod6 (predicate-presence prune)".
- Prefer descriptive names in commit messages and source comments.
- Trace tags (`[yod6-trace]` etc.) keep the codes for grep / dashboard backward-compatibility — that's the one allowed exception.

Twenty-odd entries covered, grouped by area (COTTAS optimisations, HTTP server policy, CI/process). When a code is missing from the table, that's a bug.

## 3. 2026-05-06 drift recheck

`docs/designissues/2026-05-06-fstar-drift-recheck.md`. Walked `claude/main` since the boundary audit's 2026-05-01 status update. **Status: clean** — no fresh drift detected.

Two positive signals:

- **PR #136** (per-stage query timing) added observability + admin glue to `factoidal_http.ml`. Acceptable per the audit's "thin glue" classification (mutex-protected refs, JSON renderers, ring buffers — explicitly listed as reasonable OCaml glue). The pre-existing SIGALRM-based timeout wrapper not regressed.
- **PR #135** (in-memory COTTAS Phase A.5 re-scope) demonstrated audit-by-process working as designed: the dispatched agent recognised the proposed plan would have required ~6 OCaml-side patches across `Parquet_Footer.ml` + `RDF_CottasStore.ml` that "qualify as semantic glue rather than pure I/O routing," and reported back asking for a re-scope to F\*-first.

Other recent commits (#132 streaming-count-group, perf lessons note, scaffolds, CI artefact bumps) introduce no drift.

In-flight migration PRs status from the 2026-05-01 update is unchanged: #127 / #128 / #129 / sandbox branch open, not landed since.

## Test plan

- [x] Workflow YAML validates (no syntax breakage); existing patterns 1-3 unchanged
- [x] Patterns 4-6 dry-run against the last 25 commits on `claude/main` — zero false positives
- [x] `CLAUDE.md` glossary pointer renders correctly in markdown (visible in PR diff)
- [ ] First real-PR signal once this lands: any subsequent PR touching the watched files exercises the new patterns

## Companion PR

This PR is paired with `claude/roaring-fstar-phase-a` (Phase A of an experimental F\* port of Roaring bitmaps). The two are independent and can land in either order.

The `.claude/skills/fstar-env/SKILL.md` (F\* / opam / z3 toolchain setup skill) is included here rather than with the Roaring PR because it's general-purpose project tooling — the skill applies to anyone working on F\* in this repo, not specifically to the Roaring work that triggered its creation.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gid59KLYfGtaXLNfFWnPt1)_