### PR TITLE
fstar-purity: lift /admin/recent.json renderer to SPARQL.HTTP.Admin.fst

### DIFF
--- a/formal/fstar/SPARQL.HTTP.Admin.fst
+++ b/formal/fstar/SPARQL.HTTP.Admin.fst
@@ -1,0 +1,99 @@
+module SPARQL.HTTP.Admin
+
+// /admin/recent.json renderer.
+//
+// Migrated from factoidal_http.ml's `recent_query_to_json` and
+// `serve_recent_queries_json` JSON template (PR #136 added the
+// per-stage query-timing infrastructure; the JSON shape is the
+// public API for the /admin/recent.json endpoint and belongs in F\*
+// per Iron Rule #1).
+//
+// We deliberately don't lift the OCaml record types `recent_query`
+// and `query_timing` into F\* — the OCaml side owns the
+// Mutex-protected ring buffer and the gettimeofday timestamps;
+// the F\* side just renders. Each F\* function takes the field
+// values as primitives.
+//
+// The query text is JSON-escaped on the OCaml side before being
+// passed in — that uses SPARQL.JSON.Escape.json_escape (PR #126).
+//
+// Output format (byte-for-byte identical to the legacy OCaml
+// Printf templates):
+//
+//   recent_query_to_json:
+//     {"started_at":<float>,"query":"<escaped>","form":"<form>",
+//      "status":<int>,"rows":<int>,"body_bytes":<int>,
+//      "parse_ms":<float>,"eval_ms":<float>,"format_ms":<float>,
+//      "total_ms":<float>}
+//
+//   recent_queries_envelope:
+//     {"total_queries_seen":<int>,"total_wall_ms":<float>,
+//      "status_2xx":<int>,"status_4xx":<int>,"status_5xx":<int>,
+//      "recent":[<rq_json>,...]}\n
+
+open FStar.List.Tot
+open SPARQL.JSON.Escape
+
+// ---------------------------------------------------------------
+// Float -> string. F\*'s standard library doesn't ship a string-
+// formatter for FStar.Float.float that matches OCaml's "%.3f" /
+// "%.2f" / "%.1f" exactly. Keeping the OCaml caller responsible
+// for the float-to-string conversion (it's a Printf %.Nf) lets
+// us preserve the legacy bytes without porting OCaml's Printf
+// FP rounding into F\*. The F\* function takes already-formatted
+// strings.
+// ---------------------------------------------------------------
+
+let render_recent_query_json
+    (started_at_str   : string)   // pre-formatted "%.3f"
+    (query_escaped    : string)   // already JSON-escaped
+    (form             : string)
+    (status           : int)
+    (rows             : int)
+    (body_bytes       : int)
+    (parse_ms_str     : string)   // pre-formatted "%.2f"
+    (eval_ms_str      : string)
+    (format_ms_str    : string)
+    (total_ms_str     : string)
+  : Tot string =
+  "{\"started_at\":" ^ started_at_str
+  ^ ",\"query\":\"" ^ query_escaped
+  ^ "\",\"form\":\"" ^ form
+  ^ "\",\"status\":" ^ string_of_int status
+  ^ ",\"rows\":" ^ string_of_int rows
+  ^ ",\"body_bytes\":" ^ string_of_int body_bytes
+  ^ ",\"parse_ms\":" ^ parse_ms_str
+  ^ ",\"eval_ms\":" ^ eval_ms_str
+  ^ ",\"format_ms\":" ^ format_ms_str
+  ^ ",\"total_ms\":" ^ total_ms_str
+  ^ "}"
+
+// ---------------------------------------------------------------
+// Render the envelope around a list of pre-rendered recent_query
+// JSON object strings. The OCaml caller passes the per-query
+// strings already formatted (each via render_recent_query_json
+// above); this function adds the surrounding counters and the
+// "recent" array.
+// ---------------------------------------------------------------
+
+let rec join_array_elements (xs : list string) : Tot string (decreases xs) =
+  match xs with
+  | [] -> ""
+  | [x] -> x
+  | x :: rest -> x ^ "," ^ join_array_elements rest
+
+let render_recent_queries_envelope
+    (total_queries_seen : int)
+    (total_wall_ms_str  : string)   // pre-formatted "%.1f"
+    (status_2xx         : int)
+    (status_4xx         : int)
+    (status_5xx         : int)
+    (recent_jsons       : list string)
+  : Tot string =
+  "{\"total_queries_seen\":" ^ string_of_int total_queries_seen
+  ^ ",\"total_wall_ms\":" ^ total_wall_ms_str
+  ^ ",\"status_2xx\":" ^ string_of_int status_2xx
+  ^ ",\"status_4xx\":" ^ string_of_int status_4xx
+  ^ ",\"status_5xx\":" ^ string_of_int status_5xx
+  ^ ",\"recent\":[" ^ join_array_elements recent_jsons
+  ^ "]}\n"

--- a/formal/fstar/build-ocaml.sh
+++ b/formal/fstar/build-ocaml.sh
@@ -188,6 +188,7 @@ if [[ "$STEP" == "all" || "$STEP" == "extract" ]]; then
              SPARQL.HTTP.BackendInfo.fst \
              SPARQL.HTTP.QueriesIndex.fst \
              SPARQL.HTTP.StaticFiles.fst \
+             SPARQL.HTTP.Admin.fst \
              Parser.Ballyhoo.fst Parser.BallyhooBloom.fst \
              Parser.BallyhooHDT.fst Parser.BallyhooHDTQ.fst \
              Parser.BallyhooCOTTAS.fst \
@@ -279,6 +280,7 @@ if [[ "$STEP" == "all" || "$STEP" == "compile" ]]; then
     SPARQL_HTTP_BackendInfo.ml \
     SPARQL_HTTP_QueriesIndex.ml \
     SPARQL_HTTP_StaticFiles.ml \
+    SPARQL_HTTP_Admin.ml \
     Parser_Ballyhoo.ml Parser_BallyhooBloom.ml \
     Parser_BallyhooHDT.ml Parser_BallyhooHDTQ.ml Parser_BallyhooCOTTAS.ml \
     RDF_CottasStore_ColumnSeq.ml \
@@ -575,6 +577,7 @@ if [[ "$STEP" == "all" || "$STEP" == "js" ]]; then
     SPARQL_HTTP_BackendInfo.ml
     SPARQL_HTTP_QueriesIndex.ml
     SPARQL_HTTP_StaticFiles.ml
+    SPARQL_HTTP_Admin.ml
     Parser_Ballyhoo.ml Parser_BallyhooBloom.ml
     Parser_BallyhooHDT.ml Parser_BallyhooHDTQ.ml
     Parser_BallyhooCOTTAS.ml

--- a/formal/fstar/ocaml-output/SPARQL_HTTP_Admin.ml
+++ b/formal/fstar/ocaml-output/SPARQL_HTTP_Admin.ml
@@ -1,0 +1,89 @@
+open Prims
+let (render_recent_query_json :
+  Prims.string ->
+    Prims.string ->
+      Prims.string ->
+        Prims.int ->
+          Prims.int ->
+            Prims.int ->
+              Prims.string ->
+                Prims.string -> Prims.string -> Prims.string -> Prims.string)
+  =
+  fun started_at_str ->
+    fun query_escaped ->
+      fun form ->
+        fun status ->
+          fun rows ->
+            fun body_bytes ->
+              fun parse_ms_str ->
+                fun eval_ms_str ->
+                  fun format_ms_str ->
+                    fun total_ms_str ->
+                      Prims.strcat "{\"started_at\":"
+                        (Prims.strcat started_at_str
+                           (Prims.strcat ",\"query\":\""
+                              (Prims.strcat query_escaped
+                                 (Prims.strcat "\",\"form\":\""
+                                    (Prims.strcat form
+                                       (Prims.strcat "\",\"status\":"
+                                          (Prims.strcat
+                                             (Prims.string_of_int status)
+                                             (Prims.strcat ",\"rows\":"
+                                                (Prims.strcat
+                                                   (Prims.string_of_int rows)
+                                                   (Prims.strcat
+                                                      ",\"body_bytes\":"
+                                                      (Prims.strcat
+                                                         (Prims.string_of_int
+                                                            body_bytes)
+                                                         (Prims.strcat
+                                                            ",\"parse_ms\":"
+                                                            (Prims.strcat
+                                                               parse_ms_str
+                                                               (Prims.strcat
+                                                                  ",\"eval_ms\":"
+                                                                  (Prims.strcat
+                                                                    eval_ms_str
+                                                                    (Prims.strcat
+                                                                    ",\"format_ms\":"
+                                                                    (Prims.strcat
+                                                                    format_ms_str
+                                                                    (Prims.strcat
+                                                                    ",\"total_ms\":"
+                                                                    (Prims.strcat
+                                                                    total_ms_str
+                                                                    "}")))))))))))))))))))
+let rec (join_array_elements : Prims.string Prims.list -> Prims.string) =
+  fun xs ->
+    match xs with
+    | [] -> ""
+    | x::[] -> x
+    | x::rest -> Prims.strcat x (Prims.strcat "," (join_array_elements rest))
+let (render_recent_queries_envelope :
+  Prims.int ->
+    Prims.string ->
+      Prims.int ->
+        Prims.int -> Prims.int -> Prims.string Prims.list -> Prims.string)
+  =
+  fun total_queries_seen ->
+    fun total_wall_ms_str ->
+      fun status_2xx ->
+        fun status_4xx ->
+          fun status_5xx ->
+            fun recent_jsons ->
+              Prims.strcat "{\"total_queries_seen\":"
+                (Prims.strcat (Prims.string_of_int total_queries_seen)
+                   (Prims.strcat ",\"total_wall_ms\":"
+                      (Prims.strcat total_wall_ms_str
+                         (Prims.strcat ",\"status_2xx\":"
+                            (Prims.strcat (Prims.string_of_int status_2xx)
+                               (Prims.strcat ",\"status_4xx\":"
+                                  (Prims.strcat
+                                     (Prims.string_of_int status_4xx)
+                                     (Prims.strcat ",\"status_5xx\":"
+                                        (Prims.strcat
+                                           (Prims.string_of_int status_5xx)
+                                           (Prims.strcat ",\"recent\":["
+                                              (Prims.strcat
+                                                 (join_array_elements
+                                                    recent_jsons) "]}\n")))))))))))

--- a/formal/fstar/ocaml-output/factoidal_http.ml
+++ b/formal/fstar/ocaml-output/factoidal_http.ml
@@ -1184,25 +1184,27 @@ let json_string_escape s =
   ) s;
   Buffer.contents buf
 
+(* /admin/recent.json renderer — F* owns the JSON template
+   (SPARQL.HTTP.Admin.fst per rule #1). The OCaml side keeps the
+   ring buffer / counter Mutex protection (runtime mutable state =
+   thin glue per rule #11(c)) and pre-formats the per-call float
+   strings (OCaml Printf "%.Nf" semantics; F* has no equivalent
+   formatter). *)
 let recent_query_to_json (rq : recent_query) : string =
-  Printf.sprintf
-    "{\"started_at\":%.3f,\"query\":\"%s\",\"form\":\"%s\",\"status\":%d,\
-     \"rows\":%d,\"body_bytes\":%d,\"parse_ms\":%.2f,\"eval_ms\":%.2f,\
-     \"format_ms\":%.2f,\"total_ms\":%.2f}"
-    rq.rq_started_at
-    (json_string_escape rq.rq_query_text)
+  SPARQL_HTTP_Admin.render_recent_query_json
+    (Printf.sprintf "%.3f" rq.rq_started_at)
+    (SPARQL_JSON_Escape.json_escape rq.rq_query_text)
     rq.rq_timing.qt_form
     rq.rq_timing.qt_status
     rq.rq_timing.qt_rows
     rq.rq_timing.qt_body_bytes
-    rq.rq_timing.qt_parse_ms
-    rq.rq_timing.qt_eval_ms
-    rq.rq_timing.qt_format_ms
-    rq.rq_timing.qt_total_ms
+    (Printf.sprintf "%.2f" rq.rq_timing.qt_parse_ms)
+    (Printf.sprintf "%.2f" rq.rq_timing.qt_eval_ms)
+    (Printf.sprintf "%.2f" rq.rq_timing.qt_format_ms)
+    (Printf.sprintf "%.2f" rq.rq_timing.qt_total_ms)
 
 let serve_recent_queries_json () : response_body =
   let xs = snapshot_recent_queries () in
-  let body = Buffer.create 4096 in
   Mutex.lock counters_mu;
   let total = !total_queries_seen in
   let total_wall = !total_query_wall_ms in
@@ -1210,20 +1212,16 @@ let serve_recent_queries_json () : response_body =
   let s4 = !queries_status_4xx in
   let s5 = !queries_status_5xx in
   Mutex.unlock counters_mu;
-  Buffer.add_string body
-    (Printf.sprintf
-       "{\"total_queries_seen\":%d,\"total_wall_ms\":%.1f,\
-        \"status_2xx\":%d,\"status_4xx\":%d,\"status_5xx\":%d,\"recent\":["
-       total total_wall s2 s4 s5);
-  let first = ref true in
-  List.iter (fun rq ->
-    if !first then first := false else Buffer.add_char body ',';
-    Buffer.add_string body (recent_query_to_json rq)
-  ) xs;
-  Buffer.add_string body "]}\n";
+  let body =
+    SPARQL_HTTP_Admin.render_recent_queries_envelope
+      total
+      (Printf.sprintf "%.1f" total_wall)
+      s2 s4 s5
+      (List.map recent_query_to_json xs)
+  in
   { rb_status = 200;
     rb_content_type = "application/json; charset=utf-8";
-    rb_body = Buffer.contents body }
+    rb_body = body }
 
 (* Wrap a unit -> 'a thunk, return result paired with elapsed wall ms. *)
 let timed (f : unit -> 'a) : 'a * float =


### PR DESCRIPTION
Migrate the JSON template for `recent_query_to_json` and the envelope wrap for `serve_recent_queries_json` from `factoidal_http.ml` (added by PR #136 for per-stage query timing). Both encode the public API shape of `/admin/recent.json` — Iron Rule #1 wants the shape decisions in F\*.

> Qualifier per CLAUDE.md rule #11: parser and algebra spec verified in F\*; on-disk backend currently has unverified OCaml-side caching/optimisation layers being migrated back to F\* (see `docs/designissues/fstar-purity-unwind.md`). This PR retires 22 LoC of OCaml-side semantic logic.

## What stays in OCaml (acceptable glue)

- The `recent_query` and `query_timing` record types — they live close to the Mutex-protected ring buffer / mutable counter cells. The audit's "thin glue" classification covers `Mutex` + `ref` runtime state.
- Printf `"%.Nf"` float-to-string formatting. F\*'s standard library doesn't ship a string formatter for `FStar.Float.float` that matches OCaml's `%.3f` / `%.2f` / `%.1f` rounding semantics exactly. The OCaml caller pre-formats the floats and hands the resulting strings to F\*.
- `SPARQL_JSON_Escape.json_escape` on the query text (already in F\* via PR #126; called from OCaml).

## What moves to F\*

```fstar
val render_recent_query_json :
     started_at_str : string         (* pre-formatted "%.3f" *)
  -> query_escaped : string          (* already JSON-escaped *)
  -> form : string
  -> status : int
  -> rows : int
  -> body_bytes : int
  -> parse_ms_str : string           (* pre-formatted "%.2f" *)
  -> eval_ms_str : string
  -> format_ms_str : string
  -> total_ms_str : string
  -> Tot string

val render_recent_queries_envelope :
     total_queries_seen : int
  -> total_wall_ms_str : string      (* pre-formatted "%.1f" *)
  -> status_2xx : int
  -> status_4xx : int
  -> status_5xx : int
  -> recent_jsons : list string      (* each from render_recent_query_json *)
  -> Tot string
```

Output is byte-for-byte identical to the legacy Printf templates, preserving the field order, the lack of whitespace, and the trailing newline.

## OCaml side

```ocaml
let recent_query_to_json (rq : recent_query) : string =
  SPARQL_HTTP_Admin.render_recent_query_json
    (Printf.sprintf "%.3f" rq.rq_started_at)
    (SPARQL_JSON_Escape.json_escape rq.rq_query_text)
    rq.rq_timing.qt_form
    rq.rq_timing.qt_status
    rq.rq_timing.qt_rows
    rq.rq_timing.qt_body_bytes
    (Printf.sprintf "%.2f" rq.rq_timing.qt_parse_ms)
    (Printf.sprintf "%.2f" rq.rq_timing.qt_eval_ms)
    (Printf.sprintf "%.2f" rq.rq_timing.qt_format_ms)
    (Printf.sprintf "%.2f" rq.rq_timing.qt_total_ms)
```

## Verification

```
$ fstar.exe --z3version 4.13.3 SPARQL.HTTP.Admin.fst
Verified module: SPARQL.HTTP.Admin
Extracted module SPARQL.HTTP.Admin
```

## LoC delta

| File | Before | After | Delta |
|---|---:|---:|---:|
| `factoidal_http.ml` (these two functions) | 40 | 18 | −22 |

Plus +90 in `SPARQL.HTTP.Admin.fst`.

## Test plan

- [ ] CI: full F\* extract + native compile + js_of_ocaml + wasm
- [ ] CI: `GET /admin/recent.json` after a few queries — JSON byte-for-byte identical before/after
- [ ] CI: F\*-purity gate (PR #138's expanded version) — clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gid59KLYfGtaXLNfFWnPt1)_