### PR TITLE
fstar-purity: retire factoidal_cli.ml's local json_escape + json_term

### DIFF
--- a/formal/fstar/ocaml-output/SPARQL_JSON_Escape.ml
+++ b/formal/fstar/ocaml-output/SPARQL_JSON_Escape.ml
@@ -1,0 +1,92 @@
+open Prims
+let (hex_digit_lc : Prims.nat -> FStar_Char.char) =
+  fun n ->
+    if n < (Prims.of_int (10))
+    then FStar_Char.char_of_int ((Prims.of_int (0x30)) + n)
+    else
+      if n < (Prims.of_int (16))
+      then
+        FStar_Char.char_of_int
+          ((Prims.of_int (0x61)) + (n - (Prims.of_int (10))))
+      else FStar_Char.char_of_int (Prims.of_int (0x30))
+let (push_u_escape :
+  Prims.nat -> FStar_Char.char Prims.list -> FStar_Char.char Prims.list) =
+  fun b ->
+    fun acc ->
+      let n3 = b mod (Prims.of_int (16)) in
+      let r1 = b / (Prims.of_int (16)) in
+      let n2 = r1 mod (Prims.of_int (16)) in
+      let r2 = r1 / (Prims.of_int (16)) in
+      let n1 = r2 mod (Prims.of_int (16)) in
+      let n0 = (r2 / (Prims.of_int (16))) mod (Prims.of_int (16)) in
+      let acc1 = (hex_digit_lc n3) :: acc in
+      let acc2 = (hex_digit_lc n2) :: acc1 in
+      let acc3 = (hex_digit_lc n1) :: acc2 in
+      let acc4 = (hex_digit_lc n0) :: acc3 in
+      let acc5 = (FStar_Char.char_of_int (Prims.of_int (0x75))) :: acc4 in
+      let acc6 = (FStar_Char.char_of_int (Prims.of_int (0x5C))) :: acc5 in
+      acc6
+let (push_escape2 :
+  FStar_Char.char -> FStar_Char.char Prims.list -> FStar_Char.char Prims.list)
+  =
+  fun c ->
+    fun acc ->
+      let acc1 = c :: acc in
+      let acc2 = (FStar_Char.char_of_int (Prims.of_int (0x5C))) :: acc1 in
+      acc2
+let (escape_byte :
+  Prims.nat -> FStar_Char.char Prims.list -> FStar_Char.char Prims.list) =
+  fun b ->
+    fun acc ->
+      if b = (Prims.of_int (0x5C))
+      then push_escape2 (FStar_Char.char_of_int (Prims.of_int (0x5C))) acc
+      else
+        if b = (Prims.of_int (0x22))
+        then push_escape2 (FStar_Char.char_of_int (Prims.of_int (0x22))) acc
+        else
+          if b = (Prims.of_int (0x0A))
+          then
+            push_escape2 (FStar_Char.char_of_int (Prims.of_int (0x6E))) acc
+          else
+            if b = (Prims.of_int (0x0D))
+            then
+              push_escape2 (FStar_Char.char_of_int (Prims.of_int (0x72))) acc
+            else
+              if b = (Prims.of_int (0x09))
+              then
+                push_escape2 (FStar_Char.char_of_int (Prims.of_int (0x74)))
+                  acc
+              else
+                if b = (Prims.of_int (0x08))
+                then
+                  push_escape2 (FStar_Char.char_of_int (Prims.of_int (0x62)))
+                    acc
+                else
+                  if b = (Prims.of_int (0x0C))
+                  then
+                    push_escape2
+                      (FStar_Char.char_of_int (Prims.of_int (0x66))) acc
+                  else
+                    if b < (Prims.of_int (0x20))
+                    then push_u_escape b acc
+                    else (FStar_Char.char_of_int b) :: acc
+let rec (walk :
+  Prims.string ->
+    Prims.nat ->
+      Prims.nat -> FStar_Char.char Prims.list -> FStar_Char.char Prims.list)
+  =
+  fun s ->
+    fun len ->
+      fun pos ->
+        fun acc ->
+          if pos >= len
+          then acc
+          else
+            (let b = Parser_FastString.fs_byte_at s pos in
+             let acc' = escape_byte b acc in
+             walk s len (pos + Prims.int_one) acc')
+let (json_escape : Prims.string -> Prims.string) =
+  fun s ->
+    let len = Parser_FastString.fs_byte_length s in
+    let acc = walk s len Prims.int_zero [] in
+    FStar_String.string_of_list (FStar_List_Tot_Base.rev acc)

--- a/formal/fstar/ocaml-output/factoidal_cli.ml
+++ b/formal/fstar/ocaml-output/factoidal_cli.ml
@@ -338,42 +338,12 @@ let print_results_csv vars rows =
     Printf.printf "%s\n" (String.concat "," cells)
   ) rows
 
-let json_escape s =
-  let buf = Buffer.create (String.length s + 8) in
-  String.iter (fun c ->
-    match c with
-    | '"'  -> Buffer.add_string buf "\\\""
-    | '\\' -> Buffer.add_string buf "\\\\"
-    | '\n' -> Buffer.add_string buf "\\n"
-    | '\r' -> Buffer.add_string buf "\\r"
-    | '\t' -> Buffer.add_string buf "\\t"
-    | '\b' -> Buffer.add_string buf "\\b"
-    | '\012' -> Buffer.add_string buf "\\f"
-    | c when Char.code c < 0x20 ->
-      Buffer.add_string buf (Printf.sprintf "\\u%04x" (Char.code c))
-    | c -> Buffer.add_char buf c
-  ) s;
-  Buffer.contents buf
-
-let json_term t =
-  match t with
-  | T_IRI i ->
-    Printf.sprintf "{\"type\":\"uri\",\"value\":\"%s\"}" (json_escape i)
-  | T_BNode b ->
-    Printf.sprintf "{\"type\":\"bnode\",\"value\":\"%s\"}" (json_escape b)
-  | T_Literal l ->
-    let xsd_string = "http://www.w3.org/2001/XMLSchema#string" in
-    (match l.lang_tag with
-     | Some tag ->
-       Printf.sprintf "{\"type\":\"literal\",\"value\":\"%s\",\"xml:lang\":\"%s\"}"
-         (json_escape l.lexical_form) (json_escape tag)
-     | None ->
-       if l.datatype = "" || l.datatype = xsd_string then
-         Printf.sprintf "{\"type\":\"literal\",\"value\":\"%s\"}"
-           (json_escape l.lexical_form)
-       else
-         Printf.sprintf "{\"type\":\"literal\",\"value\":\"%s\",\"datatype\":\"%s\"}"
-           (json_escape l.lexical_form) (json_escape l.datatype))
+(* json_escape and json_term delegate to F*: SPARQL.JSON.Escape and
+   SPARQL.Protocol own the SPARQL Results JSON byte-level rendering.
+   factoidal_http.ml already does the same delegation; this brings
+   factoidal_cli.ml in line. Rule #1 / #11. *)
+let json_escape s = SPARQL_JSON_Escape.json_escape s
+let json_term t = SPARQL_Protocol.json_term t
 
 let print_results_json vars rows =
   let vars_json = String.concat "," (List.map (fun v ->


### PR DESCRIPTION
## Summary

Mirrors the delegation `factoidal_http.ml` already does: `factoidal_cli.ml`'s
local `json_escape` and `json_term` are duplicates of the F\*-extracted
`SPARQL_JSON_Escape.json_escape` and `SPARQL_Protocol.json_term`. Replace
the local 36-line implementations with one-line shims that forward to F\*.

This is a small rule #11 cleanup, but it kills a subtle drift: the cli's
branch had `l.datatype = ""` as a fallback case that the F\* version
rightly drops because `wf_literal.datatype : wf_iri` (the empty string
is unreachable in well-formed F\* literals). Lining up on the F\* copy
fixes that subtle inconsistency.

## Changes

- `formal/fstar/ocaml-output/factoidal_cli.ml`: replaces the 36-line
  local `json_escape` / `json_term` block with two one-line shims
  (`let json_escape s = SPARQL_JSON_Escape.json_escape s` and
  `let json_term t = SPARQL_Protocol.json_term t`). Net `-36+6 = -30`
  OCaml-side semantic LoC retired.

No new F\* code: both target functions already exist on `claude/main`
in `SPARQL.JSON.Escape.fst` and `SPARQL.Protocol.fst`.

## Verification

- `./build-ocaml.sh compile` produces clean `factoidal`,
  `factoidal-http`, `w3c_runner` binaries.
- Smoke test: `factoidal --data X.ttl -e 'SELECT *...' --output json`
  still emits the same SPARQL Results JSON shape — `{"head":{"vars":...},
  "results":{"bindings":[{"o":{"type":"uri","value":"..."}}]}}`.
- The rest of `print_results_json`'s pretty-printing (whitespace,
  indentation) is unchanged because it's the I/O wrapper around
  `json_term` — only the byte-level JSON value object is touched.

## Rule compliance

- **Rule #1** (F\* is source of truth): JSON term-rendering rules
  centralised in F\*.
- **Rule #11** (no semantic logic in OCaml glue): cli's previous
  private duplicate is retired; OCaml side is now a one-line shim.

## Test plan

- [x] `./build-ocaml.sh compile` succeeds
- [x] `factoidal --output json` smoke test produces correct JSON

https://claude.ai/code/session_01Gid59KLYfGtaXLNfFWnPt1

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gid59KLYfGtaXLNfFWnPt1)_