### PR TITLE
Lift update_has_load to SPARQL.Update.Analysis.fst

### DIFF
--- a/formal/fstar/SPARQL.Update.Analysis.fst
+++ b/formal/fstar/SPARQL.Update.Analysis.fst
@@ -1,0 +1,31 @@
+module SPARQL.Update.Analysis
+
+// Cheap structural-analysis predicates over SPARQL 1.1 UPDATE ASTs.
+// One question per predicate, all pure, all total.
+//
+// Migrated from factoidal_http.ml. The HTTP layer uses these to make
+// dispatch decisions (whether to reject the request, whether to set
+// up a sandbox, etc.). The semantic decision "what does this update
+// contain?" lives here in F\* per Iron Rule #1; the HTTP wiring
+// (status codes, error messages) stays in the OCaml caller.
+
+open FStar.List.Tot
+open SPARQL11.Algebra
+
+// ---------------------------------------------------------------
+// update_has_load: does this update include any U_Load operation?
+//
+// LOAD requires fetching an external IRI over HTTP — outside the F\*
+// runtime's purview. The HTTP layer therefore rejects updates that
+// contain LOAD with 501 Not Implemented (rather than running them
+// silently and producing wrong results). This predicate is the
+// "is there a LOAD anywhere in this update?" check it consults.
+// ---------------------------------------------------------------
+
+let is_load_op (op : update_op) : Tot bool =
+  match op with
+  | U_Load _ _ _ -> true
+  | _            -> false
+
+let update_has_load (u : sparql_update) : Tot bool =
+  existsb is_load_op u.u_ops

--- a/formal/fstar/build-ocaml.sh
+++ b/formal/fstar/build-ocaml.sh
@@ -198,6 +198,7 @@ if [[ "$STEP" == "all" || "$STEP" == "extract" ]]; then
              SPARQL11.Store.fst \
              SPARQL.Protocol.fst \
              SPARQL.Update.Sandbox.fst \
+             SPARQL.Update.Analysis.fst \
              SPARQL.Diagnostics.fst \
              SPARQL.Explain.fst \
              SPARQL.HTTP.fst \
@@ -286,6 +287,7 @@ if [[ "$STEP" == "all" || "$STEP" == "compile" ]]; then
     RDF_Canonical.ml \
     SPARQL11_Algebra.ml OWL_QueryRewrite.ml OWL_QueryEval.ml SPARQL11_Parser.ml SPARQL11_Store.ml SPARQL_Protocol.ml \
     SPARQL_Update_Sandbox.ml \
+    SPARQL_Update_Analysis.ml \
     SPARQL_Diagnostics.ml \
     SPARQL_Explain.ml \
     SPARQL_HTTP.ml SPARQL_HTTP_Client.ml SPARQL_ServiceDescription.ml \
@@ -582,6 +584,7 @@ if [[ "$STEP" == "all" || "$STEP" == "js" ]]; then
     SPARQL11_Store.ml
     SPARQL_Protocol.ml
     SPARQL_Update_Sandbox.ml
+    SPARQL_Update_Analysis.ml
     SPARQL_Diagnostics.ml
     SPARQL_Explain.ml
     SPARQL_HTTP.ml SPARQL_HTTP_Client.ml SPARQL_ServiceDescription.ml SPARQL_GraphStore.ml

--- a/formal/fstar/ocaml-output/SPARQL_Update_Analysis.ml
+++ b/formal/fstar/ocaml-output/SPARQL_Update_Analysis.ml
@@ -1,0 +1,8 @@
+open Prims
+let (is_load_op : SPARQL11_Algebra.update_op -> Prims.bool) =
+  fun op ->
+    match op with
+    | SPARQL11_Algebra.U_Load (uu___, uu___1, uu___2) -> true
+    | uu___ -> false
+let (update_has_load : SPARQL11_Algebra.sparql_update -> Prims.bool) =
+  fun u -> FStar_List_Tot_Base.existsb is_load_op u.SPARQL11_Algebra.u_ops

--- a/formal/fstar/ocaml-output/factoidal_http.ml
+++ b/formal/fstar/ocaml-output/factoidal_http.ml
@@ -1461,12 +1461,10 @@ let with_query_timeout ~secs (f : unit -> 'a) : 'a =
 (* Detect whether an update contains any U_Load op (LOAD is still
    unimplemented — needs HTTP client).  We return 501 for requests
    that contain LOAD rather than silently skipping it. *)
-let update_has_load (u : SPARQL11_Algebra.sparql_update) : bool =
-  List.exists (fun op ->
-    match op with
-    | SPARQL11_Algebra.U_Load (_, _, _) -> true
-    | _ -> false
-  ) u.u_ops
+(* update_has_load lives in F* per rule #1; see
+   formal/fstar/SPARQL.Update.Analysis.fst. *)
+let update_has_load : SPARQL11_Algebra.sparql_update -> bool =
+  SPARQL_Update_Analysis.update_has_load
 
 (* ============================================================================
    Per-user UPDATE sandboxing.


### PR DESCRIPTION
Tiny migration. `update_has_load` inspects a SPARQL update for any `U_Load` operation; LOAD requires external HTTP fetching outside the F\* runtime, so the HTTP layer rejects updates containing it with `501 Not Implemented`. The "is there a LOAD?" predicate is structural analysis of the algebra — rule #1 wants it in F\*.

> Qualifier per CLAUDE.md rule #11: parser and algebra spec verified in F\*; on-disk backend currently has unverified OCaml-side caching/optimisation layers being migrated back to F\* (see `docs/designissues/fstar-purity-unwind.md`). This PR retires 6 LoC of OCaml-side semantic logic.

## Module choice

Lifted to a new module `SPARQL.Update.Analysis.fst` rather than `SPARQL.Update.Sandbox.fst`. The sandbox module is specifically about per-user write sandboxing; this is an unrelated structural predicate. Today the new module contains a single function plus a small helper; future PRs can append other update-analysis predicates (e.g. `update_has_clear`, `update_has_drop`, `update_targets_default_graph`, etc.) without needing yet another module.

## Verification

```
$ fstar.exe --z3version 4.13.3 SPARQL.Update.Analysis.fst
Verified module: SPARQL.Update.Analysis
Extracted module SPARQL.Update.Analysis
```

## OCaml side

```ocaml
let update_has_load : SPARQL11_Algebra.sparql_update -> bool =
  SPARQL_Update_Analysis.update_has_load
```

## LoC delta

| File | Before | After | Delta |
|---|---:|---:|---:|
| `factoidal_http.ml` (this function) | 6 | 2 | −4 |

Plus +20 in `SPARQL.Update.Analysis.fst`.

## Test plan

- [ ] CI: full F\* extract + native compile + js_of_ocaml + wasm
- [ ] CI: POST `/update` with `LOAD <some-iri>` returns 501; without LOAD continues normally
- [ ] CI: F\*-purity gate (PR #138's expanded version) — clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gid59KLYfGtaXLNfFWnPt1)_