### PR TITLE
fstar-purity: retire factoidal_http.ml's duplicate string_replace_all

### DIFF
--- a/formal/fstar/ocaml-output/factoidal_http.ml
+++ b/formal/fstar/ocaml-output/factoidal_http.ml
@@ -1490,31 +1490,11 @@ let update_has_load (u : SPARQL11_Algebra.sparql_update) : bool =
    parse_sparql_update and apply_update. Pure OCaml glue, no F* changes.
    ============================================================================ *)
 
-(* Simple substring replace: replace every literal occurrence of [needle]
-   in [haystack] with [replacement]. *)
+(* string_replace_all lives in F* per rule #1
+   (formal/fstar/SPARQL.Update.Sandbox.fst). The local copy here
+   duplicated that logic; replaced with a thin alias. *)
 let string_replace_all ~needle ~replacement haystack =
-  if needle = "" then haystack
-  else begin
-    let nlen = String.length needle in
-    let hlen = String.length haystack in
-    let buf = Buffer.create (hlen + 16) in
-    let i = ref 0 in
-    while !i <= hlen - nlen do
-      if String.sub haystack !i nlen = needle then begin
-        Buffer.add_string buf replacement;
-        i := !i + nlen
-      end else begin
-        Buffer.add_char buf haystack.[!i];
-        incr i
-      end
-    done;
-    (* tail *)
-    while !i < hlen do
-      Buffer.add_char buf haystack.[!i];
-      incr i
-    done;
-    Buffer.contents buf
-  end
+  SPARQL_Update_Sandbox.string_replace_all needle replacement haystack
 
 (* Thin OCaml dispatch shims around the verified F-star sandbox module.
    The semantic policy (graph-target rewriting, alias expansion, accept/


### PR DESCRIPTION
The sandbox migration (PR `claude/http-update-sandbox-to-fstar`, since merged into `claude/main`) added `string_replace_all` to `SPARQL.Update.Sandbox.fst` (used as an internal helper for `expand_user_graph`). `factoidal_http.ml` had a separate inline copy with the same algorithm. Replacing the local copy with a thin alias.

> Qualifier per CLAUDE.md rule #11: parser and algebra spec verified in F\*; on-disk backend currently has unverified OCaml-side caching/optimisation layers being migrated back to F\* (see `docs/designissues/fstar-purity-unwind.md`). This PR retires 22 LoC of duplicated OCaml-side semantic logic.

## Behavioural equivalence

Both implementations:
- Use literal-substring matching (no regex)
- Don't overlap-shift after a match (`i := !i + nlen`)
- Short-circuit on empty needle (return haystack unchanged)
- Append the unmatched tail unchanged

Observably identical.

## OCaml side

```ocaml
let string_replace_all ~needle ~replacement haystack =
  SPARQL_Update_Sandbox.string_replace_all needle replacement haystack
```

## LoC delta

| File | Before | After | Delta |
|---|---:|---:|---:|
| `factoidal_http.ml` (this function) | 24 | 2 | −22 |

## Test plan

- [ ] CI: full F\* extract + native compile + js_of_ocaml + wasm
- [ ] CI: any code path that called the old `string_replace_all` works (the local one was used in the `parliament_template_prefix` analysis at line ~1577 — search for callers in the extracted output)
- [ ] CI: F\*-purity gate (PR #138's expanded version) — clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gid59KLYfGtaXLNfFWnPt1)_