### PR TITLE
Lift N-Quads serializers to RDF.NQuads.Serialize.fst

### DIFF
--- a/formal/fstar/RDF.NQuads.Serialize.fst
+++ b/formal/fstar/RDF.NQuads.Serialize.fst
@@ -1,0 +1,111 @@
+module RDF.NQuads.Serialize
+
+// N-Quads / N-Triples wire-format serializers.
+//
+// Migrated from factoidal_http.ml's nq_escape_literal,
+// nq_term_to_string, nq_subject_to_string, and nq_line_for_triple.
+// All four are pure character / string mappings that encode the
+// N-Quads serialization rules from the W3C spec; per Iron Rule #1
+// they belong in F*.
+//
+// This is the *byte-correct* serializer (escapes \" and control
+// characters in literals). The Turtle-style abbreviated rendering
+// for human-facing output lives in RDF.Pretty.fst; that file has
+// `term_to_ntriples` which is intentionally lossy on literal
+// escaping (it's for display, not wire). Both functions exist
+// because the call sites have different correctness requirements.
+
+open RDF.Graph.Executable
+
+module S = FStar.String
+
+// ---------------------------------------------------------------
+// nq_escape_literal: escape the lexical form of an RDF literal for
+// embedding in an N-Triples / N-Quads / Turtle quoted string.
+//
+// Bytes escaped:
+//   0x5C  '\\'  ->  \\
+//   0x22  '"'   ->  \"
+//   0x0A  '\n'  ->  \n
+//   0x0D  '\r'  ->  \r
+//   0x09  '\t'  ->  \t
+// All other bytes pass through unchanged.
+//
+// Note: this matches the legacy OCaml nq_escape_literal byte-for-byte.
+// A more conservative escape-anything-< 0x20 form would be more
+// rigorously NT-compliant, but the existing OCaml impl is what the
+// downstream consumers (the /sandbox/dump output, w3c_runner output
+// comparison) currently expect — preserve.
+// ---------------------------------------------------------------
+
+let escape_char (c : FStar.Char.char) : Tot string =
+  let n = FStar.Char.int_of_char c in
+  if n = 0x5C then "\\\\"
+  else if n = 0x22 then "\\\""
+  else if n = 0x0A then "\\n"
+  else if n = 0x0D then "\\r"
+  else if n = 0x09 then "\\t"
+  else S.string_of_char c
+
+let rec escape_chars_aux (cs : list FStar.Char.char)
+  : Tot string (decreases cs) =
+  match cs with
+  | [] -> ""
+  | c :: rest -> escape_char c ^ escape_chars_aux rest
+
+let nq_escape_literal (s : string) : Tot string =
+  escape_chars_aux (S.list_of_string s)
+
+// ---------------------------------------------------------------
+// nq_term_to_string : serialize an RDF term in N-Quads object form.
+//
+// Output:
+//   T_IRI i           ->  "<i>"
+//   T_BNode b         ->  "_:b"
+//   T_Literal { lex; lang_tag = Some t }                   ->  "\"<esc>\"@t"
+//   T_Literal { lex; datatype = xsd_string; lang = None }  ->  "\"<esc>\""
+//   T_Literal { lex; datatype = d; lang = None }           ->  "\"<esc>\"^^<d>"
+//
+// where <esc> = nq_escape_literal lex.
+//
+// xsd:string is the implicit default datatype per the RDF 1.1 spec,
+// so omit "^^<...>" for a literal whose datatype is already xsd:string.
+//
+// (The legacy OCaml had a defensive `l.datatype = ""` check that the
+// F* wf_iri refinement makes unreachable; it's dropped here.)
+// ---------------------------------------------------------------
+
+let nq_term_to_string (t : rdf_term) : Tot string =
+  match t with
+  | T_IRI i   -> "<" ^ i ^ ">"
+  | T_BNode b -> "_:" ^ b
+  | T_Literal l ->
+    let esc = nq_escape_literal l.lexical_form in
+    (match l.lang_tag with
+     | Some tag -> "\"" ^ esc ^ "\"@" ^ tag
+     | None ->
+       if l.datatype = xsd_string then
+         "\"" ^ esc ^ "\""
+       else
+         "\"" ^ esc ^ "\"^^<" ^ l.datatype ^ ">")
+
+// ---------------------------------------------------------------
+// nq_subject_to_string : serialize a subject (IRI or blank node).
+// ---------------------------------------------------------------
+
+let nq_subject_to_string (s : subject) : Tot string =
+  match s with
+  | S_IRI i   -> "<" ^ i ^ ">"
+  | S_BNode b -> "_:" ^ b
+
+// ---------------------------------------------------------------
+// nq_line_for_triple : full N-Quads line for a triple in a named
+// graph. Caller passes the graph IRI as a string (already-validated
+// upstream).
+//
+//   <subject> <predicate> <object> <graph> .\n
+// ---------------------------------------------------------------
+
+let nq_line_for_triple (graph_iri : string) (t : triple) : Tot string =
+  nq_subject_to_string t.s ^ " <" ^ t.p ^ "> "
+  ^ nq_term_to_string t.o ^ " <" ^ graph_iri ^ "> .\n"

--- a/formal/fstar/build-ocaml.sh
+++ b/formal/fstar/build-ocaml.sh
@@ -171,6 +171,7 @@ if [[ "$STEP" == "all" || "$STEP" == "extract" ]]; then
   for fst in Util.Log.fst \
              RDF.Format.fst \
              RDF.Graph.Executable.fst Parquet.Footer.fst \
+             RDF.NQuads.Serialize.fst \
              RDF.Canonical.fst \
              Tableau.fst SPARQL11.Algebra.fst \
              OWL.QueryRewrite.fst OWL.QueryEval.fst \
@@ -264,7 +265,7 @@ if [[ "$STEP" == "all" || "$STEP" == "compile" ]]; then
   # (COTTAS runtime glue calls Parquet_Footer.probe_*). SPARQL11_Store
   # depends on Parser_BallyhooHDT and Parser_BallyhooCOTTAS. See
   # docs/designissues/2026-04-19-cottas-parquet-wiring-plan.md §Phase 1.
-  COMMON_MODULES="Util_Log.ml RDF_Format.ml RDF_Graph_Executable.ml Parquet_Footer.ml Tableau.ml \
+  COMMON_MODULES="Util_Log.ml RDF_Format.ml RDF_Graph_Executable.ml RDF_NQuads_Serialize.ml Parquet_Footer.ml Tableau.ml \
     Parser_FastString.ml Parser_IRI.ml \
     Parser_Combinators.ml Parser_TurtleScanner.ml Parser_NTriples.ml Parser_Turtle.ml \
     Parser_NQuads.ml Parser_TriG.ml Parser_XML.ml Parser_RDFXML.ml \
@@ -557,7 +558,7 @@ if [[ "$STEP" == "all" || "$STEP" == "js" ]]; then
   # See docs/designissues/2026-04-19-cottas-parquet-wiring-plan.md.
   FSTAR_MODULES=(
     RDF_Format.ml
-    RDF_Graph_Executable.ml Parquet_Footer.ml Tableau.ml
+    RDF_Graph_Executable.ml RDF_NQuads_Serialize.ml Parquet_Footer.ml Tableau.ml
     Parser_FastString.ml Parser_IRI.ml
     Parser_Combinators.ml Parser_TurtleScanner.ml Parser_NTriples.ml Parser_Turtle.ml
     Parser_NQuads.ml Parser_TriG.ml Parser_XML.ml Parser_RDFXML.ml

--- a/formal/fstar/ocaml-output/RDF_NQuads_Serialize.ml
+++ b/formal/fstar/ocaml-output/RDF_NQuads_Serialize.ml
@@ -1,0 +1,61 @@
+open Prims
+let (escape_char : FStar_Char.char -> Prims.string) =
+  fun c ->
+    let n = FStar_Char.int_of_char c in
+    if n = (Prims.of_int (0x5C))
+    then "\\\\"
+    else
+      if n = (Prims.of_int (0x22))
+      then "\\\""
+      else
+        if n = (Prims.of_int (0x0A))
+        then "\\n"
+        else
+          if n = (Prims.of_int (0x0D))
+          then "\\r"
+          else
+            if n = (Prims.of_int (0x09))
+            then "\\t"
+            else FStar_String.string_of_char c
+let rec (escape_chars_aux : FStar_Char.char Prims.list -> Prims.string) =
+  fun cs ->
+    match cs with
+    | [] -> ""
+    | c::rest -> Prims.strcat (escape_char c) (escape_chars_aux rest)
+let (nq_escape_literal : Prims.string -> Prims.string) =
+  fun s -> escape_chars_aux (FStar_String.list_of_string s)
+let (nq_term_to_string : RDF_Graph_Executable.rdf_term -> Prims.string) =
+  fun t ->
+    match t with
+    | RDF_Graph_Executable.T_IRI i -> Prims.strcat "<" (Prims.strcat i ">")
+    | RDF_Graph_Executable.T_BNode b -> Prims.strcat "_:" b
+    | RDF_Graph_Executable.T_Literal l ->
+        let esc = nq_escape_literal l.RDF_Graph_Executable.lexical_form in
+        (match l.RDF_Graph_Executable.lang_tag with
+         | FStar_Pervasives_Native.Some tag ->
+             Prims.strcat "\"" (Prims.strcat esc (Prims.strcat "\"@" tag))
+         | FStar_Pervasives_Native.None ->
+             if
+               l.RDF_Graph_Executable.datatype =
+                 RDF_Graph_Executable.xsd_string
+             then Prims.strcat "\"" (Prims.strcat esc "\"")
+             else
+               Prims.strcat "\""
+                 (Prims.strcat esc
+                    (Prims.strcat "\"^^<"
+                       (Prims.strcat l.RDF_Graph_Executable.datatype ">"))))
+let (nq_subject_to_string : RDF_Graph_Executable.subject -> Prims.string) =
+  fun s ->
+    match s with
+    | RDF_Graph_Executable.S_IRI i -> Prims.strcat "<" (Prims.strcat i ">")
+    | RDF_Graph_Executable.S_BNode b -> Prims.strcat "_:" b
+let (nq_line_for_triple :
+  Prims.string -> RDF_Graph_Executable.triple -> Prims.string) =
+  fun graph_iri ->
+    fun t ->
+      Prims.strcat (nq_subject_to_string t.RDF_Graph_Executable.s)
+        (Prims.strcat " <"
+           (Prims.strcat t.RDF_Graph_Executable.p
+              (Prims.strcat "> "
+                 (Prims.strcat (nq_term_to_string t.RDF_Graph_Executable.o)
+                    (Prims.strcat " <" (Prims.strcat graph_iri "> .\n"))))))

--- a/formal/fstar/ocaml-output/factoidal_http.ml
+++ b/formal/fstar/ocaml-output/factoidal_http.ml
@@ -1558,50 +1558,17 @@ let sandbox_update ~usergraph (u : SPARQL11_Algebra.sparql_update) :
    Literals are quoted with proper escaping. Blank nodes are "_:id".
    ============================================================================ *)
 
-let nq_escape_literal s =
-  let buf = Buffer.create (String.length s + 4) in
-  String.iter (fun c ->
-    match c with
-    | '\\' -> Buffer.add_string buf "\\\\"
-    | '"'  -> Buffer.add_string buf "\\\""
-    | '\n' -> Buffer.add_string buf "\\n"
-    | '\r' -> Buffer.add_string buf "\\r"
-    | '\t' -> Buffer.add_string buf "\\t"
-    | c    -> Buffer.add_char buf c
-  ) s;
-  Buffer.contents buf
-
-let nq_term_to_string (t : rdf_term) =
-  match t with
-  | T_IRI i -> Printf.sprintf "<%s>" i
-  | T_BNode b -> Printf.sprintf "_:%s" b
-  | T_Literal l ->
-    let xsd_string = "http://www.w3.org/2001/XMLSchema#string" in
-    let rdf_lang_string =
-      "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString" in
-    let esc = nq_escape_literal l.lexical_form in
-    (match l.lang_tag with
-     | Some tag -> Printf.sprintf "\"%s\"@%s" esc tag
-     | None ->
-       if l.datatype = "" || l.datatype = xsd_string then
-         Printf.sprintf "\"%s\"" esc
-       else if l.datatype = rdf_lang_string then
-         (* Malformed — langString with no tag. Preserve lexically. *)
-         Printf.sprintf "\"%s\"^^<%s>" esc l.datatype
-       else
-         Printf.sprintf "\"%s\"^^<%s>" esc l.datatype)
-
-let nq_subject_to_string (s : subject) =
-  match s with
-  | S_IRI i -> Printf.sprintf "<%s>" i
-  | S_BNode b -> Printf.sprintf "_:%s" b
-
-let nq_line_for_triple ~graph_iri (t : triple) =
-  Printf.sprintf "%s <%s> %s <%s> .\n"
-    (nq_subject_to_string t.s)
-    t.p
-    (nq_term_to_string t.o)
-    graph_iri
+(* N-Quads wire-format serializers — F* is the source of truth.
+   formal/fstar/RDF.NQuads.Serialize.fst owns the byte-correct
+   escape/term/subject/line rendering. *)
+let nq_escape_literal : string -> string =
+  RDF_NQuads_Serialize.nq_escape_literal
+let nq_term_to_string : rdf_term -> string =
+  RDF_NQuads_Serialize.nq_term_to_string
+let nq_subject_to_string : subject -> string =
+  RDF_NQuads_Serialize.nq_subject_to_string
+let nq_line_for_triple ~graph_iri (t : triple) : string =
+  RDF_NQuads_Serialize.nq_line_for_triple graph_iri t
 
 (* Which named graphs in the current dataset belong to user-writable
    sandboxes? We compute this by listing every named graph whose IRI is not


### PR DESCRIPTION
Migrate four pure functions from `factoidal_http.ml` to a new `RDF.NQuads.Serialize.fst`:

- **`nq_escape_literal`** — escape `\` `"` `\n` `\r` `\t` in literal lexical form
- **`nq_term_to_string`** — RDF term → N-Quads object form
- **`nq_subject_to_string`** — subject → N-Quads subject form
- **`nq_line_for_triple`** — full `s p o g .\n` line for a quad

All four are byte-level wire-format serialization rules from the W3C N-Quads spec; rule #1 wants them in F\*.

> Qualifier per CLAUDE.md rule #11: parser and algebra spec verified in F\*; on-disk backend currently has unverified OCaml-side caching/optimisation layers being migrated back to F\* (see `docs/designissues/fstar-purity-unwind.md`). This PR retires 32 LoC of OCaml-side semantic logic.

## Note: this is the byte-correct serializer

The Turtle-style abbreviated rendering for human-facing output lives separately in `RDF.Pretty.fst` (lifted in PR #140). Both serializers need to coexist because their call sites have different correctness requirements:

- `RDF.NQuads.Serialize.nq_term_to_string` — wire format. Escapes literals. Used by `/sandbox/dump`, w3c_runner output comparison.
- `RDF.Pretty.term_to_ntriples` — display format. Doesn't escape (preserves the legacy `factoidal_cli.ml` behaviour). Used by CSV / table / JSON-of-display result rows.

## Behavioural equivalence

The legacy OCaml had a defensive `l.datatype = ""` check; the F\* refinement `datatype : wf_iri` makes that case unreachable, so it's dropped. The legacy "malformed langString with no tag" branch was identical to the generic-datatype branch and is folded. Behaviour on all valid `wf_literal` inputs is byte-for-byte identical.

## Verification

```
$ fstar.exe --z3version 4.13.3 RDF.NQuads.Serialize.fst
Verified module: RDF.NQuads.Serialize

$ fstar.exe --z3version 4.13.3 --codegen OCaml ... RDF.NQuads.Serialize.fst
Extracted module RDF.NQuads.Serialize
```

## OCaml side

```ocaml
let nq_escape_literal    : string -> string   = RDF_NQuads_Serialize.nq_escape_literal
let nq_term_to_string    : rdf_term -> string = RDF_NQuads_Serialize.nq_term_to_string
let nq_subject_to_string : subject  -> string = RDF_NQuads_Serialize.nq_subject_to_string
let nq_line_for_triple ~graph_iri (t : triple) : string =
  RDF_NQuads_Serialize.nq_line_for_triple graph_iri t
```

## LoC delta

| File | Before | After | Delta |
|---|---:|---:|---:|
| `factoidal_http.ml` (these four functions) | 45 | 13 | −32 |

Plus +95 in `RDF.NQuads.Serialize.fst` (verified F\* core).

## Test plan

- [ ] CI: full F\* extract + native compile + js_of_ocaml + wasm
- [ ] CI: `/sandbox/dump` end-to-end — every literal containing `"` / `\` / newline serializes correctly
- [ ] CI: SPARQL Update INSERT then GET /sandbox/dump round-trip preserves exact bytes
- [ ] CI: F\*-purity gate (PR #138's expanded version) — clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gid59KLYfGtaXLNfFWnPt1)_