### PR TITLE
fstar-purity: retire rdfc10_runner.ml's local escape_literal_lexical

### DIFF
--- a/formal/fstar/ocaml-output/rdfc10_runner.ml
+++ b/formal/fstar/ocaml-output/rdfc10_runner.ml
@@ -196,17 +196,11 @@ let iri_to_path (iri : string) : string option =
    no-bnode tests in Phase 0. Phase 1+ replaces this with the
    F\*-extracted canonical_nquads serialiser. *)
 
-let escape_literal_lexical (s : string) : string =
-  let b = Buffer.create (String.length s + 8) in
-  String.iter (fun c ->
-    match c with
-    | '\\' -> Buffer.add_string b "\\\\"
-    | '"'  -> Buffer.add_string b "\\\""
-    | '\n' -> Buffer.add_string b "\\n"
-    | '\r' -> Buffer.add_string b "\\r"
-    | '\t' -> Buffer.add_string b "\\t"
-    | _    -> Buffer.add_char b c) s;
-  Buffer.contents b
+(* Delegates to F*'s RDF.NQuads.Serialize.nq_escape_literal. The
+   local OCaml impl was a byte-for-byte duplicate; per CLAUDE.md
+   rule #11 OCaml glue may not carry serialisation logic. *)
+let escape_literal_lexical : string -> string =
+  RDF_NQuads_Serialize.nq_escape_literal
 
 let term_nq (t : rdf_term) : string =
   match t with


### PR DESCRIPTION
## Summary

The OCaml impl in `rdfc10_runner.ml` was a byte-for-byte duplicate of `RDF.NQuads.Serialize.nq_escape_literal` (F*). Per CLAUDE.md rule #11, OCaml glue may not carry serialisation logic. Replaced with a one-line delegation.

- `formal/fstar/ocaml-output/rdfc10_runner.ml`: −11 / +5 lines
- No F* changes; F* version pre-existed.

## Test plan

- [x] `./build-ocaml.sh compile` — links cleanly with `RDF_NQuads_Serialize.nq_escape_literal`.
- [x] `rdfc10_runner` invocation against W3C RDF-canon corpus unchanged.

Track-1 quick win #2 of the migration plan in `docs/designissues/2026-05-07-query-planning-fstar-recovery.md`.