### PR TITLE
fstar-purity: retire rdfc10_runner.ml's local N-Quads serializers

### DIFF
--- a/formal/fstar/RDF.NQuads.Serialize.fst
+++ b/formal/fstar/RDF.NQuads.Serialize.fst
@@ -109,3 +109,15 @@ let nq_subject_to_string (s : subject) : Tot string =
 let nq_line_for_triple (graph_iri : string) (t : triple) : Tot string =
   nq_subject_to_string t.s ^ " <" ^ t.p ^ "> "
   ^ nq_term_to_string t.o ^ " <" ^ graph_iri ^ "> .\n"
+
+// ---------------------------------------------------------------
+// nq_line_for_triple_default_graph : N-Triples-style line for a
+// triple in the default (unnamed) graph. Same as
+// nq_line_for_triple but without the trailing graph IRI.
+//
+// Output:  <subject> <predicate> <object> .\n
+// ---------------------------------------------------------------
+
+let nq_line_for_triple_default_graph (t : triple) : Tot string =
+  nq_subject_to_string t.s ^ " <" ^ t.p ^ "> "
+  ^ nq_term_to_string t.o ^ " .\n"

--- a/formal/fstar/ocaml-output/RDF_NQuads_Serialize.ml
+++ b/formal/fstar/ocaml-output/RDF_NQuads_Serialize.ml
@@ -59,3 +59,12 @@ let (nq_line_for_triple :
               (Prims.strcat "> "
                  (Prims.strcat (nq_term_to_string t.RDF_Graph_Executable.o)
                     (Prims.strcat " <" (Prims.strcat graph_iri "> .\n"))))))
+let (nq_line_for_triple_default_graph :
+  RDF_Graph_Executable.triple -> Prims.string) =
+  fun t ->
+    Prims.strcat (nq_subject_to_string t.RDF_Graph_Executable.s)
+      (Prims.strcat " <"
+         (Prims.strcat t.RDF_Graph_Executable.p
+            (Prims.strcat "> "
+               (Prims.strcat (nq_term_to_string t.RDF_Graph_Executable.o)
+                  " .\n"))))

--- a/formal/fstar/ocaml-output/rdfc10_runner.ml
+++ b/formal/fstar/ocaml-output/rdfc10_runner.ml
@@ -189,44 +189,25 @@ let iri_to_path (iri : string) : string option =
 (* ------------------------------------------------------------------ *)
 (* N-Quads serialiser.
 
-   This is intentionally minimal — same shape as factoidal_cli's
-   term_to_ntriples plus a graph-name slot. RDFC-1.0 specifies an
-   exact canonical N-Quads format (sorted lines, specific escaping);
-   we approximate here so byte-comparison can succeed for the trivial
-   no-bnode tests in Phase 0. Phase 1+ replaces this with the
-   F\*-extracted canonical_nquads serialiser. *)
+   Delegates to RDF.NQuads.Serialize (F-star). Per CLAUDE.md rule #11
+   OCaml glue may not carry serialisation logic — the byte-correct
+   N-Quads encoding (escapes, IRI/bnode/literal forms, optional
+   graph-IRI tail) lives in formal/fstar/RDF.NQuads.Serialize.fst. *)
 
-(* Delegates to F*'s RDF.NQuads.Serialize.nq_escape_literal. The
-   local OCaml impl was a byte-for-byte duplicate; per CLAUDE.md
-   rule #11 OCaml glue may not carry serialisation logic. *)
+(* Delegates to F*'s RDF.NQuads.Serialize. Per CLAUDE.md rule #11
+   OCaml glue may not carry serialisation logic — the byte-correct
+   N-Quads encoding (escapes, IRI/bnode/literal forms, optional
+   graph-IRI tail) lives in formal/fstar/RDF.NQuads.Serialize.fst. *)
 let escape_literal_lexical : string -> string =
   RDF_NQuads_Serialize.nq_escape_literal
 
-let term_nq (t : rdf_term) : string =
-  match t with
-  | T_IRI i -> "<" ^ i ^ ">"
-  | T_BNode b -> "_:" ^ b
-  | T_Literal l ->
-    let lex = escape_literal_lexical l.lexical_form in
-    (match l.lang_tag with
-     | Some tag -> Printf.sprintf "\"%s\"@%s" lex tag
-     | None ->
-       let xsd_string = "http://www.w3.org/2001/XMLSchema#string" in
-       if l.datatype = xsd_string || l.datatype = ""
-       then Printf.sprintf "\"%s\"" lex
-       else Printf.sprintf "\"%s\"^^<%s>" lex l.datatype)
-
-let subj_nq (s : subject) : string =
-  match s with
-  | S_IRI i -> "<" ^ i ^ ">"
-  | S_BNode b -> "_:" ^ b
+let term_nq : rdf_term -> string = RDF_NQuads_Serialize.nq_term_to_string
+let subj_nq : subject  -> string = RDF_NQuads_Serialize.nq_subject_to_string
 
 let triple_nq (graph : string option) (t : triple) : string =
-  let g = match graph with
-    | Some gi -> Printf.sprintf " <%s>" gi
-    | None -> ""
-  in
-  Printf.sprintf "%s <%s> %s%s .\n" (subj_nq t.s) t.p (term_nq t.o) g
+  match graph with
+  | Some gi -> RDF_NQuads_Serialize.nq_line_for_triple gi t
+  | None    -> RDF_NQuads_Serialize.nq_line_for_triple_default_graph t
 
 (* RDFC-1.0 §3.1: the canonical form sorts the *output* quads
    lexicographically. For Phase 0 we sort to give a fighting chance


### PR DESCRIPTION
## Summary

`term_nq`, `subj_nq`, `triple_nq` in `rdfc10_runner.ml` were byte-for-byte duplicates of `nq_term_to_string`, `nq_subject_to_string`, `nq_line_for_triple` in `RDF.NQuads.Serialize.fst` (F*). Replaced with delegations.

Added `nq_line_for_triple_default_graph` to the F* module (graph-IRI optional case) since `triple_nq` supports the default graph.

- `formal/fstar/RDF.NQuads.Serialize.fst`: +3 lines (default-graph helper).
- `formal/fstar/ocaml-output/rdfc10_runner.ml`: −25 / +6 lines.

Per CLAUDE.md rule #11, OCaml glue may not carry serialisation logic.

## Test plan

- [x] F* verifies under z3 4.13.3, no `--lax`.
- [x] Re-extracted `RDF_NQuads_Serialize.ml` contains the new helper.
- [x] `rdfc10_runner --help` runs cleanly.

Track-1 quick win #3.