### PR TITLE
fstar-purity: lift HTTP response-head template (render_response_head)

### DIFF
--- a/formal/fstar/SPARQL.HTTP.Response.fst
+++ b/formal/fstar/SPARQL.HTTP.Response.fst
@@ -200,3 +200,44 @@ let cors_mode_to_string (p : cors_policy) : Tot string =
   | CORS_Any  -> "any origin (Access-Control-Allow-Origin: *)"
   | CORS_List origins ->
       "allowlist (" ^ join_with_comma_space origins ^ ")"
+
+// ---------------------------------------------------------------
+// render_response_head
+//
+// Build the HTTP/1.1 response head — status line + standard
+// headers + caller-supplied extras (CORS, Server-Timing, etc.).
+// The OCaml caller writes (head + body) to the connection's
+// out_channel; the F* function owns the byte template.
+//
+// Migrated from factoidal_http.ml's write_response template.
+// Byte-for-byte identical to the legacy OCaml Printf:
+//
+//   HTTP/1.1 <status> <reason>\r\n
+//   Content-Type: <content_type>\r\n
+//   Content-Length: <body_len>\r\n
+//   Connection: close\r\n
+//   <extras (each followed by CRLF)>
+//   \r\n
+//
+// where <reason> is from status_text and <body_len> is the size
+// of the response body in bytes.
+// ---------------------------------------------------------------
+
+let rec concat_header_lines (xs : list string) : Tot string (decreases xs) =
+  match xs with
+  | [] -> ""
+  | h :: rest -> h ^ "\r\n" ^ concat_header_lines rest
+
+let render_response_head
+    (status        : int)
+    (content_type  : string)
+    (body_len      : int)
+    (extra_headers : list string)
+  : Tot string =
+  let reason = status_text status in
+  "HTTP/1.1 " ^ string_of_int status ^ " " ^ reason ^ "\r\n"
+  ^ "Content-Type: " ^ content_type ^ "\r\n"
+  ^ "Content-Length: " ^ string_of_int body_len ^ "\r\n"
+  ^ "Connection: close\r\n"
+  ^ concat_header_lines extra_headers
+  ^ "\r\n"

--- a/formal/fstar/ocaml-output/SPARQL_HTTP_Response.ml
+++ b/formal/fstar/ocaml-output/SPARQL_HTTP_Response.ml
@@ -141,3 +141,35 @@ let (cors_mode_to_string : cors_policy -> Prims.string) =
     | CORS_List origins ->
         Prims.strcat "allowlist ("
           (Prims.strcat (join_with_comma_space origins) ")")
+let rec (concat_header_lines : Prims.string Prims.list -> Prims.string) =
+  fun xs ->
+    match xs with
+    | [] -> ""
+    | h::rest ->
+        Prims.strcat h (Prims.strcat "\r\n" (concat_header_lines rest))
+let (render_response_head :
+  Prims.int ->
+    Prims.string -> Prims.int -> Prims.string Prims.list -> Prims.string)
+  =
+  fun status ->
+    fun content_type ->
+      fun body_len ->
+        fun extra_headers ->
+          let reason = status_text status in
+          Prims.strcat "HTTP/1.1 "
+            (Prims.strcat (Prims.string_of_int status)
+               (Prims.strcat " "
+                  (Prims.strcat reason
+                     (Prims.strcat "\r\n"
+                        (Prims.strcat "Content-Type: "
+                           (Prims.strcat content_type
+                              (Prims.strcat "\r\n"
+                                 (Prims.strcat "Content-Length: "
+                                    (Prims.strcat
+                                       (Prims.string_of_int body_len)
+                                       (Prims.strcat "\r\n"
+                                          (Prims.strcat
+                                             "Connection: close\r\n"
+                                             (Prims.strcat
+                                                (concat_header_lines
+                                                   extra_headers) "\r\n"))))))))))))

--- a/formal/fstar/ocaml-output/factoidal_http.ml
+++ b/formal/fstar/ocaml-output/factoidal_http.ml
@@ -852,16 +852,13 @@ let status_text code = SPARQL_HTTP_Response.status_text (Z.of_int code)
    that are emitted between the standard headers and the body. CORS headers
    go here. Empty list = historical behaviour. *)
 let write_response ?(extra_headers=[]) oc ~status ~content_type ~body =
-  let text = status_text status in
-  let extras =
-    List.fold_left (fun acc h -> acc ^ h ^ "\r\n") "" extra_headers
+  (* Response-head template lives in F* per rule #1; see
+     SPARQL.HTTP.Response.render_response_head. *)
+  let head =
+    SPARQL_HTTP_Response.render_response_head
+      status content_type (String.length body) extra_headers
   in
-  let headers =
-    Printf.sprintf
-      "HTTP/1.1 %d %s\r\nContent-Type: %s\r\nContent-Length: %d\r\nConnection: close\r\n%s\r\n"
-      status text content_type (String.length body) extras
-  in
-  output_string oc headers;
+  output_string oc head;
   output_string oc body;
   flush oc
 


### PR DESCRIPTION
Migrate the HTTP/1.1 response-head Printf template from `factoidal_http.ml`'s `write_response`. The template is the byte-level shape of every response the server emits — status line, three fixed headers (Content-Type, Content-Length, Connection: close), caller-supplied extras (CORS, Server-Timing, etc.), and the header-terminating CRLF. Rule #1 wants this template in F\*.

> Qualifier per CLAUDE.md rule #11: parser and algebra spec verified in F\*; on-disk backend currently has unverified OCaml-side caching/optimisation layers being migrated back to F\* (see `docs/designissues/fstar-purity-unwind.md`). This PR retires 8 LoC of OCaml-side semantic logic.

## What lives where

The OCaml caller still owns the I/O syscalls (`output_string`, `flush`). The F\* function owns the byte template.

```fstar
val render_response_head :
     status:int
  -> content_type:string
  -> body_len:int
  -> extra_headers:list string
  -> Tot string
```

Output:

```
HTTP/1.1 <status> <reason>\r\n
Content-Type: <content_type>\r\n
Content-Length: <body_len>\r\n
Connection: close\r\n
<extras (each followed by CRLF)>
\r\n
```

Byte-for-byte identical to the legacy Printf template in `factoidal_http.ml`.

## OCaml side

```ocaml
let write_response ?(extra_headers=[]) oc ~status ~content_type ~body =
  let head =
    SPARQL_HTTP_Response.render_response_head
      status content_type (String.length body) extra_headers
  in
  output_string oc head;
  output_string oc body;
  flush oc
```

## Verification

```
$ fstar.exe --z3version 4.13.3 SPARQL.HTTP.Response.fst
Verified module: SPARQL.HTTP.Response
Extracted module SPARQL.HTTP.Response
```

## LoC delta

| File | Before | After | Delta |
|---|---:|---:|---:|
| `factoidal_http.ml` (write_response body) | 13 | 5 | −8 |

Plus +35 in `SPARQL.HTTP.Response.fst` (the `concat_header_lines` helper + `render_response_head` + comment).

## Test plan

- [ ] CI: full F\* extract + native compile + js_of_ocaml + wasm
- [ ] CI: every HTTP response (200 OK / 400 / 404 / 405 / 413 / 500 / 503 / etc.) — the `HTTP/1.1 ...` head is byte-identical before/after
- [ ] CI: SELECT response with CORS allowed origin — extras still emitted in the right slot
- [ ] CI: F\*-purity gate (PR #138's expanded version) — clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gid59KLYfGtaXLNfFWnPt1)_