### PR TITLE
fstar-purity: lift bgps_in_query to SPARQL.Query.Analysis.fst

### DIFF
--- a/formal/fstar/SPARQL.Query.Analysis.fst
+++ b/formal/fstar/SPARQL.Query.Analysis.fst
@@ -1,0 +1,52 @@
+module SPARQL.Query.Analysis
+
+// Cheap structural-analysis predicates over SPARQL 1.1 query ASTs.
+// One question per function, all pure, all total. Companion to
+// SPARQL.Update.Analysis.fst (which serves the analogous purpose for
+// SPARQL UPDATE).
+//
+// Migrated from factoidal_explain.ml. The Pe5 explain dump uses
+// `bgps_in_query` to walk a parsed query and report per-BGP rows;
+// the semantic decision "what counts as a BGP under nested patterns"
+// belongs in F\* per Iron Rule #1 even though the dump itself is
+// observability glue.
+
+open FStar.List.Tot
+open SPARQL11.Algebra
+
+// ---------------------------------------------------------------
+// bgps_in_query
+//
+// Walk a query's group_graph_pattern, collecting every non-empty BGP
+// in source order. Recurses through Join / LeftJoin / Filter / Union
+// / Graph / Minus / Bind / Service / ServiceVar; bottoms out at
+// SubSelect / Values / PropertyPath / Empty (which are not BGPs by
+// the SPARQL 1.1 algebra's flattening rules — explain-time
+// reporting just lists them as their own constructors).
+//
+// Returns the BGPs in *first-seen* order so the explain dump's
+// per-BGP row order matches what a user reading the query
+// top-to-bottom would expect.
+// ---------------------------------------------------------------
+
+let rec collect_bgps_aux
+    (acc : list bgp) (p : group_graph_pattern)
+  : Tot (list bgp) (decreases p) =
+  match p with
+  | GP_BGP tps -> if Cons? tps then tps :: acc else acc
+  | GP_Join p1 p2 -> collect_bgps_aux (collect_bgps_aux acc p1) p2
+  | GP_LeftJoin p1 p2 _ -> collect_bgps_aux (collect_bgps_aux acc p1) p2
+  | GP_Union p1 p2 -> collect_bgps_aux (collect_bgps_aux acc p1) p2
+  | GP_Minus p1 p2 -> collect_bgps_aux (collect_bgps_aux acc p1) p2
+  | GP_Filter _ p1 -> collect_bgps_aux acc p1
+  | GP_Graph _ p1 -> collect_bgps_aux acc p1
+  | GP_Bind _ _ p1 -> collect_bgps_aux acc p1
+  | GP_Service _ p1 _ -> collect_bgps_aux acc p1
+  | GP_ServiceVar _ p1 _ -> collect_bgps_aux acc p1
+  | GP_SubSelect _ -> acc
+  | GP_Values _ _ -> acc
+  | GP_PropertyPath _ _ _ -> acc
+  | GP_Empty -> acc
+
+let bgps_in_query (q : query) : Tot (list bgp) =
+  rev (collect_bgps_aux [] q.q_pattern)

--- a/formal/fstar/build-ocaml.sh
+++ b/formal/fstar/build-ocaml.sh
@@ -200,6 +200,7 @@ if [[ "$STEP" == "all" || "$STEP" == "extract" ]]; then
              SPARQL.Update.Sandbox.fst \
              SPARQL.Diagnostics.fst \
              SPARQL.Explain.fst \
+             SPARQL.Query.Analysis.fst \
              SPARQL.HTTP.fst \
              SPARQL.HTTP.Client.fst \
              SPARQL.ServiceDescription.fst \
@@ -288,6 +289,7 @@ if [[ "$STEP" == "all" || "$STEP" == "compile" ]]; then
     SPARQL_Update_Sandbox.ml \
     SPARQL_Diagnostics.ml \
     SPARQL_Explain.ml \
+    SPARQL_Query_Analysis.ml \
     SPARQL_HTTP.ml SPARQL_HTTP_Client.ml SPARQL_ServiceDescription.ml \
     SPARQL_GraphStore.ml"
 
@@ -584,6 +586,7 @@ if [[ "$STEP" == "all" || "$STEP" == "js" ]]; then
     SPARQL_Update_Sandbox.ml
     SPARQL_Diagnostics.ml
     SPARQL_Explain.ml
+    SPARQL_Query_Analysis.ml
     SPARQL_HTTP.ml SPARQL_HTTP_Client.ml SPARQL_ServiceDescription.ml SPARQL_GraphStore.ml
   )
   JS_TARGETS=(

--- a/formal/fstar/ocaml-output/SPARQL_Query_Analysis.ml
+++ b/formal/fstar/ocaml-output/SPARQL_Query_Analysis.ml
@@ -1,0 +1,35 @@
+open Prims
+let rec (collect_bgps_aux :
+  SPARQL11_Algebra.bgp Prims.list ->
+    SPARQL11_Algebra.group_graph_pattern -> SPARQL11_Algebra.bgp Prims.list)
+  =
+  fun acc ->
+    fun p ->
+      match p with
+      | SPARQL11_Algebra.GP_BGP tps ->
+          if Prims.uu___is_Cons tps then tps :: acc else acc
+      | SPARQL11_Algebra.GP_Join (p1, p2) ->
+          collect_bgps_aux (collect_bgps_aux acc p1) p2
+      | SPARQL11_Algebra.GP_LeftJoin (p1, p2, uu___) ->
+          collect_bgps_aux (collect_bgps_aux acc p1) p2
+      | SPARQL11_Algebra.GP_Union (p1, p2) ->
+          collect_bgps_aux (collect_bgps_aux acc p1) p2
+      | SPARQL11_Algebra.GP_Minus (p1, p2) ->
+          collect_bgps_aux (collect_bgps_aux acc p1) p2
+      | SPARQL11_Algebra.GP_Filter (uu___, p1) -> collect_bgps_aux acc p1
+      | SPARQL11_Algebra.GP_Graph (uu___, p1) -> collect_bgps_aux acc p1
+      | SPARQL11_Algebra.GP_Bind (uu___, uu___1, p1) ->
+          collect_bgps_aux acc p1
+      | SPARQL11_Algebra.GP_Service (uu___, p1, uu___1) ->
+          collect_bgps_aux acc p1
+      | SPARQL11_Algebra.GP_ServiceVar (uu___, p1, uu___1) ->
+          collect_bgps_aux acc p1
+      | SPARQL11_Algebra.GP_SubSelect uu___ -> acc
+      | SPARQL11_Algebra.GP_Values (uu___, uu___1) -> acc
+      | SPARQL11_Algebra.GP_PropertyPath (uu___, uu___1, uu___2) -> acc
+      | SPARQL11_Algebra.GP_Empty -> acc
+let (bgps_in_query :
+  SPARQL11_Algebra.query -> SPARQL11_Algebra.bgp Prims.list) =
+  fun q ->
+    FStar_List_Tot_Base.rev
+      (collect_bgps_aux [] q.SPARQL11_Algebra.q_pattern)

--- a/formal/fstar/ocaml-output/factoidal_explain.ml
+++ b/formal/fstar/ocaml-output/factoidal_explain.ml
@@ -205,27 +205,10 @@ let collect_triple_patterns (q : A.query) : (string * A.triple_pattern) list =
   List.rev !acc
 
 (* Pull the BGP back out of a GP_BGP wrapper for choose_best_tp_backend. *)
-let bgps_in_query (q : A.query) : A.bgp list =
-  let acc : A.bgp list ref = ref [] in
-  let rec go (p : A.group_graph_pattern) : unit =
-    match p with
-    | A.GP_BGP tps -> if tps <> [] then acc := tps :: !acc
-    | A.GP_Join (p1, p2) -> go p1; go p2
-    | A.GP_LeftJoin (p1, p2, _) -> go p1; go p2
-    | A.GP_Filter (_, p1) -> go p1
-    | A.GP_Union (p1, p2) -> go p1; go p2
-    | A.GP_Graph (_, p1) -> go p1
-    | A.GP_Minus (p1, p2) -> go p1; go p2
-    | A.GP_Bind (_, _, p1) -> go p1
-    | A.GP_Service (_, p1, _) -> go p1
-    | A.GP_ServiceVar (_, p1, _) -> go p1
-    | A.GP_SubSelect _ -> ()
-    | A.GP_Values _ -> ()
-    | A.GP_PropertyPath _ -> ()
-    | A.GP_Empty -> ()
-  in
-  go q.A.q_pattern;
-  List.rev !acc
+(* bgps_in_query lives in F* per rule #1; see
+   formal/fstar/SPARQL.Query.Analysis.fst. *)
+let bgps_in_query : A.query -> A.bgp list =
+  SPARQL_Query_Analysis.bgps_in_query
 
 (* =========================================================================
    Per-triple-pattern explain row.


### PR DESCRIPTION
Migrate the BGP-collecting tree-walk from `factoidal_explain.ml`. The walk inspects a query's `group_graph_pattern`, recurses through every pattern combinator (Join / LeftJoin / Union / Filter / Graph / Minus / Bind / Service / ServiceVar), and collects each non-empty `GP_BGP` body in source order. Pure structural analysis — rule #1 wants this in F\*.

> Qualifier per CLAUDE.md rule #11: parser and algebra spec verified in F\*; on-disk backend currently has unverified OCaml-side caching/optimisation layers being migrated back to F\* (see `docs/designissues/fstar-purity-unwind.md`). This PR retires 19 LoC of OCaml-side semantic logic.

## Why a new module

`SPARQL.Query.Analysis.fst`. Created rather than reusing `SPARQL.Update.Analysis.fst` (PR #145) because the two domains shouldn't be tangled — Update.Analysis is for `sparql_update` predicates, Query.Analysis is for `query`. Future query-side analysis predicates (`query_uses_aggregate`, `query_unbound_subjects`, etc.) belong here too.

## Behavioural detail

`SubSelect` / `Values` / `PropertyPath` / `Empty` are deliberate non-recursive base cases — they don't contain BGPs by the SPARQL 1.1 algebra's flattening rules. Matches the legacy OCaml exactly.

Order: first-seen, top-to-bottom in source. The accumulator is built in reverse and then reversed at the end, mirroring the OCaml `List.rev !acc` idiom.

## Verification

```
$ fstar.exe --z3version 4.13.3 SPARQL.Query.Analysis.fst
Verified module: SPARQL.Query.Analysis
Extracted module SPARQL.Query.Analysis
```

## OCaml side

```ocaml
let bgps_in_query : A.query -> A.bgp list =
  SPARQL_Query_Analysis.bgps_in_query
```

## LoC delta

| File | Before | After | Delta |
|---|---:|---:|---:|
| `factoidal_explain.ml` (this function) | 21 | 2 | −19 |

Plus +50 in `SPARQL.Query.Analysis.fst` (the F\* core + comment).

## Test plan

- [ ] CI: full F\* extract + native compile + js_of_ocaml + wasm
- [ ] CI: `factoidal --explain '<query>'` on a representative query (e.g. one with nested OPTIONAL or UNION) — per-BGP rows match before/after
- [ ] CI: F\*-purity gate (PR #138's expanded version) — clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gid59KLYfGtaXLNfFWnPt1)_