### PR TITLE
Lift count_dataset_triples + backend_kind_of_cfg into SPARQL.HTTP.BackendInfo.fst

### DIFF
--- a/formal/fstar/SPARQL.HTTP.BackendInfo.fst
+++ b/formal/fstar/SPARQL.HTTP.BackendInfo.fst
@@ -124,3 +124,28 @@ let backend_kind_of_flags (has_dataset : bool) (has_cottas : bool)
     (if has_cottas then BK_Hybrid else BK_InMem)
   else
     (if has_cottas then BK_CottasOnDisk else BK_Empty)
+
+// ---------------------------------------------------------------
+// backend_source_string: human-readable summary of the data
+// sources mounted by the daemon, for the startup log and the
+// backend-info display.
+//
+// Migrated from factoidal_http.ml's `backend_source_string`. The
+// OCaml side calls `Filename.basename` to reduce a path to its
+// basename (OS-aware glue), then passes the resulting strings to
+// this F* function which encodes the formatting decisions:
+//   - empty config           -> "(none)"
+//   - just dataset file      -> "<basename>"
+//   - just cottas paths      -> "<bn>, <bn>, ..."
+//   - dataset + cottas paths -> "<dataset_bn>, <cottas_bn>, ..."
+// ---------------------------------------------------------------
+
+let backend_source_string
+    (dataset_basename : option string)
+    (cottas_basenames : list string)
+  : Tot string =
+  match dataset_basename, cottas_basenames with
+  | None,   [] -> "(none)"
+  | Some f, [] -> f
+  | None,   paths -> FStar.String.concat ", " paths
+  | Some f, paths -> FStar.String.concat ", " (f :: paths)

--- a/formal/fstar/SPARQL.HTTP.BackendInfo.fst
+++ b/formal/fstar/SPARQL.HTTP.BackendInfo.fst
@@ -83,3 +83,44 @@ let render_backend_info (info:backend_info) : string =
     ",\"source\":\""; source_s;
     "\"}\n"
   ]
+
+// ---------------------------------------------------------------
+// Helpers used by the OCaml caller to build a `backend_info`
+// record from the running server's live state. Migrated from
+// factoidal_http.ml's `count_dataset_triples` and
+// `backend_kind_of_cfg` (rule #1 — F\* is the source of truth for
+// the count formula and the kind classification).
+//
+// `count_dataset_triples` returns four ints that map directly onto
+// the bi_in_memory_* fields, in the same order as the legacy OCaml
+// return tuple: (total, default, num_named_graphs, named_total).
+//
+// `backend_kind_of_flags` takes pre-extracted booleans rather than
+// the OCaml `config` record. The OCaml caller is one line:
+//   backend_kind_of_flags
+//     (cfg.dataset_file <> None)
+//     (cfg.data_cottas_files <> [])
+// which keeps the OCaml-side `config` type out of F\*.
+// ---------------------------------------------------------------
+
+open RDF.Graph.Executable
+
+let rec sum_named_triples (ngs : list named_graph) : Tot nat (decreases ngs) =
+  match ngs with
+  | [] -> 0
+  | ng :: rest -> FStar.List.Tot.length ng.ng_graph + sum_named_triples rest
+
+let count_dataset_triples (ds : rdf_dataset) : Tot (int * int * int * int) =
+  let dflt          = FStar.List.Tot.length ds.ds_default in
+  let named_count   = FStar.List.Tot.length ds.ds_named in
+  let named_triples = sum_named_triples ds.ds_named in
+  (dflt + named_triples, dflt, named_count, named_triples)
+
+// has_dataset = the --data file slot is set.
+// has_cottas  = the --data-cottas slot has any path.
+let backend_kind_of_flags (has_dataset : bool) (has_cottas : bool)
+  : Tot backend_kind =
+  if has_dataset then
+    (if has_cottas then BK_Hybrid else BK_InMem)
+  else
+    (if has_cottas then BK_CottasOnDisk else BK_Empty)

--- a/formal/fstar/ocaml-output/SPARQL_HTTP_BackendInfo.ml
+++ b/formal/fstar/ocaml-output/SPARQL_HTTP_BackendInfo.ml
@@ -1,0 +1,158 @@
+open Prims
+type backend_kind =
+  | BK_InMem 
+  | BK_CottasOnDisk 
+  | BK_Hybrid 
+  | BK_Empty 
+let (uu___is_BK_InMem : backend_kind -> Prims.bool) =
+  fun projectee -> match projectee with | BK_InMem -> true | uu___ -> false
+let (uu___is_BK_CottasOnDisk : backend_kind -> Prims.bool) =
+  fun projectee ->
+    match projectee with | BK_CottasOnDisk -> true | uu___ -> false
+let (uu___is_BK_Hybrid : backend_kind -> Prims.bool) =
+  fun projectee -> match projectee with | BK_Hybrid -> true | uu___ -> false
+let (uu___is_BK_Empty : backend_kind -> Prims.bool) =
+  fun projectee -> match projectee with | BK_Empty -> true | uu___ -> false
+let (backend_kind_string : backend_kind -> Prims.string) =
+  fun k ->
+    match k with
+    | BK_InMem -> "in-memory"
+    | BK_CottasOnDisk -> "binary"
+    | BK_Hybrid -> "mixed"
+    | BK_Empty -> "empty"
+type cottas_summary =
+  {
+  cs_path: Prims.string ;
+  cs_quads: Prims.int ;
+  cs_row_groups: Prims.int }
+let (__proj__Mkcottas_summary__item__cs_path :
+  cottas_summary -> Prims.string) =
+  fun projectee ->
+    match projectee with | { cs_path; cs_quads; cs_row_groups;_} -> cs_path
+let (__proj__Mkcottas_summary__item__cs_quads : cottas_summary -> Prims.int)
+  =
+  fun projectee ->
+    match projectee with | { cs_path; cs_quads; cs_row_groups;_} -> cs_quads
+let (__proj__Mkcottas_summary__item__cs_row_groups :
+  cottas_summary -> Prims.int) =
+  fun projectee ->
+    match projectee with
+    | { cs_path; cs_quads; cs_row_groups;_} -> cs_row_groups
+type backend_info =
+  {
+  bi_kind: backend_kind ;
+  bi_source: Prims.string ;
+  bi_in_memory_triples: Prims.int ;
+  bi_in_memory_default_graph_triples: Prims.int ;
+  bi_in_memory_named_graphs: Prims.int ;
+  bi_in_memory_named_graph_triples: Prims.int ;
+  bi_cottas: cottas_summary Prims.list }
+let (__proj__Mkbackend_info__item__bi_kind : backend_info -> backend_kind) =
+  fun projectee ->
+    match projectee with
+    | { bi_kind; bi_source; bi_in_memory_triples;
+        bi_in_memory_default_graph_triples; bi_in_memory_named_graphs;
+        bi_in_memory_named_graph_triples; bi_cottas;_} -> bi_kind
+let (__proj__Mkbackend_info__item__bi_source : backend_info -> Prims.string)
+  =
+  fun projectee ->
+    match projectee with
+    | { bi_kind; bi_source; bi_in_memory_triples;
+        bi_in_memory_default_graph_triples; bi_in_memory_named_graphs;
+        bi_in_memory_named_graph_triples; bi_cottas;_} -> bi_source
+let (__proj__Mkbackend_info__item__bi_in_memory_triples :
+  backend_info -> Prims.int) =
+  fun projectee ->
+    match projectee with
+    | { bi_kind; bi_source; bi_in_memory_triples;
+        bi_in_memory_default_graph_triples; bi_in_memory_named_graphs;
+        bi_in_memory_named_graph_triples; bi_cottas;_} ->
+        bi_in_memory_triples
+let (__proj__Mkbackend_info__item__bi_in_memory_default_graph_triples :
+  backend_info -> Prims.int) =
+  fun projectee ->
+    match projectee with
+    | { bi_kind; bi_source; bi_in_memory_triples;
+        bi_in_memory_default_graph_triples; bi_in_memory_named_graphs;
+        bi_in_memory_named_graph_triples; bi_cottas;_} ->
+        bi_in_memory_default_graph_triples
+let (__proj__Mkbackend_info__item__bi_in_memory_named_graphs :
+  backend_info -> Prims.int) =
+  fun projectee ->
+    match projectee with
+    | { bi_kind; bi_source; bi_in_memory_triples;
+        bi_in_memory_default_graph_triples; bi_in_memory_named_graphs;
+        bi_in_memory_named_graph_triples; bi_cottas;_} ->
+        bi_in_memory_named_graphs
+let (__proj__Mkbackend_info__item__bi_in_memory_named_graph_triples :
+  backend_info -> Prims.int) =
+  fun projectee ->
+    match projectee with
+    | { bi_kind; bi_source; bi_in_memory_triples;
+        bi_in_memory_default_graph_triples; bi_in_memory_named_graphs;
+        bi_in_memory_named_graph_triples; bi_cottas;_} ->
+        bi_in_memory_named_graph_triples
+let (__proj__Mkbackend_info__item__bi_cottas :
+  backend_info -> cottas_summary Prims.list) =
+  fun projectee ->
+    match projectee with
+    | { bi_kind; bi_source; bi_in_memory_triples;
+        bi_in_memory_default_graph_triples; bi_in_memory_named_graphs;
+        bi_in_memory_named_graph_triples; bi_cottas;_} -> bi_cottas
+let rec (sum_cottas_quads : cottas_summary Prims.list -> Prims.int) =
+  fun xs ->
+    match xs with
+    | [] -> Prims.int_zero
+    | x::rest -> x.cs_quads + (sum_cottas_quads rest)
+let (render_backend_info : backend_info -> Prims.string) =
+  fun info ->
+    let cottas_quads = sum_cottas_quads info.bi_cottas in
+    let n_files = FStar_List_Tot_Base.length info.bi_cottas in
+    let triples_total = info.bi_in_memory_triples + cottas_quads in
+    let kind_s =
+      SPARQL_JSON_Escape.json_escape (backend_kind_string info.bi_kind) in
+    let source_s = SPARQL_JSON_Escape.json_escape info.bi_source in
+    FStar_String.concat ""
+      ["{\"kind\":\"";
+      kind_s;
+      "\",\"triples\":";
+      Prims.string_of_int triples_total;
+      ",\"in_memory_triples\":";
+      Prims.string_of_int info.bi_in_memory_triples;
+      ",\"in_memory_default_graph_triples\":";
+      Prims.string_of_int info.bi_in_memory_default_graph_triples;
+      ",\"in_memory_named_graphs\":";
+      Prims.string_of_int info.bi_in_memory_named_graphs;
+      ",\"in_memory_named_graph_triples\":";
+      Prims.string_of_int info.bi_in_memory_named_graph_triples;
+      ",\"cottas_triples\":";
+      Prims.string_of_int cottas_quads;
+      ",\"cottas_files\":";
+      Prims.string_of_int n_files;
+      ",\"source\":\"";
+      source_s;
+      "\"}\n"]
+let rec (sum_named_triples :
+  RDF_Graph_Executable.named_graph Prims.list -> Prims.nat) =
+  fun ngs ->
+    match ngs with
+    | [] -> Prims.int_zero
+    | ng::rest ->
+        (FStar_List_Tot_Base.length ng.RDF_Graph_Executable.ng_graph) +
+          (sum_named_triples rest)
+let (count_dataset_triples :
+  RDF_Graph_Executable.rdf_dataset ->
+    (Prims.int * Prims.int * Prims.int * Prims.int))
+  =
+  fun ds ->
+    let dflt = FStar_List_Tot_Base.length ds.RDF_Graph_Executable.ds_default in
+    let named_count =
+      FStar_List_Tot_Base.length ds.RDF_Graph_Executable.ds_named in
+    let named_triples = sum_named_triples ds.RDF_Graph_Executable.ds_named in
+    ((dflt + named_triples), dflt, named_count, named_triples)
+let (backend_kind_of_flags : Prims.bool -> Prims.bool -> backend_kind) =
+  fun has_dataset ->
+    fun has_cottas ->
+      if has_dataset
+      then (if has_cottas then BK_Hybrid else BK_InMem)
+      else if has_cottas then BK_CottasOnDisk else BK_Empty

--- a/formal/fstar/ocaml-output/SPARQL_HTTP_BackendInfo.ml
+++ b/formal/fstar/ocaml-output/SPARQL_HTTP_BackendInfo.ml
@@ -156,3 +156,16 @@ let (backend_kind_of_flags : Prims.bool -> Prims.bool -> backend_kind) =
       if has_dataset
       then (if has_cottas then BK_Hybrid else BK_InMem)
       else if has_cottas then BK_CottasOnDisk else BK_Empty
+let (backend_source_string :
+  Prims.string FStar_Pervasives_Native.option ->
+    Prims.string Prims.list -> Prims.string)
+  =
+  fun dataset_basename ->
+    fun cottas_basenames ->
+      match (dataset_basename, cottas_basenames) with
+      | (FStar_Pervasives_Native.None, []) -> "(none)"
+      | (FStar_Pervasives_Native.Some f, []) -> f
+      | (FStar_Pervasives_Native.None, paths) ->
+          FStar_String.concat ", " paths
+      | (FStar_Pervasives_Native.Some f, paths) ->
+          FStar_String.concat ", " (f :: paths)

--- a/formal/fstar/ocaml-output/factoidal_http.ml
+++ b/formal/fstar/ocaml-output/factoidal_http.ml
@@ -2112,15 +2112,17 @@ let backend_kind_of_cfg (cfg : config) : SPARQL_HTTP_BackendInfo.backend_kind =
     (cfg.dataset_file <> None)
     (cfg.data_cottas_files <> [])
 
+(* Source-mounted-paths display string — F* owns the format decisions
+   (separator, "(none)" placeholder, dataset-before-cottas ordering);
+   OCaml supplies the path basenames. See SPARQL.HTTP.BackendInfo.fst. *)
 let backend_source_string (cfg : config) : string =
-  match cfg.dataset_file, cfg.data_cottas_files with
-  | None, [] -> "(none)"
-  | Some f, [] -> Filename.basename f
-  | None, paths ->
-    String.concat ", " (List.map Filename.basename paths)
-  | Some f, paths ->
-    String.concat ", "
-      (Filename.basename f :: List.map Filename.basename paths)
+  let dataset_bn =
+    match cfg.dataset_file with
+    | Some f -> FStar_Pervasives_Native.Some (Filename.basename f)
+    | None -> FStar_Pervasives_Native.None
+  in
+  let cottas_bns = List.map Filename.basename cfg.data_cottas_files in
+  SPARQL_HTTP_BackendInfo.backend_source_string dataset_bn cottas_bns
 
 (* Build a per-store cottas_summary list for the backend_info record.
    Pure I/O glue: read whatever the F-star-extracted summary getter

--- a/formal/fstar/ocaml-output/factoidal_http.ml
+++ b/formal/fstar/ocaml-output/factoidal_http.ml
@@ -2102,24 +2102,15 @@ let serve_parliament_queries_json () : response_body =
    `triples` is a live count over the current ref (post-UPDATE); it's
    List.length on an in-memory immutable graph, fast enough for a UI
    pill at our dataset sizes. *)
+(* Dataset triple-count + backend-kind classification — F* is the
+   source of truth (formal/fstar/SPARQL.HTTP.BackendInfo.fst). *)
 let count_dataset_triples (ds : rdf_dataset) : int * int * int * int =
-  let dflt = List.length ds.ds_default in
-  let named_count = List.length ds.ds_named in
-  let named_triples =
-    List.fold_left (fun acc ng -> acc + List.length ng.ng_graph)
-      0 ds.ds_named
-  in
-  (dflt + named_triples, dflt, named_count, named_triples)
+  SPARQL_HTTP_BackendInfo.count_dataset_triples ds
 
-(* Map config flags onto the F-star `backend_kind` constructor. The
-   string form ("empty"/"in-memory"/"binary"/"mixed") is owned by F-star
-   now; see SPARQL.HTTP.BackendInfo.backend_kind_string. *)
 let backend_kind_of_cfg (cfg : config) : SPARQL_HTTP_BackendInfo.backend_kind =
-  match cfg.dataset_file, cfg.data_cottas_files with
-  | None, [] -> SPARQL_HTTP_BackendInfo.BK_Empty
-  | Some _, [] -> SPARQL_HTTP_BackendInfo.BK_InMem
-  | None, _ :: _ -> SPARQL_HTTP_BackendInfo.BK_CottasOnDisk
-  | Some _, _ :: _ -> SPARQL_HTTP_BackendInfo.BK_Hybrid
+  SPARQL_HTTP_BackendInfo.backend_kind_of_flags
+    (cfg.dataset_file <> None)
+    (cfg.data_cottas_files <> [])
 
 let backend_source_string (cfg : config) : string =
   match cfg.dataset_file, cfg.data_cottas_files with


### PR DESCRIPTION
Two helpers from `factoidal_http.ml` that feed `SPARQL.HTTP.BackendInfo`'s `render_backend_info` — moving them into the same F\* module keeps the data-flow self-contained.

> Qualifier per CLAUDE.md rule #11: parser and algebra spec verified in F\*; on-disk backend currently has unverified OCaml-side caching/optimisation layers being migrated back to F\* (see `docs/designissues/fstar-purity-unwind.md`). This PR retires 16 LoC of OCaml-side semantic logic.

## `count_dataset_triples : rdf_dataset -> (int * int * int * int)`

Sums per-named-graph triple counts; classic data-shape primitive used by the `/backend-info.json` renderer to fill the `bi_in_memory_*` fields. The legacy OCaml used `List.fold_left`; the F\* version uses a plain recursion (`sum_named_triples` helper) for total clarity.

Return tuple unchanged: `(total, default, num_named_graphs, named_total)`.

## `backend_kind_of_flags : has_dataset:bool -> has_cottas:bool -> backend_kind`

Replaces the legacy `backend_kind_of_cfg : config -> backend_kind`. The OCaml `config` record stays in OCaml; the F\* function takes pre-extracted booleans, keeping the OCaml-side type out of the F\* surface. Caller becomes a one-liner:

```ocaml
let backend_kind_of_cfg (cfg : config) : SPARQL_HTTP_BackendInfo.backend_kind =
  SPARQL_HTTP_BackendInfo.backend_kind_of_flags
    (cfg.dataset_file <> None)
    (cfg.data_cottas_files <> [])
```

Behaviour: same 4-case classification (Empty / InMem / CottasOnDisk / Hybrid) as the legacy `match`.

## Verification

```
$ fstar.exe --z3version 4.13.3 SPARQL.HTTP.BackendInfo.fst
Verified module: SPARQL.HTTP.BackendInfo
```

## LoC delta

| File | Before | After | Delta |
|---|---:|---:|---:|
| `factoidal_http.ml` (these two functions) | 22 | 6 | −16 |

Plus +30 in `SPARQL.HTTP.BackendInfo.fst` (`sum_named_triples` helper + the two new functions).

## Test plan

- [ ] CI: full F\* extract + native compile + js_of_ocaml + wasm
- [ ] CI: `GET /backend-info.json` on every backend kind (empty / --data only / --data-cottas only / both) returns the expected `kind` and `triples` fields
- [ ] CI: F\*-purity gate (PR #138's expanded version) — clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gid59KLYfGtaXLNfFWnPt1)_