### PR TITLE
fstar-purity: lift backend_source_string (stacked on #146)

### DIFF
--- a/formal/fstar/SPARQL.HTTP.BackendInfo.fst
+++ b/formal/fstar/SPARQL.HTTP.BackendInfo.fst
@@ -124,3 +124,28 @@ let backend_kind_of_flags (has_dataset : bool) (has_cottas : bool)
     (if has_cottas then BK_Hybrid else BK_InMem)
   else
     (if has_cottas then BK_CottasOnDisk else BK_Empty)
+
+// ---------------------------------------------------------------
+// backend_source_string: human-readable summary of the data
+// sources mounted by the daemon, for the startup log and the
+// backend-info display.
+//
+// Migrated from factoidal_http.ml's `backend_source_string`. The
+// OCaml side calls `Filename.basename` to reduce a path to its
+// basename (OS-aware glue), then passes the resulting strings to
+// this F* function which encodes the formatting decisions:
+//   - empty config           -> "(none)"
+//   - just dataset file      -> "<basename>"
+//   - just cottas paths      -> "<bn>, <bn>, ..."
+//   - dataset + cottas paths -> "<dataset_bn>, <cottas_bn>, ..."
+// ---------------------------------------------------------------
+
+let backend_source_string
+    (dataset_basename : option string)
+    (cottas_basenames : list string)
+  : Tot string =
+  match dataset_basename, cottas_basenames with
+  | None,   [] -> "(none)"
+  | Some f, [] -> f
+  | None,   paths -> FStar.String.concat ", " paths
+  | Some f, paths -> FStar.String.concat ", " (f :: paths)

--- a/formal/fstar/ocaml-output/SPARQL_HTTP_BackendInfo.ml
+++ b/formal/fstar/ocaml-output/SPARQL_HTTP_BackendInfo.ml
@@ -156,3 +156,16 @@ let (backend_kind_of_flags : Prims.bool -> Prims.bool -> backend_kind) =
       if has_dataset
       then (if has_cottas then BK_Hybrid else BK_InMem)
       else if has_cottas then BK_CottasOnDisk else BK_Empty
+let (backend_source_string :
+  Prims.string FStar_Pervasives_Native.option ->
+    Prims.string Prims.list -> Prims.string)
+  =
+  fun dataset_basename ->
+    fun cottas_basenames ->
+      match (dataset_basename, cottas_basenames) with
+      | (FStar_Pervasives_Native.None, []) -> "(none)"
+      | (FStar_Pervasives_Native.Some f, []) -> f
+      | (FStar_Pervasives_Native.None, paths) ->
+          FStar_String.concat ", " paths
+      | (FStar_Pervasives_Native.Some f, paths) ->
+          FStar_String.concat ", " (f :: paths)

--- a/formal/fstar/ocaml-output/factoidal_http.ml
+++ b/formal/fstar/ocaml-output/factoidal_http.ml
@@ -2112,15 +2112,17 @@ let backend_kind_of_cfg (cfg : config) : SPARQL_HTTP_BackendInfo.backend_kind =
     (cfg.dataset_file <> None)
     (cfg.data_cottas_files <> [])
 
+(* Source-mounted-paths display string — F* owns the format decisions
+   (separator, "(none)" placeholder, dataset-before-cottas ordering);
+   OCaml supplies the path basenames. See SPARQL.HTTP.BackendInfo.fst. *)
 let backend_source_string (cfg : config) : string =
-  match cfg.dataset_file, cfg.data_cottas_files with
-  | None, [] -> "(none)"
-  | Some f, [] -> Filename.basename f
-  | None, paths ->
-    String.concat ", " (List.map Filename.basename paths)
-  | Some f, paths ->
-    String.concat ", "
-      (Filename.basename f :: List.map Filename.basename paths)
+  let dataset_bn =
+    match cfg.dataset_file with
+    | Some f -> FStar_Pervasives_Native.Some (Filename.basename f)
+    | None -> FStar_Pervasives_Native.None
+  in
+  let cottas_bns = List.map Filename.basename cfg.data_cottas_files in
+  SPARQL_HTTP_BackendInfo.backend_source_string dataset_bn cottas_bns
 
 (* Build a per-store cottas_summary list for the backend_info record.
    Pure I/O glue: read whatever the F-star-extracted summary getter


### PR DESCRIPTION
**Stacked on #146.** Continues from PR #146's migration of `count_dataset_triples` and `backend_kind_of_flags`. Migrates the third `backend_info`-building helper from `factoidal_http.ml`: the source-mounted-paths summary string.

> Qualifier per CLAUDE.md rule #11: parser and algebra spec verified in F\*; on-disk backend currently has unverified OCaml-side caching/optimisation layers being migrated back to F\* (see `docs/designissues/fstar-purity-unwind.md`). This PR retires 3 LoC of OCaml-side semantic logic.

## What lives where

The decisions move to F\* (`SPARQL.HTTP.BackendInfo.fst`):
- empty config            → `"(none)"`
- just dataset file       → `"<basename>"`
- just cottas paths       → `"<bn>, <bn>, ..."`
- dataset + cottas paths  → `"<dataset_bn>, <cottas_bn>, ..."`

OS-aware `Filename.basename` stays in OCaml. The F\* function takes already-basenamed strings as `option string` + `list string`.

```fstar
val backend_source_string :
     dataset_basename:option string
  -> cottas_basenames:list string
  -> Tot string
```

## OCaml side

```ocaml
let backend_source_string (cfg : config) : string =
  let dataset_bn = match cfg.dataset_file with
    | Some f -> FStar_Pervasives_Native.Some (Filename.basename f)
    | None -> FStar_Pervasives_Native.None
  in
  let cottas_bns = List.map Filename.basename cfg.data_cottas_files in
  SPARQL_HTTP_BackendInfo.backend_source_string dataset_bn cottas_bns
```

## Verification

```
$ fstar.exe --z3version 4.13.3 SPARQL.HTTP.BackendInfo.fst
Verified module: SPARQL.HTTP.BackendInfo
```

## LoC delta

| File | Before | After | Delta |
|---|---:|---:|---:|
| `factoidal_http.ml` (this function) | 9 | 6 | −3 |

Plus +25 in `SPARQL.HTTP.BackendInfo.fst`.

## Stacking note

PR base is `claude/backend-info-helpers-fstar` (PR #146's branch), not `claude/main`. Merge #146 first; this then rebases onto fresh main automatically. If #146 is rebased / squash-merged, this PR's base needs to be flipped back to `claude/main` and the diff re-evaluated (it will be additive only, no conflicts).

## Test plan

- [ ] CI: full F\* extract + native compile + js_of_ocaml + wasm
- [ ] CI: Server startup log line `[backend] source: <X>` matches expected on each backend kind
- [ ] CI: `GET /backend-info.json`'s `source` field matches before/after
- [ ] CI: F\*-purity gate (PR #138's expanded version) — clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gid59KLYfGtaXLNfFWnPt1)_