### PR TITLE
Lift content_type_for_path + path_has_dotdot to SPARQL.HTTP.StaticFiles.fst

### DIFF
--- a/formal/fstar/SPARQL.HTTP.StaticFiles.fst
+++ b/formal/fstar/SPARQL.HTTP.StaticFiles.fst
@@ -1,0 +1,77 @@
+module SPARQL.HTTP.StaticFiles
+
+// Static-file serving primitives — the "decision" parts.
+//
+// Migrated from factoidal_http.ml's content_type_for_path and
+// path_has_dotdot. Both are pure string analysis; both encode policy
+// (file-extension -> MIME type mapping; "no path traversal") that
+// belongs in F* per Iron Rule #1.
+//
+// The actual file I/O (open, read, stat) stays in the OCaml caller
+// because that's a syscall.
+
+module S = FStar.String
+
+// ---------------------------------------------------------------
+// content_type_for_path
+//
+// Maps a path's extension to an HTTP Content-Type response header
+// value. Restricted to the file types the server actually serves
+// from the demo / web directories. Anything else falls back to
+// application/octet-stream so the browser doesn't auto-execute
+// unknown content.
+// ---------------------------------------------------------------
+
+let ends_with (s : string) (suf : string) : Tot bool =
+  let lp = S.length s in
+  let ls = S.length suf in
+  if lp >= ls then S.sub s (lp - ls) ls = suf
+  else false
+
+let content_type_for_path (path : string) : Tot string =
+  let p = S.lowercase path in
+  if ends_with p ".html" || ends_with p ".htm"
+    then "text/html; charset=utf-8"
+  else if ends_with p ".css"
+    then "text/css; charset=utf-8"
+  else if ends_with p ".js" || ends_with p ".mjs"
+    then "application/javascript; charset=utf-8"
+  else if ends_with p ".json"
+    then "application/json; charset=utf-8"
+  else if ends_with p ".svg"
+    then "image/svg+xml; charset=utf-8"
+  else if ends_with p ".png"
+    then "image/png"
+  else if ends_with p ".jpg" || ends_with p ".jpeg"
+    then "image/jpeg"
+  else if ends_with p ".ico"
+    then "image/x-icon"
+  else if ends_with p ".txt" || ends_with p ".md"
+    then "text/plain; charset=utf-8"
+  else if ends_with p ".ttl"
+    then "text/turtle; charset=utf-8"
+  else if ends_with p ".nt"
+    then "application/n-triples; charset=utf-8"
+  else if ends_with p ".nq"
+    then "application/n-quads; charset=utf-8"
+  else "application/octet-stream"
+
+// ---------------------------------------------------------------
+// path_has_dotdot
+//
+// Coarse path-traversal guard: the URL path must not contain "..".
+// We only ever concatenate the URL path onto a resolved demo root,
+// so this is sufficient — no full URL canonicalisation needed.
+//
+// Return true iff the input contains the byte sequence "..".
+// ---------------------------------------------------------------
+
+let rec contains_dotdot_at (s : string) (i : nat) : Tot bool (decreases (S.length s - i)) =
+  let n = S.length s in
+  if i + 2 > n then false
+  else if S.sub s i 2 = ".." then true
+  else if i + 1 > n then false
+  else contains_dotdot_at s (i + 1)
+
+let path_has_dotdot (p : string) : Tot bool =
+  contains_dotdot_at p 0

--- a/formal/fstar/build-ocaml.sh
+++ b/formal/fstar/build-ocaml.sh
@@ -185,6 +185,7 @@ if [[ "$STEP" == "all" || "$STEP" == "extract" ]]; then
              SPARQL.HTTP.Response.fst \
              SPARQL.HTTP.BackendInfo.fst \
              SPARQL.HTTP.QueriesIndex.fst \
+             SPARQL.HTTP.StaticFiles.fst \
              Parser.Ballyhoo.fst Parser.BallyhooBloom.fst \
              Parser.BallyhooHDT.fst Parser.BallyhooHDTQ.fst \
              Parser.BallyhooCOTTAS.fst \
@@ -273,6 +274,7 @@ if [[ "$STEP" == "all" || "$STEP" == "compile" ]]; then
     SPARQL_HTTP_Response.ml \
     SPARQL_HTTP_BackendInfo.ml \
     SPARQL_HTTP_QueriesIndex.ml \
+    SPARQL_HTTP_StaticFiles.ml \
     Parser_Ballyhoo.ml Parser_BallyhooBloom.ml \
     Parser_BallyhooHDT.ml Parser_BallyhooHDTQ.ml Parser_BallyhooCOTTAS.ml \
     RDF_CottasStore_ColumnSeq.ml \
@@ -566,6 +568,7 @@ if [[ "$STEP" == "all" || "$STEP" == "js" ]]; then
     SPARQL_HTTP_Response.ml
     SPARQL_HTTP_BackendInfo.ml
     SPARQL_HTTP_QueriesIndex.ml
+    SPARQL_HTTP_StaticFiles.ml
     Parser_Ballyhoo.ml Parser_BallyhooBloom.ml
     Parser_BallyhooHDT.ml Parser_BallyhooHDTQ.ml
     Parser_BallyhooCOTTAS.ml

--- a/formal/fstar/ocaml-output/SPARQL_HTTP_StaticFiles.ml
+++ b/formal/fstar/ocaml-output/SPARQL_HTTP_StaticFiles.ml
@@ -1,0 +1,61 @@
+open Prims
+let (ends_with : Prims.string -> Prims.string -> Prims.bool) =
+  fun s ->
+    fun suf ->
+      let lp = FStar_String.strlen s in
+      let ls = FStar_String.strlen suf in
+      if lp >= ls then (FStar_String.sub s (lp - ls) ls) = suf else false
+let (content_type_for_path : Prims.string -> Prims.string) =
+  fun path ->
+    let p = FStar_String.lowercase path in
+    if (ends_with p ".html") || (ends_with p ".htm")
+    then "text/html; charset=utf-8"
+    else
+      if ends_with p ".css"
+      then "text/css; charset=utf-8"
+      else
+        if (ends_with p ".js") || (ends_with p ".mjs")
+        then "application/javascript; charset=utf-8"
+        else
+          if ends_with p ".json"
+          then "application/json; charset=utf-8"
+          else
+            if ends_with p ".svg"
+            then "image/svg+xml; charset=utf-8"
+            else
+              if ends_with p ".png"
+              then "image/png"
+              else
+                if (ends_with p ".jpg") || (ends_with p ".jpeg")
+                then "image/jpeg"
+                else
+                  if ends_with p ".ico"
+                  then "image/x-icon"
+                  else
+                    if (ends_with p ".txt") || (ends_with p ".md")
+                    then "text/plain; charset=utf-8"
+                    else
+                      if ends_with p ".ttl"
+                      then "text/turtle; charset=utf-8"
+                      else
+                        if ends_with p ".nt"
+                        then "application/n-triples; charset=utf-8"
+                        else
+                          if ends_with p ".nq"
+                          then "application/n-quads; charset=utf-8"
+                          else "application/octet-stream"
+let rec (contains_dotdot_at : Prims.string -> Prims.nat -> Prims.bool) =
+  fun s ->
+    fun i ->
+      let n = FStar_String.strlen s in
+      if (i + (Prims.of_int (2))) > n
+      then false
+      else
+        if (FStar_String.sub s i (Prims.of_int (2))) = ".."
+        then true
+        else
+          if (i + Prims.int_one) > n
+          then false
+          else contains_dotdot_at s (i + Prims.int_one)
+let (path_has_dotdot : Prims.string -> Prims.bool) =
+  fun p -> contains_dotdot_at p Prims.int_zero

--- a/formal/fstar/ocaml-output/factoidal_http.ml
+++ b/formal/fstar/ocaml-output/factoidal_http.ml
@@ -1777,38 +1777,14 @@ let resolve_web_demo_dir (demo : string option) : string option =
 
 (* Cheap content-type sniff by filename suffix. We deliberately keep the
    table small — the demos only ship HTML/JS/CSS/JSON/SVG/PNG today. *)
-let content_type_for_path (path : string) : string =
-  let path = String.lowercase_ascii path in
-  let ends_with suf =
-    let lp = String.length path and ls = String.length suf in
-    lp >= ls && String.sub path (lp - ls) ls = suf
-  in
-  if ends_with ".html" || ends_with ".htm"
-    then "text/html; charset=utf-8"
-  else if ends_with ".css" then "text/css; charset=utf-8"
-  else if ends_with ".js" || ends_with ".mjs"
-    then "application/javascript; charset=utf-8"
-  else if ends_with ".json" then "application/json; charset=utf-8"
-  else if ends_with ".svg" then "image/svg+xml; charset=utf-8"
-  else if ends_with ".png" then "image/png"
-  else if ends_with ".jpg" || ends_with ".jpeg" then "image/jpeg"
-  else if ends_with ".ico" then "image/x-icon"
-  else if ends_with ".txt" || ends_with ".md" then "text/plain; charset=utf-8"
-  else if ends_with ".ttl" then "text/turtle; charset=utf-8"
-  else if ends_with ".nt"  then "application/n-triples; charset=utf-8"
-  else if ends_with ".nq"  then "application/n-quads; charset=utf-8"
-  else "application/octet-stream"
+(* Static-file content-type mapping and path-traversal guard live in
+   F* per rule #1 (formal/fstar/SPARQL.HTTP.StaticFiles.fst); the
+   OCaml side is the read/stat syscalls. *)
+let content_type_for_path : string -> string =
+  SPARQL_HTTP_StaticFiles.content_type_for_path
 
-(* Refuse traversal: the URL path must not contain "..". This is a
-   coarse but adequate guard since we only ever concatenate it onto
-   the resolved demo root. *)
-let path_has_dotdot (p : string) : bool =
-  let n = String.length p in
-  let rec loop i =
-    if i + 2 > n then false
-    else if String.sub p i 2 = ".." then true
-    else loop (i + 1)
-  in loop 0
+let path_has_dotdot : string -> bool =
+  SPARQL_HTTP_StaticFiles.path_has_dotdot
 
 (* Strip a leading slash from URL path. *)
 let strip_leading_slash s =


### PR DESCRIPTION
Two pure string-analysis functions from `factoidal_http.ml`:

- **`content_type_for_path`** — map a path's extension to the HTTP `Content-Type` response header value. Restricted to the file types the server actually serves (HTML/CSS/JS/JSON/SVG/PNG/JPG/ICO/TXT/MD/TTL/NT/NQ); anything else falls back to `application/octet-stream` so the browser doesn't auto-execute unknown content.
- **`path_has_dotdot`** — coarse path-traversal guard: refuse any URL path containing `..`. Sufficient because we only ever concatenate the URL onto a resolved demo root.

Both are policy decisions (rule #1 — F\* is the source of truth). Lifted to a new `SPARQL.HTTP.StaticFiles.fst`.

> Qualifier per CLAUDE.md rule #11: parser and algebra spec verified in F\*; on-disk backend currently has unverified OCaml-side caching/optimisation layers being migrated back to F\* (see `docs/designissues/fstar-purity-unwind.md`). This PR retires 25 LoC of OCaml-side semantic logic.

## What stays in OCaml

The actual file I/O (`Sys.file_exists`, `Filename.concat`, `open_in`, etc.) stays in the OCaml caller because that's syscall territory. Only the decisions (extension → MIME, `".."` rejection) move.

## Verification

```
$ fstar.exe --z3version 4.13.3 SPARQL.HTTP.StaticFiles.fst
Verified module: SPARQL.HTTP.StaticFiles

$ fstar.exe --z3version 4.13.3 --codegen OCaml ... SPARQL.HTTP.StaticFiles.fst
Extracted module SPARQL.HTTP.StaticFiles
```

## OCaml side

```ocaml
let content_type_for_path : string -> string =
  SPARQL_HTTP_StaticFiles.content_type_for_path

let path_has_dotdot : string -> bool =
  SPARQL_HTTP_StaticFiles.path_has_dotdot
```

## LoC delta

| File | Before | After | Delta |
|---|---:|---:|---:|
| `factoidal_http.ml` (these two functions) | 33 | 8 | −25 |

Plus +85 in `SPARQL.HTTP.StaticFiles.fst` (verified F\* core + helpers).

## Test plan

- [ ] CI: full F\* extract + native compile + js_of_ocaml + wasm
- [ ] CI: Web demo serving — every static file (`.html`, `.css`, `.js`, `.json`, `.svg`, `.png`, etc.) gets the right `Content-Type` header
- [ ] CI: GET `/web/../../etc/passwd` → 404, doesn't leak files
- [ ] CI: F\*-purity gate (PR #138's expanded version) — clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gid59KLYfGtaXLNfFWnPt1)_