### PR TITLE
Lift parse_cors_value, cors_mode_to_string, simplify select_vars

### DIFF
--- a/formal/fstar/SPARQL.HTTP.Response.fst
+++ b/formal/fstar/SPARQL.HTTP.Response.fst
@@ -135,3 +135,68 @@ let _ = assert_norm (
 // with a JSON timeout body — keep them locked together at extract
 // time.
 let _ = assert_norm (status_text 504 = "Gateway Timeout")
+
+// ---------------------------------------------------------------
+// CLI parsing: --cors=<value> string -> cors_policy.
+//
+// Migrated from factoidal_http.ml's parse_cors_value (rule #1 — F* is
+// the source of truth for the mapping). Two semantic decisions:
+//   - "*" means CORS_Any
+//   - otherwise, comma-separated origins (with whitespace trimmed and
+//     empty entries dropped); empty list falls back to CORS_Off so a
+//     stray "--cors=" or "--cors=," is a no-op rather than rejecting
+//     every request silently.
+//
+// We implement ASCII trim here rather than asking the caller to
+// pre-trim because the per-part trim after split(',') makes the
+// responsibility-split awkward.
+// ---------------------------------------------------------------
+
+let is_ascii_ws (c : FStar.Char.char) : Tot bool =
+  let n = FStar.Char.int_of_char c in
+  n = 0x20 || n = 0x09 || n = 0x0A || n = 0x0D
+
+let rec drop_leading_ws (cs : list FStar.Char.char)
+  : Tot (list FStar.Char.char) (decreases cs) =
+  match cs with
+  | [] -> []
+  | c :: rest -> if is_ascii_ws c then drop_leading_ws rest else cs
+
+let trim_ascii (s : string) : Tot string =
+  let cs = FStar.String.list_of_string s in
+  let l = drop_leading_ws cs in
+  let r = FStar.List.Tot.rev (drop_leading_ws (FStar.List.Tot.rev l)) in
+  FStar.String.string_of_list r
+
+let rec map_trim (xs : list string) : Tot (list string) (decreases xs) =
+  match xs with
+  | [] -> []
+  | x :: rest -> trim_ascii x :: map_trim rest
+
+let rec drop_empty (xs : list string) : Tot (list string) (decreases xs) =
+  match xs with
+  | [] -> []
+  | x :: rest -> if x = "" then drop_empty rest else x :: drop_empty rest
+
+let parse_cors_value (raw : string) : Tot cors_policy =
+  let v = trim_ascii raw in
+  if v = "*" then CORS_Any
+  else
+    let parts = drop_empty (map_trim (FStar.String.split [','] v)) in
+    match parts with
+    | [] -> CORS_Off
+    | _  -> CORS_List parts
+
+// Human-readable description of the CORS mode, for the startup log.
+let rec join_with_comma_space (xs : list string) : Tot string (decreases xs) =
+  match xs with
+  | [] -> ""
+  | [x] -> x
+  | x :: rest -> x ^ ", " ^ join_with_comma_space rest
+
+let cors_mode_to_string (p : cors_policy) : Tot string =
+  match p with
+  | CORS_Off  -> "off (no Access-Control-* headers)"
+  | CORS_Any  -> "any origin (Access-Control-Allow-Origin: *)"
+  | CORS_List origins ->
+      "allowlist (" ^ join_with_comma_space origins ^ ")"

--- a/formal/fstar/ocaml-output/SPARQL_HTTP_Response.ml
+++ b/formal/fstar/ocaml-output/SPARQL_HTTP_Response.ml
@@ -91,3 +91,53 @@ let (query_timeout_response_body : Prims.int -> Prims.string) =
       ["{\"error\":\"query_timeout\",\"seconds\":";
       Prims.string_of_int secs;
       ",\"hint\":\"Add LIMIT or bind more triple-pattern terms.\"}\n"]
+let (is_ascii_ws : FStar_Char.char -> Prims.bool) =
+  fun c ->
+    let n = FStar_Char.int_of_char c in
+    (((n = (Prims.of_int (0x20))) || (n = (Prims.of_int (0x09)))) ||
+       (n = (Prims.of_int (0x0A))))
+      || (n = (Prims.of_int (0x0D)))
+let rec (drop_leading_ws :
+  FStar_Char.char Prims.list -> FStar_Char.char Prims.list) =
+  fun cs ->
+    match cs with
+    | [] -> []
+    | c::rest -> if is_ascii_ws c then drop_leading_ws rest else cs
+let (trim_ascii : Prims.string -> Prims.string) =
+  fun s ->
+    let cs = FStar_String.list_of_string s in
+    let l = drop_leading_ws cs in
+    let r =
+      FStar_List_Tot_Base.rev (drop_leading_ws (FStar_List_Tot_Base.rev l)) in
+    FStar_String.string_of_list r
+let rec (map_trim : Prims.string Prims.list -> Prims.string Prims.list) =
+  fun xs ->
+    match xs with | [] -> [] | x::rest -> (trim_ascii x) :: (map_trim rest)
+let rec (drop_empty : Prims.string Prims.list -> Prims.string Prims.list) =
+  fun xs ->
+    match xs with
+    | [] -> []
+    | x::rest -> if x = "" then drop_empty rest else x :: (drop_empty rest)
+let (parse_cors_value : Prims.string -> cors_policy) =
+  fun raw ->
+    let v = trim_ascii raw in
+    if v = "*"
+    then CORS_Any
+    else
+      (let parts = drop_empty (map_trim (FStar_String.split [44] v)) in
+       match parts with | [] -> CORS_Off | uu___1 -> CORS_List parts)
+let rec (join_with_comma_space : Prims.string Prims.list -> Prims.string) =
+  fun xs ->
+    match xs with
+    | [] -> ""
+    | x::[] -> x
+    | x::rest ->
+        Prims.strcat x (Prims.strcat ", " (join_with_comma_space rest))
+let (cors_mode_to_string : cors_policy -> Prims.string) =
+  fun p ->
+    match p with
+    | CORS_Off -> "off (no Access-Control-* headers)"
+    | CORS_Any -> "any origin (Access-Control-Allow-Origin: *)"
+    | CORS_List origins ->
+        Prims.strcat "allowlist ("
+          (Prims.strcat (join_with_comma_space origins) ")")

--- a/formal/fstar/ocaml-output/factoidal_http.ml
+++ b/formal/fstar/ocaml-output/factoidal_http.ml
@@ -308,26 +308,15 @@ let usage () =
    "*" -> CORS_Any; otherwise split on commas and trim whitespace. An empty
    list (e.g. --cors= with nothing after) falls back to CORS_Off so the flag
    is effectively a no-op rather than rejecting every origin silently. *)
-let parse_cors_value (v : string) : cors_policy =
-  let v = String.trim v in
-  if v = "*" then CORS_Any
-  else begin
-    let parts =
-      String.split_on_char ',' v
-      |> List.map String.trim
-      |> List.filter (fun s -> s <> "")
-    in
-    match parts with
-    | [] -> CORS_Off
-    | _  -> CORS_List parts
-  end
+(* Forward to the F*-verified parse + display functions in
+   SPARQL_HTTP_Response. The semantic decisions (string -> CORS variant,
+   variant -> human description) are F*-source-of-truth per rule #1.
+   See formal/fstar/SPARQL.HTTP.Response.fst. *)
+let parse_cors_value : string -> cors_policy =
+  SPARQL_HTTP_Response.parse_cors_value
 
-(* Human-readable description of the CORS mode, for the startup log. *)
-let cors_mode_to_string = function
-  | CORS_Off -> "off (no Access-Control-* headers)"
-  | CORS_Any -> "any origin (Access-Control-Allow-Origin: *)"
-  | CORS_List origins ->
-    Printf.sprintf "allowlist (%s)" (String.concat ", " origins)
+let cors_mode_to_string : cors_policy -> string =
+  SPARQL_HTTP_Response.cors_mode_to_string
 
 (* Split "--key=value" into ("--key", Some "value"); otherwise (arg, None). *)
 let split_eq arg =
@@ -912,15 +901,18 @@ let response_format_of_accept accept =
   let entries = P.parse_accept_header accept in
   P.pick_response_format entries P.RF_Json
 
-(* Extract variable list from a SELECT query (same shape as factoidal_cli). *)
+(* Extract variable list from a SELECT query.
+   The "explicit projection" half (Select_Vars items) goes through the
+   F*-verified SPARQL11_Algebra.select_item_vars (rule #1 — F* is the
+   source of truth for SPARQL semantics). The star-projection fallback
+   "collect distinct vars from the actual result rows in first-seen
+   order" stays here as glue: it observes runtime data, doesn't make a
+   semantic decision about what the SELECT clause projects. *)
 let select_vars query results =
   match query.q_form with
   | QF_Select (Select_Vars items) ->
-    List.map (fun item -> match item with
-      | SI_Var v -> v
-      | SI_Expr (_, v) -> v) items
+    SPARQL11_Algebra.select_item_vars items
   | _ ->
-    (* Star projection — collect from actual result rows, keep first-seen order. *)
     let seen = Hashtbl.create 16 in
     let acc = ref [] in
     List.iter (fun row ->


### PR DESCRIPTION
Three small lifts that fit naturally together as `factoidal_http.ml` glue cleanup. None require new F\* infrastructure; all are existing functions that should have been in F\* already per Iron Rule #1.

> Qualifier per CLAUDE.md rule #11: parser and algebra spec verified in F\*; on-disk backend currently has unverified OCaml-side caching/optimisation layers being migrated back to F\* (see `docs/designissues/fstar-purity-unwind.md`). This PR retires three pieces of duplicated/diverged OCaml-side semantic logic.

## 1. `select_vars` — call F\*'s existing `select_item_vars`

The "explicit projection" half of `select_vars` (the `Select_Vars items` branch) was reimplementing `SPARQL11_Algebra.select_item_vars` — which already exists at `SPARQL11.Algebra.fst:3551` and is already extracted to OCaml. Replaced the inline `List.map` with a direct call.

Star-projection fallback retained: it observes runtime data (collect distinct vars from result rows in first-seen order), which is data-observation glue rather than a SPARQL semantic decision per the audit's "thin glue" classification.

## 2. `parse_cors_value` → `SPARQL.HTTP.Response.parse_cors_value`

Parses `--cors=<value>` CLI strings into the `cors_policy` variant (defined in `SPARQL.HTTP.Response.fst` per PR #127). The mapping
- `"*"` → `CORS_Any`
- empty / all-empty after trim → `CORS_Off` (no-op safety)
- `"a, b, c"` → `CORS_List ["a"; "b"; "c"]` (whitespace-trimmed, empty-dropped)

is a semantic decision. Lifted with helpers:

```fstar
val is_ascii_ws : char -> bool
val drop_leading_ws : list char -> list char
val trim_ascii : string -> string
val map_trim : list string -> list string
val drop_empty : list string -> list string
val parse_cors_value : string -> cors_policy
```

`trim_ascii` strips 0x09 / 0x0A / 0x0D / 0x20 from both ends via reverse-strip-leading-reverse. Pure F\*, no `assume val` introduced.

## 3. `cors_mode_to_string` → `SPARQL.HTTP.Response.cors_mode_to_string`

Human-readable description of a `cors_policy` for the startup log. Pure mapping with the same drift-target shape as `parse_cors_value`. Lifted alongside, with a small `join_with_comma_space` helper (the `FStar.String.concat` shape doesn't match what we want for a list-of-string join, so a 4-line recursion is the simplest path).

## OCaml side

`factoidal_http.ml` now contains:

```ocaml
let parse_cors_value   : string -> cors_policy = SPARQL_HTTP_Response.parse_cors_value
let cors_mode_to_string : cors_policy -> string = SPARQL_HTTP_Response.cors_mode_to_string

let select_vars query results =
  match query.q_form with
  | QF_Select (Select_Vars items) -> SPARQL11_Algebra.select_item_vars items
  | _ -> (* star-fallback Hashtbl glue retained *)
```

## Verification

```
$ fstar.exe --z3version 4.13.3 SPARQL.HTTP.Response.fst
Verified module: SPARQL.HTTP.Response
Extracted module SPARQL.HTTP.Response
```

(F\* 2025.03.25~dev was reinstalled mid-session and wants the explicit `--z3version 4.13.3`. The project's standard CI invocation already has the right flag baked into `build-ocaml.sh`.)

## LoC delta (factoidal_http.ml)

| Function | Before | After | Delta |
|---|---:|---:|---:|
| `parse_cors_value` | 15 | 2 | −13 |
| `cors_mode_to_string` | 6 | 1 | −5 |
| `select_vars` | 19 | 16 | −3 |
| **OCaml-side semantic LoC retired** | — | — | **−21** |

Plus +60 in `SPARQL.HTTP.Response.fst` (the new functions and helpers).

## Test plan

- [ ] CI: full F\* extract + native compile + js_of_ocaml + wasm
- [ ] CI: `factoidal-http --cors='*'` / `--cors='https://a, https://b'` / `--cors=' '` — parsing + startup-log display unchanged
- [ ] CI: SPARQL response var-listing on `SELECT ?x ?y { ... }` and on `SELECT * { ... }` unchanged
- [ ] CI: F\*-purity gate (PR #138's expanded version) — clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gid59KLYfGtaXLNfFWnPt1)_