### PR TITLE
ci: gate CI-shadow pushes to claude/main + .gitattributes for collision-free merges

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,55 @@
+# =====================================================================
+# CI shadow build artifacts
+# =====================================================================
+#
+# bin/ci-<platform>/ holds binaries auto-committed by the
+# .github/workflows/w3c-tests.yml workflow. Every push to claude/main
+# regenerates them, so divergent versions on PR branches vs. main were
+# the dominant source of merge conflicts during the F*-purity unwind
+# (PRs #155-#161 each had to be re-rebased multiple times).
+#
+# Two-layer fix:
+#
+# 1. Workflow-level (primary): the "Commit + push CI shadow artifacts"
+#    step in w3c-tests.yml is now gated on `github.ref ==
+#    'refs/heads/claude/main'`. PR-branch CI runs build the binaries
+#    (still needed for in-job tests) but no longer push them back.
+#    PR branches stop diverging from main on these paths entirely.
+#
+# 2. Driver-level (defense-in-depth): the `merge=ours` attribute below
+#    tells git's merge driver to keep main's version of these files
+#    when two inputs collide. Useful when two concurrent
+#    claude/main pushes race and the second one needs `git pull
+#    --rebase` to land — without this, the rebase would conflict on
+#    every CI shadow path. The driver is registered in the workflow's
+#    git-config setup (`git config merge.ours.driver true`).
+#
+# IMPORTANT CAVEAT: GitHub's web-UI merge button does NOT honor
+# custom merge drivers — it uses libgit2 server-side. The merge=ours
+# rule only helps the workflow's own rebases and any local-merge flow
+# where the driver is registered. The web-UI scenario is covered by
+# layer 1 above (PR branches don't push CI shadows, so there's
+# nothing to conflict).
+#
+# See:
+#   - https://git-scm.com/docs/gitattributes#_merge
+#   - .github/workflows/w3c-tests.yml
+# =====================================================================
+
+bin/ci-linux-x86_64/*  merge=ours
+bin/ci-darwin-arm64/*  merge=ours
+
+# Mark the binaries themselves as binary so git doesn't try to
+# normalize line endings or produce textual diffs for them.
+bin/ci-linux-x86_64/cottas_ondisk_smoketest  binary
+bin/ci-linux-x86_64/factoidal                binary
+bin/ci-linux-x86_64/factoidal-http           binary
+bin/ci-linux-x86_64/owl_runner               binary
+bin/ci-linux-x86_64/rdfc10_runner            binary
+bin/ci-linux-x86_64/w3c_runner               binary
+bin/ci-darwin-arm64/cottas_ondisk_smoketest  binary
+bin/ci-darwin-arm64/factoidal                binary
+bin/ci-darwin-arm64/factoidal-http           binary
+bin/ci-darwin-arm64/owl_runner               binary
+bin/ci-darwin-arm64/rdfc10_runner            binary
+bin/ci-darwin-arm64/w3c_runner               binary

--- a/.github/workflows/w3c-tests.yml
+++ b/.github/workflows/w3c-tests.yml
@@ -171,10 +171,21 @@ jobs:
           ls -la "$CI_BIN_DIR"
 
       - name: Commit + push CI shadow artifacts
+        # Only push back when running on claude/main. PR-branch builds
+        # still produce the binaries (used by the in-job test step),
+        # but we don't push them back to the branch. This keeps PR
+        # branches diverging from main only on the actual code changes,
+        # not on auto-generated binary blobs that would otherwise
+        # collide with main's shadow commits on every parallel PR.
+        if: github.ref == 'refs/heads/claude/main'
         run: |
           set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          # Register the `merge=ours` driver referenced by .gitattributes
+          # for bin/ci-*/*. Used below if `git pull --rebase` races with
+          # another concurrent main-branch push.
+          git config merge.ours.driver true
 
           git add '${{ matrix.ci_dir }}'
           git add formal/fstar/ocaml-output-ci/
@@ -332,10 +343,16 @@ jobs:
                || echo "(differences above — check which suites diverge)"
 
       - name: Commit + push Linux generated docs artifacts
+        # Same scope as the CI shadow artifacts step above: only push
+        # to claude/main, never to PR branches.
+        if: github.ref == 'refs/heads/claude/main'
         run: |
           set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          # Register the `merge=ours` driver referenced by .gitattributes
+          # (defense-in-depth for concurrent main-branch pushes).
+          git config merge.ours.driver true
 
           git add docs/test-results/ \
                   docs/fstar-extracted/ \


### PR DESCRIPTION
## Summary

Tonight's PR queue (#155–#161) hit the same merge-conflict
treadmill 3 times each: the w3c-tests workflow auto-commits
`bin/ci-<platform>/*` binaries on **every** push to **every** branch,
so each parallel PR had its own divergent shadow-binary commit, and
every merge to main caused all the other branches to conflict on
those same files.

Two-layer systemic fix.

## 1. Workflow-level (primary fix) — Option B

The "Commit + push CI shadow artifacts" step (and its sibling for
generated docs artifacts) is now gated on
`github.ref == 'refs/heads/claude/main'`. PR-branch CI runs still
**build + test** the binaries (the in-job test step needs them); they
just don't **push** them back to the branch. PR branches stop
diverging from main on these paths entirely.

This is the actually-effective fix for the GitHub web-UI merge
button case.

## 2. Driver-level (defense-in-depth) — Option A

New `.gitattributes` declares:

```
bin/ci-linux-x86_64/*  merge=ours
bin/ci-darwin-arm64/*  merge=ours
bin/ci-{linux-x86_64,darwin-arm64}/<binary>  binary
```

…plus the workflow now runs `git config merge.ours.driver true`
so concurrent main-branch pushes that race to commit shadow
binaries can resolve via `git pull --rebase` instead of failing.

## Caveats (documented in `.gitattributes` itself)

- ⚠️ GitHub's web-UI merge button does NOT honor custom merge
  drivers (libgit2 server-side merge). So layer 2 alone wouldn't
  have fixed the original conflict treadmill — **layer 1 is what
  matters for the PR-merge UI scenario.**
- Layer 2 is a backstop for runner-side rebases and any
  local-merge workflows where the driver is registered.

## Why C is explicitly **not** chosen

Moving `bin/ci-*/*` out of git (release assets / git-LFS / orphan
branch) would lose the "fresh checkout → run binaries immediately"
property documented in CLAUDE.md rule #9. Keeping the artifacts in
the working tree is a deliberate design choice; this PR fixes the
collision symptom without disturbing the artifact-distribution
mechanism.

## Test plan

- [x] YAML lint clean (`python3 -c "import yaml; yaml.safe_load(open(...))"`)
- [ ] After this lands: open a follow-up "no-op" PR and verify the
      CI run does NOT push a `[skip ci]` shadow commit to that PR
      branch.
- [ ] Push to `claude/main` (after this PR merges) should still
      auto-commit binaries as before — gate is `==`, not `!=`.

## Effect on the open queue

Once this lands, PRs #155–#160 can be merged (in any order) without
the recurring shadow-build conflicts. The PR-branch CI runs that
fired earlier produced commits that I had to repeatedly rebase
away; after this fix those commits stop appearing.

https://claude.ai/code/session_01Gid59KLYfGtaXLNfFWnPt1

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gid59KLYfGtaXLNfFWnPt1)_