### PR TITLE
docs: tighten CLAUDE.md (456→194 lines), factor into skills, add markdown-style guide

### DIFF
--- a/.claude/skills/build-and-test/SKILL.md
+++ b/.claude/skills/build-and-test/SKILL.md
@@ -1,0 +1,214 @@
+---
+name: build-and-test
+description: Build, extract, compile, and test the Factoidal F* project. Use when the user asks to "run the tests", "verify F*", "build the binary", "extract OCaml", "build for JS/WASM", or wants to know how to invoke the W3C test runner. Also use when troubleshooting build-ocaml.sh, ocaml-patches.sh, or test-runner output.
+---
+
+# Build, extract, and test
+
+The `formal/fstar/build-ocaml.sh` script orchestrates F\* → OCaml extraction,
+compilation to native binaries, and the JS/WASM extraction targets. The
+W3C test runner exercises the resulting binaries against the real W3C
+test corpora vendored as a submodule.
+
+This skill assumes the toolchain is already set up. If `fstar.exe`,
+`make verify`, or `./build-ocaml.sh` fails before producing output, run
+the **fstar-env** skill first.
+
+## TL;DR
+
+```bash
+eval $(opam env --switch=fstar)
+cd formal/fstar
+
+make verify                # F* type-check + SMT discharge
+./build-ocaml.sh           # full extract + compile + test
+./build-ocaml.sh extract   # extract only
+./build-ocaml.sh compile   # compile only (skip extract; doesn't run patches)
+./build-ocaml.sh test      # run tests only
+./build-ocaml.sh js        # js_of_ocaml output
+./build-ocaml.sh wasm      # wasm_of_ocaml output (experimental)
+./build-ocaml.sh karamel   # F* → .krml (C-build pilot; krml binary install pending)
+
+cd ocaml-output
+./w3c_runner               # all SPARQL suites
+./w3c_runner --rdf         # RDF parser suites
+./w3c_runner --all         # both
+./w3c_runner --list        # list suites
+./w3c_runner bind          # specific suite(s)
+./w3c_runner -v aggregates # verbose: full expected/actual on stderr
+```
+
+## Build steps in detail
+
+### `make verify`
+
+Walks the `MODULES` list in `formal/fstar/Makefile` and writes a
+`<module>.verified` marker per module. Failure ⇒ a real spec error
+(rare during setup, common during dev). z3 wrong version ⇒ false
+errors that look like real ones; check `z3 --version` first.
+
+The `Makefile` passes `--z3version 4.13.3` via the `FSTAR` variable.
+
+### `./build-ocaml.sh extract`
+
+Runs `fstar.exe --codegen OCaml` over the hardcoded module list inside
+the script. **Each new F\* module must be added to that list** (search
+for `for fst in ... do` around line 215).
+
+Common pitfall: extract does not pass `--z3version 4.13.3` on older
+checkouts (pre-PR `claude/build-z3version-flag`). If you see
+`Unexpected Z3 version` errors, that fix is the prereq.
+
+The .ml output files in `ocaml-output/` are tracked in git.
+
+### `./build-ocaml.sh compile`
+
+Compiles the extracted .ml plus the hand-written CLI/runner wrappers
+into native binaries. **Does NOT run `ocaml-patches.sh`** — if a fresh
+extraction needs patches, use `extract` (which includes patches) or
+run `./ocaml-patches.sh` manually.
+
+Output binaries land in `bin/<platform>/` (e.g. `bin/linux-x86_64/`).
+Symlinks from `ocaml-output/` point to them. Per Iron Rule #9 the
+binaries are committed; do not skip them when staging.
+
+### `./build-ocaml.sh test`
+
+Runs unit tests. Does not run W3C tests — use `./w3c_runner` for those.
+
+### `./build-ocaml.sh js`
+
+Produces `docs/fstar-extracted/factoidal-fstar.js` via js_of_ocaml. Used
+for the demo page deployment. Optional; only relevant for browser
+deployment.
+
+### `./build-ocaml.sh wasm`
+
+Experimental wasm_of_ocaml output. Most SPARQL suites pass under wasm
+runtime but suites invoking SHA/MD5 (the `functions` suite hash tests)
+crash because stub_sha\* / caml_digestif_\* have no wasm-side binding
+yet. Vendoring or hand-writing the wasm shims is pending.
+
+### `./build-ocaml.sh karamel`
+
+C-build pilot: runs `fstar.exe --codegen krml` on a small allowlist
+of pure modules and writes `.krml` files to `krml-output/`. Currently
+extracts 5/6 candidates clean; `RDF.Format.fst` fails Warning 250
+(string-pattern match arms not supported by KaRaMeL). Final
+`.krml → .c → .a` step blocked on krml binary install.
+
+See `docs/designissues/2026-05-07-c-build-and-roaring-plan.md`.
+
+## W3C test runner
+
+Lives at `formal/fstar/ocaml-output/w3c_runner` (symlink) and in
+`bin/<platform>/w3c_runner`.
+
+### Test data discovery
+
+The runner searches a list of relative paths for the test fixture
+submodule:
+
+1. `third_party/testing/w3c/sparql/sparql11`
+2. `../../third_party/testing/w3c/sparql/sparql11`
+3. `../../../third_party/testing/w3c/sparql/sparql11`
+4. `../../tests/w3c/sparql/sparql11` (legacy)
+5. `../../../tests/w3c/sparql/sparql11` (legacy)
+6. `tests/w3c/sparql/sparql11` (legacy)
+
+If none are found, output shows zero tests. Always run from a
+directory whose ancestor contains `third_party/testing/w3c/`. The
+project root works; `formal/fstar/ocaml-output/` works.
+
+If the binary in `bin/linux-x86_64/` was built before the
+`third_party/...` paths were added, it'll only know the legacy paths
+and fail on a fresh checkout. Recompile.
+
+### Output format
+
+```
+TOTAL: 626 pass, 1 fail, 4 skip, 0 unsupported
+```
+
+Always show pass/fail/skip explicitly. Per anti-pattern #25, **never**
+write "626/631" without labels — split into pass-vs-fail and
+pass-vs-total framings if both ratios matter.
+
+The most-recent recorded run's JSON is at
+`docs/test-results/latest.json` and historical runs are in
+`docs/test-results/history/`.
+
+### Failure debugging
+
+- `-v <suite>` writes the full expected vs actual row dump to stderr.
+- FAIL lines on stdout always show the unmatched expected rows
+  inline; -v adds the actual rows.
+- For a single test: `./w3c_runner -v <suite>` then grep stderr.
+
+### Per-suite scores (May 2026)
+
+| Suite | Pass | Total |
+|---|---:|---:|
+| SPARQL 1.1 (all) | 626 | 631 |
+| RDF 1.1 N-Triples | 70 | 70 |
+| RDF 1.1 Turtle | 313 | 313 |
+| RDF 1.1 N-Quads | 87 | 87 |
+| RDF 1.1 TriG | 356 | 356 |
+| RDF 1.1 RDF/XML | 166 | 166 |
+| RDF 1.1 Model Theory | 39 | 39 |
+
+Combined: 1657 pass, 1 fail, 4 skip out of 1662. **99.94%
+pass-vs-fail**, 99.7% pass-vs-total.
+
+## W3C test data layout (submodule)
+
+```
+third_party/testing/w3c/                   git submodule (rdf-tests)
+  rdf/rdf11/rdf-n-triples/                 N-Triples syntax tests
+  rdf/rdf11/rdf-turtle/                    Turtle syntax+eval tests
+  rdf/rdf11/rdf-n-quads/                   N-Quads syntax tests
+  rdf/rdf11/rdf-trig/                      TriG syntax+eval tests
+  rdf/rdf11/rdf-xml/                       RDF/XML eval tests
+  rdf/rdf11/rdf-mt/                        Model theory / semantics
+  sparql/sparql11/                         SPARQL 1.1 (34 suites, 631 tests)
+```
+
+Initialise via `git submodule update --init --recursive` — without it
+the runner reports zero tests.
+
+## Extraction notes (F\* → OCaml)
+
+- `--codegen OCaml` erases proofs, ghost code, spec-only material.
+- Extracted .ml files use the `FStar_*` runtime from `fstar.lib`
+  (opam package).
+- `Prims.int` extracts to `Z.t` (zarith). Boundary casts: `Z.of_int`,
+  `Z.to_int`, `Z.lt` for compares, `Z.to_string` + `%s` for Printf.
+- `assume val` declarations extract as `failwith "Not yet
+  implemented"` — must be patched via `ocaml-patches.sh`.
+- `noeq` types block KaRaMeL C extraction (OCaml extraction works
+  fine).
+
+## Common build / test failures
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `Unexpected Z3 version: expected '4.8.5', got '4.13.3'` | Pre-fix build-ocaml.sh extract | Merge `claude/build-z3version-flag` or pass `--z3version 4.13.3` manually |
+| `failwith "Not yet implemented"` at runtime | Unpatched `assume val` | Run `./build-ocaml.sh extract` or `./ocaml-patches.sh` |
+| `bin/linux-x86_64/w3c_runner` shows 0 tests | Stale binary; built before submodule paths added | Rebuild: `./build-ocaml.sh` |
+| Ext fails with `MLP_Const` translate error | Module has string-pattern match arms unsupported by KaRaMeL | Refactor to `if/else if`; or omit from karamel allowlist |
+| Compile fails on `Prims.int` mismatch | OCaml int passed where Z.t expected | Add `Z.of_int` at the call site |
+
+## What this skill does NOT do
+
+- Does not set up the F\* toolchain — see the `fstar-env` skill.
+- Does not modify F\* source files.
+- Does not interpret W3C test failures as spec issues — that's a
+  judgement call for the developer.
+
+## Cross-references
+
+- `fstar-env` skill — toolchain setup, z3 install, opam switch.
+- `docs/designissues/2026-05-07-c-build-and-roaring-plan.md` —
+  KaRaMeL pilot details, krml install paths.
+- `docs/skills/testing.md` — narrative guide to running tests.
+- `docs/skills/measuring.md` — performance measurement workflow.

--- a/.claude/skills/github-and-prs/SKILL.md
+++ b/.claude/skills/github-and-prs/SKILL.md
@@ -1,0 +1,210 @@
+---
+name: github-and-prs
+description: Use the GitHub CLI (gh) for the Factoidal repository's PR / issue / branch workflow. Use when the user asks to create / view / merge a PR, list branches, audit stale branches, comment on an issue, or anything involving gh commands. The Factoidal repo's git remote uses a local proxy that confuses gh's repo inference, so all commands need an explicit --repo flag.
+---
+
+# GitHub CLI for the Factoidal repo
+
+The git remote in this project points at a local proxy
+(`http://local_proxy@127.0.0.1:.../git/danbri/factoidal`) so that pushes
+work in restricted-network environments. As a side effect, `gh` cannot
+infer the repo from the remote and fails with:
+
+```
+none of the git remotes configured for this repository point to a known GitHub host
+```
+
+**Fix: every `gh` command takes `--repo danbri/factoidal` explicitly.**
+This is the single most common failure mode and accounts for ~all
+gh-related friction in this project.
+
+## Auth setup (one-time per sandbox)
+
+If `gh auth status` reports "not logged into any GitHub hosts":
+
+### Device flow (interactive, no token needed)
+
+```bash
+curl -sX POST https://github.com/login/device/code \
+  -H "Accept: application/json" \
+  -d "client_id=178c6fc778ccc68e1d6a&scope=repo+read:org+workflow"
+```
+
+Output is JSON with `user_code`, `verification_uri`,
+`device_code`. Open `verification_uri` in a browser, enter
+`user_code`, authorize. Then poll for the token:
+
+```bash
+DEVICE_CODE=...   # from the previous response
+curl -sX POST https://github.com/login/oauth/access_token \
+  -H "Accept: application/json" \
+  -d "client_id=178c6fc778ccc68e1d6a&device_code=$DEVICE_CODE&grant_type=urn:ietf:params:oauth:grant-type:device_code" \
+  | python3 -c 'import sys,json; print(json.load(sys.stdin)["access_token"])'
+```
+
+Save the token via:
+
+```bash
+echo "<token>" | gh auth login --with-token
+gh auth status
+```
+
+The client_id `178c6fc778ccc68e1d6a` is `gh`'s public client — the
+flow is identical to what `gh auth login -w` does internally, just
+scriptable.
+
+### Personal access token (faster)
+
+If the user already has a PAT, paste it via:
+
+```bash
+echo "$GH_TOKEN" | gh auth login --with-token
+```
+
+## Branch + PR conventions
+
+### Branch naming
+
+- `claude/<topic>` for any agent or human work. Topics use kebab-case.
+- Examples: `claude/track1-rdfc10-escape-delegate`,
+  `claude/build-z3version-flag`, `claude/fstar-only-query-planning-recovery`.
+- Avoid project codenames in branch names (per the recovery plan +
+  glossary policy). Use the descriptive name for the work.
+
+### PR base
+
+- Default base branch is **`claude/main`**, not `main`.
+- Pass `--base claude/main` explicitly to gh commands.
+
+### Standard PR creation
+
+```bash
+gh pr create --repo danbri/factoidal \
+  --base claude/main \
+  --head claude/<branch> \
+  --title "..." \
+  --body "$(cat <<'EOF'
+## Summary
+- ...
+
+## Test plan
+- [ ] ...
+EOF
+)"
+```
+
+### Standard inspection
+
+```bash
+gh pr list --repo danbri/factoidal --state open
+gh pr list --repo danbri/factoidal --state merged --limit 50
+gh pr view 164 --repo danbri/factoidal
+gh pr view 164 --repo danbri/factoidal --json mergeable,mergeStateStatus
+gh pr checks 164 --repo danbri/factoidal
+```
+
+### Merging
+
+The user merges. **Don't** run `gh pr merge` yourself unless the user
+explicitly says so. PRs in this repo are reviewed and merged
+manually.
+
+### Force-push policy
+
+Force-push to a PR's head branch is acceptable when:
+
+1. The user has approved it (explicit "Y" or "yes").
+2. The branch is the user's own (or a Claude-generated branch).
+3. The remote tip has only a CI-shadow auto-commit on top of your
+   real work (clobbering the shadow is lossless).
+
+**Never** force-push:
+
+- To `claude/main` or `main`.
+- After someone else has commented on the PR (their inline review
+  comments will detach from line numbers).
+
+Use `--force-with-lease` first; fall back to `--force` only when a
+known-safe CI shadow is the cause of the lease rejection.
+
+## Branch cleanup workflow
+
+The repo accumulates `claude/<topic>` branches faster than they get
+deleted. The recipe for safe cleanup:
+
+```bash
+# 1. List all merged PRs and their head branches
+gh pr list --repo danbri/factoidal --state merged --limit 200 \
+  --json number,headRefName,title,mergedAt \
+  > /tmp/merged-prs.json
+
+# 2. List all remote branches
+git ls-remote --heads origin | awk '{print $2}' | sed 's|refs/heads/||' \
+  > /tmp/remote-branches.txt
+
+# 3. Cross-reference: branches whose head was merged are safe to delete.
+python3 -c '
+import json, sys
+prs = json.load(open("/tmp/merged-prs.json"))
+merged = {p["headRefName"]: p for p in prs}
+for line in open("/tmp/remote-branches.txt"):
+    b = line.strip()
+    if not b.startswith("claude/"): continue
+    if b in ("claude/main",): continue
+    if b in merged:
+        print(f"DELETE {b} (PR #{merged[b]['"'"'number'"'"']} merged {merged[b]['"'"'mergedAt'"'"'][:10]})")
+    else:
+        print(f"KEEP   {b} (no merged PR; check manually)")
+' | sort
+```
+
+Surface the DELETE list to the user, get explicit approval, then:
+
+```bash
+xargs -n1 git push origin --delete < /tmp/branches-to-delete.txt
+```
+
+**Never delete a branch without user approval**, even if it looks
+obviously stale. Some branches hold in-progress work that hasn't
+been pushed elsewhere.
+
+## CI
+
+This repo uses GitHub Actions. The relevant workflows:
+
+| Workflow | Path | Trigger |
+|---|---|---|
+| `check-extraction` | `.github/workflows/check-extraction.yml` | PR + push |
+| `check-fstar-purity` (Omega3) | `.github/workflows/check-fstar-purity.yml` | PR diff |
+| `w3c-tests` | `.github/workflows/w3c-tests.yml` | push to `claude/main` |
+| `check-derived-files` | `.github/workflows/check-derived-files.yml` | PR |
+| `deploy-pages` | `.github/workflows/deploy-pages.yml` | push to `claude/main` |
+| `ukparliament-bench` | `.github/workflows/ukparliament-bench.yml` | manual |
+| `debug-bytecode-build` | `.github/workflows/debug-bytecode-build.yml` | manual |
+
+The `w3c-tests` workflow auto-pushes a "ci(linux-x86_64): shadow
+build artifacts [skip ci]" commit to `claude/main` whenever the
+binaries change. PRs that have stale binaries diverge from
+`claude/main` here — usually merge-conflict on
+`bin/ci-linux-x86_64/build-info.json`. The standard fix is the
+`merge=ours` git driver (see CLAUDE.md).
+
+```bash
+gh run list --repo danbri/factoidal --limit 10
+gh run view <run-id> --repo danbri/factoidal
+gh run watch <run-id> --repo danbri/factoidal
+```
+
+## What this skill does NOT do
+
+- Does not interact with private/forked repos. Scope is
+  `danbri/factoidal` only.
+- Does not bypass review — never `gh pr merge` without user OK.
+- Does not delete branches without user approval, even when "obviously"
+  merged.
+
+## Cross-references
+
+- `fstar-env` skill — toolchain setup if `fstar.exe` is missing.
+- `build-and-test` skill — local verification before opening a PR.
+- `docs/claude-rules/anti-patterns.md` — full anti-pattern table.

--- a/.claude/skills/markdown-style/SKILL.md
+++ b/.claude/skills/markdown-style/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: markdown-style
+description: Markdown formatting rules for Claude-generated text in this repository — chat replies, design docs, READMEs, PR bodies, commit messages. Use whenever generating user-facing markdown that may be rendered in different clients (CLI, web, mobile chat, GitHub). The single load-bearing rule is "links must be unambiguously clickable" — bold/italic emphasis around URLs and link syntax frequently breaks the click target.
+---
+
+# Markdown style for Factoidal
+
+Different markdown renderers handle edge cases differently. Some
+interpret `**[link](url)**` cleanly; others fold the trailing `**`
+into the link text or URL and break the click target. This skill
+documents the patterns that work everywhere and the patterns that
+silently break in at least one renderer in regular use.
+
+The single load-bearing rule:
+
+> **Links must be unambiguously clickable. Never put emphasis
+> markers (`**`, `*`, `_`, `__`) immediately adjacent to the
+> closing `)` of a markdown link, or at the end of a bare URL.**
+
+If a link target needs visual emphasis, put the emphasis **inside**
+the link text, not around the link.
+
+## The bad patterns
+
+### Wrapping a link in bold
+
+❌ Bad:
+```
+**[Authorize here](https://github.com/login/device)**
+```
+**Why it breaks**: in some renderers (mobile chat, minimal CLI
+renderers, plain-text fall-throughs) the trailing `**` is
+ambiguous — is it bold-close, or part of the URL, or part of the
+link text? Click target may include or exclude the `**`, and the
+URL itself may show `https://...device**` to the user.
+
+✅ Good — put the bold inside the link text:
+```
+[**Authorize here**](https://github.com/login/device)
+```
+
+✅ Also good — drop the bold entirely, since a link is already
+visually distinguished:
+```
+[Authorize here](https://github.com/login/device)
+```
+
+### Bare URL followed by a bold close
+
+❌ Bad:
+```
+Open **https://github.com/login/device**
+```
+**Why it breaks**: most renderers treat bare URLs as autolinks,
+so they detect the URL and stop at the first character that
+can't be in a URL. Whether `*` counts varies by renderer. Some
+include `https://...device**` in the link target; the link
+404s.
+
+✅ Good — wrap in markdown link syntax + put any bold inside
+the text:
+```
+Open [**https://github.com/login/device**](https://github.com/login/device)
+```
+
+✅ Better — drop the bold; the URL is already visually distinct:
+```
+Open https://github.com/login/device
+```
+
+### Any emphasis adjacent to URL boundary characters
+
+❌ Bad:
+```
+Visit **https://example.com**.
+Visit *https://example.com*, then click.
+URL: __https://example.com__
+```
+
+The autolinker in most renderers treats `*` and `_` as continuation
+characters in some positions. You get either a broken link or the
+wrong characters in the link text.
+
+✅ Good — separate emphasis from URL:
+```
+Visit https://example.com.
+Visit https://example.com, then click.
+URL: https://example.com
+```
+
+### Heading-like bold lines that contain URLs
+
+❌ Bad — using `**Label: url**` as a pseudo-heading:
+```
+**URL: https://github.com/login/device**
+**Code: `AFCF-7227`**
+```
+The first line breaks the URL link; the second is fine but
+inconsistent with the first.
+
+✅ Good — promote to a real heading or use a label without bold:
+```
+URL: https://github.com/login/device
+Code: `AFCF-7227`
+```
+
+Or:
+```
+### Authorize
+
+URL: https://github.com/login/device
+Code: `AFCF-7227`
+```
+
+## Other patterns worth caring about
+
+### Code spans that contain backticks
+
+For inline code containing a literal backtick, use a longer fence
+on the outside:
+
+✅ ``Use `` `--z3version 4.13.3` `` to override the default.``
+
+### Tables
+
+Plain GFM tables only. No HTML inside cells. Right-align
+numeric columns. Each cell on one line; for multi-line content
+use a list outside the table.
+
+### Lists
+
+- `-` for unordered (consistency).
+- Numbered lists start at `1.`; let the renderer renumber.
+- One blank line between adjacent lists of different types,
+  otherwise some renderers merge them.
+
+### Links to local files
+
+Always relative paths from the repo root, in markdown link
+syntax:
+
+```
+See [recovery plan](docs/designissues/2026-05-07-query-planning-fstar-recovery.md).
+```
+
+Don't use `file://` URLs — they're machine-specific.
+
+### Line wrapping
+
+Wrap prose at 80 columns where practical. Don't wrap inside link
+syntax — keep `[text](url)` on one line so the link doesn't
+visibly split when soft-wrapping is off.
+
+## Quick checklist before sending a reply or committing a doc
+
+1. Every URL is either bare on its own (no surrounding emphasis)
+   or wrapped as `[text](url)` with any emphasis **inside** the
+   link text.
+2. No `**` or `*` directly before `[` or after `)`.
+3. No `**` immediately after a bare URL's final character.
+4. Code spans use the right number of backticks for their content.
+5. Tables are valid GFM; cells are single-line.
+
+## Why this matters in this project
+
+Factoidal docs render in many places: GitHub web UI, GitHub
+mobile, terminal `gh pr view`, the `claude.ai` chat surface, the
+Claude Code TUI, README mirrors on `npm`, and the deployed
+gh-pages dashboard. The intersection of "patterns that render
+cleanly everywhere" is smaller than the intersection of "patterns
+GitHub web accepts". Stick to the unambiguous patterns and the
+docs work everywhere.
+
+## What this skill does NOT cover
+
+- Code formatting style (covered by language-specific tooling).
+- Headings hierarchy (use what fits the doc).
+- Doc-of-truth selection (CLAUDE.md vs design docs vs skills) —
+  see CLAUDE.md.

--- a/.claude/skills/repo-tour/SKILL.md
+++ b/.claude/skills/repo-tour/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: repo-tour
+description: Get oriented in the Factoidal repository layout. Use when starting work on a fresh clone, when asked "where does X live?", or when a doc references a path that's unfamiliar. Maps the dual nature of the project (verified F* spec is the product; everything else is plumbing or build artifacts).
+---
+
+# Factoidal — repository tour
+
+The product is the F\* spec. Everything else is plumbing for getting
+the F\* code into runnable form (extraction, compilation, tests) or
+project documentation. The directory layout makes that visible.
+
+```
+factoidal/
+├── CLAUDE.md                     short-and-tight project rules
+├── README.md                     public-facing project overview
+├── formal/                       VERIFIED CORE
+│   ├── fstar/                    main F* tree (the product)
+│   │   ├── *.fst                 verified specs
+│   │   ├── Makefile              verify target
+│   │   ├── build-ocaml.sh        F* → OCaml → JS/WASM pipeline
+│   │   ├── ocaml-patches.sh      applies all glue patches
+│   │   ├── ocaml-output/         extracted .ml + symlinks to bin/
+│   │   │   ├── *.ml              extracted F* OCaml output (tracked)
+│   │   │   ├── factoidal_*.ml    hand-written CLI/HTTP wrappers (TBD relocated)
+│   │   │   ├── w3c_runner.ml     W3C test runner (hand-written wrapper)
+│   │   │   └── *_runner.ml       per-suite runners (rdfc10, owl)
+│   │   ├── minimal_regrettable_glue_code_each_with_an_open_issue/
+│   │   │   └── <issue>_*.sh      assume-val realisations + bug fixes
+│   │   ├── experimental_ocaml_glue/    Layer-2 unwind targets (rule #11 violators)
+│   │   ├── krml-output/          F* → .krml output (gitignored, C-build pilot)
+│   │   └── c-output/             krml → .c output (gitignored, future)
+│   ├── roaring/                  Roaring bitmap F* port
+│   │   ├── src/
+│   │   │   ├── Spec.fst              abstract roaring set
+│   │   │   ├── Bits.fst              popcount/tzcnt
+│   │   │   ├── Container.{Array,Bitmap,Run}.fst
+│   │   │   ├── IODemo.fst            file round-trip demo
+│   │   │   ├── Test.fst              verification-only tests
+│   │   │   ├── Makefile              standalone verify/extract/demo
+│   │   │   └── iterate.sh            one-shot verify-all loop
+│   │   ├── README.md
+│   │   └── paper/roaring.{pdf,txt}   reference paper
+│   └── third_party/              future home for vendored F* deps
+│       └── (e.g. hacl-star/ for SHA-256 — see io-verification doc)
+├── bin/                          PRE-BUILT BINARIES (committed, per Iron Rule #9)
+│   ├── darwin-arm64/             macOS Apple Silicon
+│   │   ├── factoidal             CLI binary
+│   │   └── w3c_runner            test runner
+│   ├── linux-x86_64/             Linux x86-64 (statically linked)
+│   │   ├── factoidal
+│   │   └── w3c_runner
+│   └── ci-linux-x86_64/          CI shadow build artifacts
+├── third_party/                  VENDORED CORPORA + DATA
+│   ├── testing/                  W3C test fixture submodules
+│   │   ├── w3c/                  rdf-tests submodule
+│   │   ├── rdf-canon/            RDFC-1.0 tests
+│   │   ├── csvw/                 CSVW tests
+│   │   ├── rml/                  RML tests
+│   │   ├── shex/                 ShEx tests
+│   │   ├── vc/                   Verifiable Credentials tests
+│   │   └── did/                  DID tests
+│   ├── data/                     vendored datasets (e.g. Wikidata samples)
+│   └── README.md
+├── docs/
+│   ├── claude-rules/             expanded Claude rules
+│   │   ├── anti-patterns.md      full text of the 25 numbered rules
+│   │   ├── current-state.md      F* inventory, assume-val table, scores
+│   │   ├── performance.md        Turtle parser audit, speed plan
+│   │   ├── scope.md
+│   │   └── README.md             index
+│   ├── designissues/             architecture decisions
+│   │   ├── 2026-05-07-c-build-and-roaring-plan.md
+│   │   ├── 2026-05-07-query-planning-fstar-recovery.md
+│   │   ├── 2026-05-07-io-verification-and-third-party.md
+│   │   ├── fstar-purity-unwind.md (TBD)
+│   │   ├── fstar-ocaml-boundary-audit.md (TBD)
+│   │   └── (many historical drift / fix design docs)
+│   ├── skills/                   narrative how-to docs
+│   │   ├── testing.md
+│   │   ├── measuring.md
+│   │   ├── optimising.md
+│   │   ├── improving-sparql.md
+│   │   ├── rdf-format-conversion.md
+│   │   └── periodic-review.md
+│   ├── code-name-glossary.md     Yod6 / Tet3 / etc. — historical decoder ring
+│   ├── test-results/
+│   │   ├── latest.json           most recent W3C run
+│   │   ├── history/              timestamped JSON snapshots
+│   │   └── index.html            dashboard (deployed to gh-pages)
+│   └── fstar-extracted/          js_of_ocaml output for browser demo
+├── .claude/
+│   ├── skills/                   skill files (this skill, fstar-env, etc.)
+│   ├── settings.json             permissions, hooks
+│   └── settings.local.json       local overrides
+├── .github/
+│   ├── workflows/                CI configs
+│   │   ├── check-extraction.yml
+│   │   ├── check-fstar-purity.yml      (Omega3 — rule #11 gate)
+│   │   ├── w3c-tests.yml
+│   │   └── (...)
+│   └── scripts/
+├── kgx/                          SPARQL CONSTRUCT queries (future)
+├── design_issues/                older design notes (e.g. roaring_fstar_plan.md)
+└── junk/do_not_use/              vibe-coded artifacts (DO NOT USE)
+```
+
+## "Where do I add a new ___?"
+
+| Adding | Goes in |
+|---|---|
+| F\* spec module | `formal/fstar/<Module>.fst` (or `formal/roaring/src/` for roaring) — and add to the for-loop in `build-ocaml.sh extract` and to `COMMON_MODULES` |
+| Hand-written CLI tool | Currently `formal/fstar/ocaml-output/<name>.ml`; **target home** is `bin/<consumer>/` per the recovery plan (Phase 8 of the F\*-only query-planning plan) |
+| `assume val` realisation | A patch file in `formal/fstar/minimal_regrettable_glue_code_each_with_an_open_issue/<issue>_<desc>.sh` referenced by `ocaml-patches.sh` |
+| Vendored 3rd-party F\* code | `formal/third_party/<lib>/` (see I/O verification design doc) |
+| Architecture decision doc | `docs/designissues/<YYYY-MM-DD>-<topic>.md` |
+| How-to / operational guide | `docs/skills/<topic>.md` (narrative) AND/OR `.claude/skills/<topic>/SKILL.md` (Claude-invocable) |
+| Anti-pattern war story | New numbered entry in `docs/claude-rules/anti-patterns.md`; one-line summary in `CLAUDE.md` |
+| W3C test data | Don't add — submodules. Update the submodule pin if the W3C suite version changes |
+
+## "I see X in a commit message — what's it mean?"
+
+- `Yod6`, `Tet3`, `Lamed3`, `Mem5`, `Pe5`, `Bet7`, `Tav5`, `Heth3`,
+  `Vav3`, `Psi3`, …: see `docs/code-name-glossary.md`. **No new
+  short-codes.** Use descriptive names for new things.
+- `Omega3`: F\*-purity CI gate (`.github/workflows/check-fstar-purity.yml`).
+- `Mim3`, `Mim2`: pre-warm fallback infrastructure (mostly retired).
+
+The recovery plan
+(`docs/designissues/2026-05-07-query-planning-fstar-recovery.md`)
+maps every short-code to a real name + target F\* module.
+
+## What this skill does NOT do
+
+- Doesn't navigate inside files — for that, just open them.
+- Doesn't track every tweak to the layout — major moves are
+  recorded in `docs/designissues/` plan docs.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,11 +1,19 @@
-# Factoidal — Verified RDF/SPARQL from F*
+# Factoidal — Verified RDF/SPARQL from F\*
 
-## :warning: F* Comment Syntax — DANGER :warning:
+A formally verified RDF/SPARQL implementation. The **F\* specifications are
+the product**. Executable code is obtained by **extraction**, not by
+hand-writing Rust/JS/OCaml/anything that "mirrors" a spec.
+
+> **CLAUDE.md is short on purpose.** Operational detail lives in skills
+> (`.claude/skills/<name>/SKILL.md`) and design docs
+> (`docs/designissues/`). The rules below are the ones every session must
+> have in working memory. The rest is one click away.
+
+## :warning: F\* Comment Syntax — DANGER :warning:
 
 **F\* comments `(* ... *)` support NESTING.** Any `*)` inside a comment
-prematurely closes it, and any `(*` opens a new nesting level. This means
-constructs containing `*)` will **silently corrupt the rest of your file**
-when placed inside comments.
+prematurely closes it; any `(*` opens a new nesting level. Constructs
+containing `*)` will **silently corrupt the rest of the file**.
 
 **This WILL break:**
 ```fstar
@@ -13,444 +21,174 @@ when placed inside comments.
    construct(*)
 *)
 ```
-The `*)` inside `construct(*)` closes the comment. Everything after it becomes
-code. F\* then reports a syntax error **hundreds of lines later**, making
-debugging extremely difficult.
+The `*)` inside `construct(*)` closes the comment. F\* reports a syntax
+error **hundreds of lines later**.
 
 **Safe alternatives:**
 - Reword to avoid parens-star: `(* COUNT-star special case *)`
-- Use `//` line comments (F\* supports them): `// COUNT(*) special case`
-- Escape or rephrase: `(* SELECT vars-or-star ... *)`
+- Use `//` line comments: `// COUNT(*) special case`
 
-**Rule: Never put `*)` or `(*` inside an F\* block comment.** Grep your `.fst`
-files for these sequences if you get mysterious syntax errors far from the
-actual cause.
+**Rule: Never put `*)` or `(*` inside an F\* block comment.** Same trap
+exists in the OCaml side — `(F*)` in an OCaml comment closes early; use
+`(F-star)`.
 
-## :warning: F* Reserved-Word Pitfall :warning:
+## :warning: F\* Reserved-Word Pitfall :warning:
 
-F\*'s parser treats some innocuous-looking identifiers as reserved (or
-reserved in certain positions) and reports the resulting parse failure
-with a misleading line number — usually pointing at the line **after**
-the offending name. Confirmed traps:
+F\*'s parser treats some innocuous identifiers as reserved and reports
+the resulting parse failure with a misleading line number — usually the
+line **after** the offender:
 
-- `total` — banned as a let-bound name. The error points at the next
-  let-binding. (Step-3 agent burned ~5 min on this 2026-04-30.)
-- `in_mem` — same: looks like `in` keyword to the parser in some
-  contexts.
+- `total` — banned as a let-bound name. Error points at the next let.
+- `in_mem` — looks like the `in` keyword in some contexts.
 - Anything containing `in` as a prefix where F\* expects a let-body.
 
 **Safe alternatives:** prefix with the domain noun (`triples_total`,
-`mem_dataset`). When you hit an unexplained "Syntax error" in F\* and
-the line it points at looks fine, check the line *above* for an
-identifier that could be a keyword fragment.
-
-## What This Project Is
-
-A formally verified RDF/SPARQL implementation. The **F\* specifications are the
-product**. Executable code is obtained by **extraction**, not by hand-writing
-Rust/JS/OCaml/anything that "mirrors" a spec.
+`mem_dataset`). When you hit an unexplained "Syntax error", check the
+line *above* the reported one.
 
 ## Iron Rules
 
 1. **F\* is the source of truth.** All RDF/SPARQL logic lives in `.fst` files.
-2. **Code is extracted, not hand-written.** Use `fstar.exe --codegen OCaml` (or
-   KaRaMeL for C/WASM). Never vibe-code an implementation and claim it "mirrors"
+2. **Code is extracted, not hand-written.** Use `fstar.exe --codegen OCaml`
+   or KaRaMeL for C/WASM. Never vibe-code an implementation that "mirrors"
    the spec.
-3. **assume val = acknowledged gap.** Every `assume val` must have a stub in
-   `minimal_regrettable_glue_code_each_with_an_open_issue/` (individual patch
-   files, each with a GitHub issue number in the filename). No silent holes.
-4. **Parsers belong in F\*.** RDF serialization parsers (N-Triples, Turtle,
-   N-Quads, TriG, RDF/XML, CSV/TSV results) are implemented in F\* and
-   extracted. All hand-written OCaml parsers have been removed. New parsers
-   MUST be written in F\* first.
-5. **Full SPARQL 1.1 is the target.** This includes Query, Update, Protocol,
-   SERVICE (federated query), and all result formats (XML/SRX, JSON, CSV, TSV).
-   Never default to 1.0 manifests when 1.1 exists.
-6. **Run the real W3C test files.** Read manifests, `.rq`, `.srx`, `.ttl` from
-   disk. Do not construct synthetic queries that are "inspired by" W3C tests.
-7. **No cobbling.** No hand-written JS/Rust/OCaml reimplementations of what F\*
-   defines. If you need new functionality, add it in F\* first, then extract.
-8. **RDF semantics are not optional.** The rdf-mt (model theory) tests verify
-   fundamental RDF graph semantics — literal equivalence, datatype handling,
-   language tag normalization, RDFS closure rules. These are core requirements,
-   not "just inference." Dismissing them is wrong.
-9. **Commit compiled binaries.** The compiled `w3c_runner` and `factoidal`
-   binaries live in `bin/<platform>/` (e.g., `bin/darwin-arm64/`,
-   `bin/linux-x86_64/`) and MUST be committed to git. This lets anyone
-   check out the repo and immediately run tests without needing an F\*/opam
-   toolchain. `ocaml-output/` contains symlinks to the current platform's
-   binaries. `build-ocaml.sh compile` auto-detects the platform and outputs
-   to the correct directory. Do not add binaries to `.gitignore`. Do not
-   skip them when staging.
-10. **Patches are for stubs and workarounds, NOT logic.** Post-extraction
-    patches live in `minimal_regrettable_glue_code_each_with_an_open_issue/`
-    as individual files named `<issue>_<description>.sh`. Each patch MUST
-    have a corresponding open GitHub issue. Patches may wire `assume val`
-    stubs, fix F\* type system limitations, and do forward-reference wiring.
-    They must **never** contain RDF/SPARQL semantic logic. If you find yourself
-    writing "if the entailment regime is RDFS then do X" in a patch, STOP —
-    that logic belongs in F\*. Every line of logic in a patch is unverified,
-    won't extract to C/WASM, and must be re-implemented for every target.
-    **Known violations:** blank-node-as-existential rewriting (#53).
-    When an issue is resolved (F\* replaces the patch), delete the patch
-    file. Resolved: RDFS closure + reflexivity axioms (#60) — now lives in
-    `RDF.Graph.Executable.fst` as `rdfs_closure_with_reflexivity`.
+3. **`assume val` = acknowledged gap.** Every `assume val` must have a
+   stub patch in
+   `formal/fstar/minimal_regrettable_glue_code_each_with_an_open_issue/`
+   named `<issue>_<description>.sh` with a corresponding open GitHub
+   issue. No silent holes.
+4. **Parsers belong in F\*.** RDF format parsers (N-Triples, Turtle,
+   N-Quads, TriG, RDF/XML, CSV/TSV results) are F\*-implemented and
+   extracted. New parsers MUST be written in F\* first.
+5. **Full SPARQL 1.1 is the target.** Query, Update, Protocol, SERVICE,
+   all result formats. Never default to 1.0 manifests when 1.1 exists.
+6. **Run the real W3C test files.** Read manifests, `.rq`, `.srx`,
+   `.ttl` from disk. No synthetic queries "inspired by" W3C tests.
+7. **No cobbling.** No hand-written JS/Rust/OCaml reimplementations of
+   what F\* defines. Add functionality in F\* first, then extract.
+8. **RDF semantics are not optional.** rdf-mt tests verify literal
+   equivalence, datatype handling, language-tag normalization, RDFS
+   closure rules. Core requirements, not "just inference."
+9. **Commit compiled binaries.** `bin/<platform>/factoidal` and
+   `bin/<platform>/w3c_runner` are committed so a fresh clone runs
+   tests without an F\* toolchain. `ocaml-output/` symlinks point at
+   the current platform's `bin/` dir. Do not gitignore binaries.
+10. **No `--lax`.** All F\* must verify under z3 4.13.3 with no `--lax`,
+    no `--admit_smt_queries`, no escape-hatch flags.
+11. **Inside the verified library boundary, OCaml is `assume val`
+    realisations only.** Hand-written `.ml` in
+    `formal/fstar/ocaml-output/*.ml` and patches in
+    `formal/fstar/experimental_ocaml_glue/*.sh` may only realise
+    `assume val` declarations: pure I/O (file/clock/socket),
+    host-engine call-outs (e.g. regex), or vendored crypto primitives.
+    Byte-layout for a companion file is **not** acceptable here — the
+    byte assembly belongs in F\* (`serialize : data -> Tot (list u8)`),
+    and the OCaml side reduces to `write_bytes`. Consumer tools (CLI,
+    runners, HTTP entry points) are not part of the verified library
+    and belong in `bin/<consumer>/`.
 
-11. **`experimental_ocaml_glue/` patches AND hand-written
-    `formal/fstar/ocaml-output/*.ml` files MUST NOT carry semantic
-    backend logic.** This is a stricter form of rule #10 specifically
-    for the COTTAS-on-disk perf area AND for `factoidal_http.ml`.
-    Between 2026-04-25 and 2026-04-26 the project accumulated ~3000
-    LoC of OCaml-side semantic logic (Yod6 pred-presence, Tet3 subj/
-    obj-presence, Lamed3 offset-index, Mem5 estimate fast-path, Pe5
-    explain re-impl, etc.) that REPLACED F\* runtime functions whole-
-    sale. The verified extraction story collapsed: F\* spec became
-    dead code, OCaml shims became the runtime. Reviewer 2026-04-26
-    flagged that the drift extends to `factoidal_http.ml`'s
-    timeout policy, `/backend-info.json` aggregation, and
-    `RDF_CottasStore.ml`'s caching/index policy. **No more.**
+    **Recovery plan + boundary audit + I/O verification pattern:**
+    - [`docs/designissues/2026-05-07-query-planning-fstar-recovery.md`](docs/designissues/2026-05-07-query-planning-fstar-recovery.md)
+    - [`docs/designissues/2026-05-07-io-verification-and-third-party.md`](docs/designissues/2026-05-07-io-verification-and-third-party.md)
 
-    **FREEZE (2026-04-26):** until
-    `docs/designissues/fstar-ocaml-boundary-audit.md` is complete and
-    each OCaml function has been classified (acceptable glue /
-    temporary prototype / semantic-must-migrate), no agent dispatch
-    or main-thread work may add **new** semantic behaviour to:
-      - `formal/fstar/ocaml-output/factoidal_http.ml`
-      - `formal/fstar/ocaml-output/RDF_CottasStore.ml`
-      - `formal/fstar/experimental_ocaml_glue/*.sh`
-    Bug fixes to existing logic are allowed; new features and new
-    optimisation paths are not. The boundary audit is the unblock.
-
-    **Qualified "verified" claim:** until the boundary audit is done
-    and the unwind has retired the rule-#11 violators, the project
-    must NOT be described as "verified RDF/SPARQL" without the
-    qualifier "**parser and algebra spec verified in F\*; on-disk
-    backend currently has unverified OCaml-side caching/optimisation
-    layers being migrated back to F\* (see fstar-purity-unwind.md)**".
-    READMEs, demo pages, talks, and PR descriptions must use this
-    qualification.
-
-    Allowed in `experimental_ocaml_glue/`:
-    - Realisations of `assume val` declarations (rule #3) — pure I/O, no
-      decisions about what to compute, only how to read/write bytes.
-    - Companion-file writers that build disk artifacts (Vav3-style); the
-      reader path must be in F\*.
-    - Trivial dispatch shims that call F\*-extracted code (e.g. perf
-      shadow tables that the F\* code itself decides to consult).
-
-12. **Assume the F\* opam switch is required unless you are only using
-    prebuilt binaries.** Before any `formal/fstar/build-ocaml.sh`
-    `extract`, `compile`, `js`, `wasm`, or source-level test run, do:
-    `eval $(opam env --switch=fstar)`. If `fstar.exe` is missing from
-    `PATH`, stop and activate the switch rather than burning time on
-    partial builds. Do not assume a fresh shell has the right opam
-    environment active.
-
-    Forbidden:
-    - Replacing the body of an F\*-extracted function with an OCaml
-      reimplementation (the `cottas_ondisk_search -> search_fast`
-      pattern).
-    - Adding pruning, optimisation, or query-planning logic in
-      OCaml. These belong in F\*. If F\*'s implementation is too slow,
-      MAKE F\*'s IMPLEMENTATION FAST — don't shadow it.
-    - "Shape A" agent prompts that tell an agent the F\* path is
-      bypassed so OCaml is acceptable. The opposite is now true: the
-      F\* path is the runtime. Agents may not bypass it.
-
-    **When dispatching an agent that touches the COTTAS backend or the
-    SPARQL evaluator, the prompt MUST include a clause forbidding
-    additions to `experimental_ocaml_glue/` other than the three
-    allowed cases above.** The dispatching coordinator (top-level
-    Claude) is responsible for enforcing this. If an agent's natural
-    path leads to a glue addition, re-scope the agent to write F\* +
-    `assume val` realisation only.
-
-    Layer-2 unwind (planned 2026-04-26): each existing override patch
-    is replaced by an F\* implementation. See
-    `docs/designissues/fstar-purity-unwind.md` (TBD) for the inventory
-    and order of operations.
+    **Until** the boundary audit completes and recovery Phase 9 lands,
+    the project carries the qualifier "**parser and algebra spec
+    verified in F\*; on-disk backend has unverified OCaml-side
+    optimization layers being migrated back to F\* (see fstar-purity-
+    unwind.md)**" on READMEs, demo pages, talks, and PR descriptions.
+12. **Activate the F\* opam switch before any F\* work.**
+    `eval $(opam env --switch=fstar)` — every shell, every time, before
+    `make verify` / `build-ocaml.sh` / `fstar.exe`. If `fstar.exe` is
+    missing from PATH, stop and activate; do not burn time on partial
+    builds. See the `fstar-env` skill for setup.
 
 ## Agent Work Strategy
 
-Use subagents aggressively for parallelism — launch separate agents for
-independent work (F\* verification + OCaml compile + test runs). Top-level
-Claude coordinates; never block the main loop waiting on one task when
-other work can proceed. Use `run_in_background: true` for long-running
-operations. See rules #19 / #20 / #21 for the timeout + logging discipline
-that makes this safe.
+Use subagents aggressively for parallelism — independent work
+(verification + compile + test) runs concurrently. Top-level Claude
+coordinates and never blocks the main loop. Use `run_in_background:
+true` for long-running ops.
 
-## Anti-Patterns (rules #1 – #25)
+**Per anti-pattern #23/#24:** scope every subagent to a single
+commit-sized goal; ship code sketches, not "figure it out". When
+dispatching against the COTTAS backend or evaluator, the agent prompt
+MUST forbid additions to `experimental_ocaml_glue/` other than the
+rule-#11 acceptable forms.
 
-The full text of each anti-pattern — with war-story justification, example
-bugs, and mitigation — lives in
-[`docs/claude-rules/anti-patterns.md`](docs/claude-rules/anti-patterns.md).
-The one-line summaries below are the shortcut. When a commit message says
-"per rule #17" or "anti-pattern #15", look it up there.
+## Anti-patterns (one-line summaries)
+
+Full text + war stories: [`docs/claude-rules/anti-patterns.md`](docs/claude-rules/anti-patterns.md).
+Commit messages and inline comments reference these by number ("per
+rule #17").
 
 1. Writing OCaml parsers instead of F\* parsers.
 2. Dismissing rdf-mt tests as "needing an inference engine."
 3. Reporting misleading test scores (unlabelled numerators/denominators).
 4. Building parallel OCaml toolkits instead of extending the F\* spec.
-5. Creating symlinks or hacks for version mismatches (esp. z3) — fix the env.
+5. Symlinks/hacks for version mismatches (esp. z3) — fix the env.
 6. Promoted-type blindness: handle `ER_Num`/`ER_Dec`/`ER_Dbl`/`ER_Bool`
    alongside `ER_Term(T_Literal _)` everywhere.
-7. Parser/evaluator AST mismatch: grep `SPARQL11_Parser.ml` to see what
-   the parser actually emits before adding evaluator logic.
-8. `parse_to_scaled` before `parse_double_to_scaled` — always try the
-   double-aware form first; E-notation gets mis-parsed as fractional digits
-   otherwise.
-9. Recursive string-function base cases kill metadata — handle the single-
-   element case explicitly to preserve lang tags and datatypes.
-10. OCaml `Str` regex operates on bytes, not codepoints; unmatched group
-    back-refs raise `Not_found`.
+7. Parser/evaluator AST mismatch: grep `SPARQL11_Parser.ml` first.
+8. `parse_to_scaled` before `parse_double_to_scaled` — try double-aware
+   first; E-notation gets mis-parsed otherwise.
+9. Recursive string-function base cases kill metadata — handle the
+   single-element case explicitly to preserve lang tags + datatypes.
+10. OCaml `Str` regex operates on bytes, not codepoints; unmatched
+    group back-refs raise `Not_found`.
 11. `build-ocaml.sh compile` does NOT apply `ocaml-patches.sh`. Use
-    `extract` after a fresh extraction or run the patches manually.
-12. `(*` inside F\* comments silently swallows the rest of the file.
-    Use `//` line comments when the text contains `(*` or `*)`.
-13. Never edit extracted `.ml` files in `ocaml-output/` directly — they
-    are regenerated by `./build-ocaml.sh extract`. Fix the `.fst` or add
-    a patch to `ocaml-patches.sh` instead.
-14. Never `|| true` to swallow shell failures — capture the exit code
+    `extract` after a fresh extraction.
+12. `(*` inside F\* comments silently swallows the file. Use `//`.
+13. Never edit extracted `.ml` files in `ocaml-output/` directly —
+    fix the `.fst` or add a patch.
+14. Never `|| true` to swallow shell failures — capture exit code
     explicitly (`CMD_RC=0; cmd || CMD_RC=$?`).
 15. Never sneak semantic logic into `ocaml-patches.sh` or `w3c_runner.ml`.
-    RDF/SPARQL decisions belong in `.fst` files; patches are I/O glue and
-    `assume val` wiring only.
-16. Never truncate command output with `tail -N` / `head -N` in scripts.
-    Use `tee` to save full output while streaming.
-17. Never let ad-hoc parse or SPARQL runs hang indefinitely — cap at
-    10 minutes (`timeout 600` or equivalent). Kill and shrink input on cap
-    trips; don't rerun and hope.
-18. Dump in-flight plan to `.claude-worklog.md` at checkpoints — the
-    harness persists transcripts but not in-memory plan state.
-19. Every long-running process gets a timestamped log under `.claude-runs/`,
-    runs in background, and has a hard wall-clock cap. Record start and
-    completion in `.claude-worklog.md`.
-20. Never burn clock time on the known-slow Turtle path. Launch
-    W3C-scale tests via subagent or `run_in_background`, not in the
-    foreground of the main loop.
-21. Never stall on parallel work. Push, CI, browser check in flight ≠
-    reason to wait — pick the next independent item off the queue.
-22. Subagent stall is a checkpoint, not a loss. Check `git status` /
-    `git log` / file mtimes before relaunching — the work may already
-    be on disk.
-23. Scope every subagent to a single commit-sized goal. One subagent =
-    one commit = one deliverable.
-24. Subagent prompts ship code sketches, not "figure it out". Include
-    the concrete diff, file + line, helper function signatures; cap
-    scope at one function or one rule.
+16. Never truncate command output with `tail -N` / `head -N` — use `tee`.
+17. Never let ad-hoc parse / SPARQL runs hang — cap at 10 min
+    (`timeout 600`). Kill and shrink input on cap trips.
+18. Dump in-flight plan to `.claude-worklog.md` at checkpoints.
+19. Long-running processes log to `.claude-runs/` with hard wall-clock cap.
+20. Never burn clock on the slow Turtle path — background it.
+21. Never stall on parallel work in flight; pick the next item.
+22. Subagent stall is a checkpoint, not a loss — check `git status`/log.
+23. One subagent = one commit = one deliverable.
+24. Subagent prompts ship code sketches + file:line + signatures.
 25. Never write cryptic score strings. "972/59" without labels is
     banned — write "972 pass, 59 fail (out of 1031)".
 
-## Setup
+## Skills (operational details, on-demand)
 
-### First-time clone
+- [`fstar-env`](.claude/skills/fstar-env/SKILL.md) — F\* / opam / z3
+  setup and repair.
+- [`build-and-test`](.claude/skills/build-and-test/SKILL.md) — build,
+  extract, compile, run W3C tests.
+- [`github-and-prs`](.claude/skills/github-and-prs/SKILL.md) — gh CLI
+  with `--repo danbri/factoidal`, branch + PR conventions.
+- [`repo-tour`](.claude/skills/repo-tour/SKILL.md) — directory layout,
+  "where does X live?".
 
-```bash
-git clone --recurse-submodules https://github.com/danbri/factoidal.git
-cd factoidal
-
-# If already cloned without --recurse-submodules:
-git submodule update --init --recursive
-```
-
-The W3C test files live in `third_party/testing/w3c/` (submodule pointing to
-`github.com/w3c/rdf-tests`). Without initialising the submodule, the test
-runner will have no test data.
-
-### System prerequisites
-
-```bash
-# Debian/Ubuntu
-sudo apt-get install -y opam libgmp-dev pkg-config
-
-# macOS (Homebrew)
-brew install opam gmp pkg-config
-```
-
-### F\* toolchain (opam)
-
-```bash
-# Initialize opam (first time only)
-opam init -y
-# Create the F* switch:
-opam switch create fstar ocaml-base-compiler.4.14.1
-eval $(opam env --switch=fstar)
-opam install fstar z3 js_of_ocaml js_of_ocaml-compiler zarith_stubs_js
-
-# Activate (run in every new shell)
-eval $(opam env --switch=fstar)
-```
-
-### Install z3 (CRITICAL — verification cannot work without it)
-
-**This project is about verified code. z3 is not optional.** Every session must
-ensure z3 is available before doing any F\* work. Without z3, extraction and
-verification will fail.
-
-```bash
-# Check if z3 is available:
-z3 --version  # must show 4.13.3
-
-# If z3 is missing, install the pre-built binary (opam build often fails):
-
-# Linux x86-64:
-cd /tmp
-curl -sL "https://github.com/Z3Prover/z3/releases/download/z3-4.13.3/z3-4.13.3-x64-glibc-2.35.zip" -o z3.zip
-unzip -q z3.zip
-cp z3-4.13.3-x64-glibc-2.35/bin/z3 /usr/local/bin/z3-4.13.3
-chmod +x /usr/local/bin/z3-4.13.3
-ln -sf /usr/local/bin/z3-4.13.3 /usr/local/bin/z3
-
-# macOS arm64 (Apple Silicon):
-cd /tmp
-curl -sL "https://github.com/Z3Prover/z3/releases/download/z3-4.13.3/z3-4.13.3-arm64-osx-13.7.zip" -o z3.zip
-unzip -q z3.zip
-cp z3-4.13.3-arm64-osx-13.7/bin/z3 /usr/local/bin/z3-4.13.3
-chmod +x /usr/local/bin/z3-4.13.3
-ln -sf /usr/local/bin/z3-4.13.3 /usr/local/bin/z3
-
-# macOS alternative (may not get exact version):
-brew install z3
-
-# Verify it works:
-z3-4.13.3 --version  # must show "Z3 version 4.13.3"
-```
-
-**Do NOT use `--lax` at all.** All F\* modules must verify and extract without
-`--lax`. The `--lax` flag is banned — it defeats the purpose of formal
-verification. Install z3 first, then verify and extract.
-
-
-### Quick verification
-
-```bash
-eval $(opam env --switch=fstar)
-cd formal/fstar
-
-# Verify F* specs
-make verify
-
-# Extract + compile + test
-./build-ocaml.sh
-
-# Run W3C tests (w3c_runner is built by build-ocaml.sh)
-cd ocaml-output
-./w3c_runner                    # all SPARQL suites
-./w3c_runner --rdf              # RDF parser suites
-./w3c_runner --all              # both
-./w3c_runner --list             # list suites
-./w3c_runner bind functions     # specific suites
-./w3c_runner -v aggregates      # verbose: full expected/actual dump on stderr
-```
-
-**Failure output**: FAIL lines always show UNMATCHED expected rows inline.
-Use `-v` for the full expected/actual row dump (goes to stderr).
-
-### Extraction notes
-
-- **Never use `--lax`** — all modules must verify before extraction
-- `--codegen OCaml` erases proofs, ghost code, spec-only material
-- Extracted `.ml` files use `FStar_*` runtime from `fstar.lib` opam package
-- `assume val` declarations extract as `failwith "Not yet implemented"` — must be patched
-- `noeq` types block KaRaMeL C extraction (OCaml extraction works fine)
-
-### W3C Test Suites
-
-```
-third_party/testing/w3c/                          git submodule: github.com/w3c/rdf-tests
-  rdf/rdf11/rdf-n-triples/         N-Triples syntax tests (70)
-  rdf/rdf11/rdf-turtle/            Turtle syntax+eval tests (313)
-  rdf/rdf11/rdf-n-quads/           N-Quads syntax tests (87)
-  rdf/rdf11/rdf-trig/              TriG syntax+eval tests (356)
-  rdf/rdf11/rdf-xml/               RDF/XML eval tests (166)
-  rdf/rdf11/rdf-mt/                Model theory / semantics (39)
-  sparql/sparql11/                 SPARQL 1.1 test suites (34 suites, 631 tests)
-```
-
-## Key Dependencies
-
-- `fstar` — F\* compiler (opam, 2025.12.15)
-- `z3` — SMT solver (required by F\*)
-- `fstar.lib` — F\* OCaml runtime library (opam)
-- `str` — OCaml regex library (for regex_match stub)
-- `zarith` — arbitrary-precision integers (F\* extracts `Prims.int` as `Z.t`)
-- `js_of_ocaml` — OCaml to JavaScript compiler (optional)
-- `zarith_stubs_js` — bigint stubs for js_of_ocaml (optional)
-- `libgmp-dev` — system package required by zarith (apt-get)
-
-## GitHub CLI (`gh`) in Claude Code
-
-The git remote uses a local proxy (`127.0.0.1`), so `gh` commands that infer
-the repo from the remote will fail with "none of the git remotes configured
-for this repository point to a known GitHub host." **Fix: always pass
-`--repo danbri/factoidal` explicitly.**
-
-```bash
-# These work:
-gh pr create --repo danbri/factoidal --base claude/main --head my-branch ...
-gh pr list --repo danbri/factoidal
-gh pr view 42 --repo danbri/factoidal
-
-# This does NOT work (no --repo):
-gh pr create --base claude/main ...  # ERROR: unknown host
-```
-
-## Expanded Docs
-
-The three sections below used to live in this file; they grew too long to
-load into every session's context. They're now separate:
+## Expanded docs (full reference)
 
 - [`docs/claude-rules/anti-patterns.md`](docs/claude-rules/anti-patterns.md)
-  — full text of the 25 numbered anti-pattern rules summarised above.
+  — full anti-pattern text with war stories.
 - [`docs/claude-rules/performance.md`](docs/claude-rules/performance.md)
-  — Known Performance Issues, esp. the Turtle parser audit + speed plan.
+  — Turtle parser audit + speed plan.
 - [`docs/claude-rules/current-state.md`](docs/claude-rules/current-state.md)
-  — Current State (Honest Assessment): F\* inventory, `assume val` table,
-  verification gaps, W3C suite scores, phased plan.
-- [`docs/code-name-glossary.md`](docs/code-name-glossary.md) — when you see
-  `Yod6`, `Tet3`, `Lamed3`, `Mem5`, `Pe5`, `Vav3`, `Bet7`, `Tav5`, `Heth3`,
-  etc. in a doc / commit / trace tag and don't know what it means, look
-  it up here. **No new short-codes** — name new things descriptively.
+  — F\* inventory, `assume val` table, W3C scores.
+- [`docs/code-name-glossary.md`](docs/code-name-glossary.md) — Yod6 /
+  Tet3 / Lamed3 / etc. decoder. **No new short-codes** — use
+  descriptive names per the recovery plan.
+- [`docs/claude-rules/README.md`](docs/claude-rules/README.md) — index
+  and the relationship between this file and the expanded docs.
 
-See also [`docs/claude-rules/README.md`](docs/claude-rules/README.md) for
-an index and for the relationship between this file and the expanded docs.
+## Recovery + planning docs
 
-## Repository Structure
-
-```
-factoidal/
-├── formal/fstar/              THE PRODUCT
-│   ├── RDF.Graph.Executable.fst   RDF graph types + operations
-│   ├── SPARQL11.Algebra.fst       SPARQL 1.1 algebra + evaluator
-│   ├── SPARQL11.Parser.fst        SPARQL parser (in development)
-│   ├── Parser.*.fst               RDF format parsers (combinators, Turtle, etc.)
-│   ├── Makefile
-│   ├── build-ocaml.sh
-│   ├── ocaml-patches.sh               applies patches from glue directory
-│   ├── minimal_regrettable_glue_code_each_with_an_open_issue/
-│   │   ├── 53_blank_node_variable_rewriting.sh
-│   │   ├── 62_forward_ref_wiring.sh
-│   │   ├── 63_regex_hash_uuid_stubs.sh
-│   │   ├── 64_sparql_parser_escape_stubs.sh
-│   │   ├── 65_base_iri_resolution.sh
-│   │   ├── 66_zero_length_property_path.sh
-│   │   ├── 67_rdfxml_validation.sh
-│   │   ├── 68_unicode_boundary_workarounds.sh
-│   │   └── 69_runner_io_glue.sh
-│   └── ocaml-output/          extracted .ml + symlinks to bin/<platform>/
-├── bin/                       pre-built binaries per platform
-│   ├── darwin-arm64/          macOS Apple Silicon
-│   │   ├── factoidal
-│   │   └── w3c_runner
-│   └── linux-x86_64/         Linux x86-64 (statically linked)
-│       ├── factoidal
-│       └── w3c_runner
-├── third_party/testing/w3c/                 git submodule (W3C test files)
-├── kgx/                       SPARQL CONSTRUCT queries (future)
-├── docs/
-│   ├── claude-rules/          expanded Claude rules (anti-patterns, perf, state)
-│   ├── designissues/          architecture docs
-│   └── skills/                operational knowledge
-├── junk/do_not_use/           vibe-coded artifacts (DO NOT USE)
-└── CLAUDE.md                  this file
-```
+- [`docs/designissues/2026-05-07-query-planning-fstar-recovery.md`](docs/designissues/2026-05-07-query-planning-fstar-recovery.md)
+  — F\*-only recovery roadmap; replaces the OCaml shadow logic
+  (Yod6/Tet3/Lamed3/Mem5/Pe5/Bet7/Tav5/Heth3) with proper F\*
+  modules.
+- [`docs/designissues/2026-05-07-io-verification-and-third-party.md`](docs/designissues/2026-05-07-io-verification-and-third-party.md)
+  — hash-based round-trip verification pattern; HACL\* / EverParse
+  vendoring policy; corrected boundary-audit taxonomy.
+- [`docs/designissues/2026-05-07-c-build-and-roaring-plan.md`](docs/designissues/2026-05-07-c-build-and-roaring-plan.md)
+  — KaRaMeL C-build pilot + Roaring continuation tracks.

--- a/docs/designissues/2026-05-07-io-verification-and-third-party.md
+++ b/docs/designissues/2026-05-07-io-verification-and-third-party.md
@@ -1,0 +1,348 @@
+# 2026-05-07 — I/O verification + third-party crypto/format vendoring
+
+Companion to
+[`2026-05-07-query-planning-fstar-recovery.md`](2026-05-07-query-planning-fstar-recovery.md).
+Phase 0 of the recovery plan demands a boundary audit; this doc
+gives the audit its taxonomy for each remaining `assume val` and
+each system-I/O bridge.
+
+## The hash-based round-trip pattern
+
+For every companion file the project writes, the byte layout
+must be defined in F\*. We can't verify the OS `write(2)` itself
+— that's outside any feasible verification target — but we can
+build a **round-trip witness** that proves byte-equivalence of
+what F\* asked to write and what's actually on disk.
+
+The pattern:
+
+```fstar
+// In F*: byte-level format spec.
+val serialize : data -> Tot (list u8)
+val parse     : list u8 -> Tot (option data)
+val serialize_parse_roundtrip
+  (d : data) :
+  Lemma (parse (serialize d) == Some d)
+
+// Hash the F*-side byte representation.
+val expected_digest : data -> Tot sha256_digest
+let expected_digest d = sha256 (serialize d)
+
+// In OCaml: pure I/O realisations. No decisions.
+assume val write_bytes : path:string -> bytes:list u8 -> ML unit
+assume val read_bytes  : path:string -> ML (list u8)
+
+// Test in F*: the on-disk file matches the F*-computed bytes.
+val verify_file_matches : data -> path:string -> ML bool
+let verify_file_matches d p =
+  let actual_digest = sha256 (read_bytes p) in
+  expected_digest d = actual_digest
+```
+
+The CI gate is a unit test, not a verification proof: for every
+companion-file format defined in F\*, the test generates sample
+data, calls `write_bytes`, reads it back, hashes both sides, and
+asserts equality.
+
+What this catches:
+
+- Byte-level corruption from a bug in the OCaml writer (e.g.
+  off-by-one, endian mistake, truncated buffer).
+- Drift between the F\* serializer and the OCaml writer if anyone
+  re-introduces semantic logic on the OCaml side.
+- Reader/writer mismatch (parse roundtrip property is checked
+  separately by the F\* lemma).
+
+What it doesn't catch:
+
+- Corruption introduced by the filesystem after the test passes.
+- Storage-medium failures (bad sectors, etc.).
+
+Both of those are out of scope for any practical verification
+strategy. The hash check is the strongest property we can claim
+short of formal modelling of the OS.
+
+## SHA-256 — vendor HACL\*
+
+For the round-trip pattern above we need a hash function inside
+F\* with proven correctness. HACL\* is the obvious choice.
+
+[HACL\*](https://github.com/hacl-star/hacl-star) is a verified
+cryptographic library written in F\*, compiled to C via KaRaMeL,
+with OCaml bindings available as the `hacl-star` opam package. It
+implements SHA-224/256/384/512, BLAKE2, ChaCha20, AES, Curve25519,
+Ed25519, and more — verified for memory safety, constant-time
+behaviour, and functional correctness. Production deployments
+include Mozilla Firefox NSS, the Linux kernel, mbedTLS, the
+Tezos blockchain, ElectionGuard, and Wireguard.
+
+For our use case (file-integrity hashing in tests) we only need
+SHA-256.
+
+### Integration plan
+
+Two modes:
+
+**Mode A — opam dependency (start here).**
+- Add `hacl-star` (currently 0.6.x) to the project's opam deps in
+  CLAUDE.md and CI.
+- Declare in F\*:
+  ```fstar
+  module ThirdParty.HACL
+
+  // SHA-256 over a list of bytes.
+  // Realised by an OCaml binding to HACL*'s verified C
+  // implementation. We trust HACL*'s upstream proof here; we
+  // don't reverify in our own F* tree.
+  assume val sha256 : list FStar.UInt8.t -> Tot (digest:list FStar.UInt8.t {length digest = 32})
+
+  // (Add other primitives as needed.)
+  ```
+- OCaml realisation patch: `let sha256 = Hacl_star.Hacl.SHA2_256.hash`
+  (with the bytes ↔ list-u8 marshalling shim).
+
+**Mode B — vendor the F\* sources (when stricter trust required).**
+- Place HACL\*'s relevant `.fst` files in
+  `formal/third_party/hacl-star/sha2/`.
+- Verify and extract them in our own toolchain.
+- Pin the upstream commit in `formal/third_party/hacl-star/VERSION`.
+
+Mode A is fine for the round-trip witness use. Mode B becomes
+necessary if a compliance audit demands an end-to-end verified
+chain inside our repo.
+
+### Why not write our own SHA-256
+
+We could. It's a few hundred lines of F\*. But:
+
+- HACL\*'s SHA-256 is verified for **constant-timeness** in
+  addition to functional correctness — a property our hand-roll
+  would not have.
+- Reimplementing means our hash differs from the de-facto F\*
+  community hash, with no benefit.
+- The C extraction route via KaRaMeL is the same either way; HACL\*
+  is exactly the kind of code KaRaMeL was designed for.
+
+## EverParse — keep an eye on, don't depend on yet
+
+[EverParse](https://github.com/project-everest/everparse)
+generates verified, secure parsers for binary formats from
+declarative DSLs (LowParse + 3D + QuackyDucky). Used in production
+by Windows Hyper-V to validate every Azure network packet.
+
+It's the right tool for **future** companion-file formats and for
+the SPARQL Protocol-over-the-wire stack (TLS already uses it via
+miTLS). Not necessary for the current recovery work, which sticks
+to bespoke byte layouts in plain F\*.
+
+When we add a new on-disk file format (e.g. for the offset-index
+in the recovery plan's Phase 6), reach for EverParse rather than
+hand-rolling — it gives parser/formatter pairs with the
+serialize-parse-roundtrip lemma for free.
+
+## UUID — implement RFC 4122 in F\*
+
+No verified F\* UUID library exists. RFC 4122 is small (16 bytes
+with specific bit patterns); we implement it ourselves.
+
+```fstar
+module ThirdParty.UUID
+
+module U8 = FStar.UInt8
+
+// 16-byte UUID. All UUIDs are 16 bytes by definition.
+type uuid = bs:list U8.t {length bs = 16}
+
+// UUID v4 (random) per RFC 4122 §4.4:
+//   octet 6 high nibble = 0100  (version 4)
+//   octet 8 high two bits = 10  (variant DCE 1.1)
+val uuid_v4_format : uuid -> bool
+let uuid_v4_format bs =
+  let octet6 = index bs 6 in
+  let octet8 = index bs 8 in
+  U8.((octet6 &^ 0xF0uy) = 0x40uy) &&
+  U8.((octet8 &^ 0xC0uy) = 0x80uy)
+
+// Construct a v4 UUID from 16 random bytes by setting the
+// version+variant bits. This is the byte-format conversion;
+// randomness comes from outside.
+val mk_v4 : raw:list U8.t {length raw = 16} -> Tot (u:uuid {uuid_v4_format u})
+let mk_v4 raw =
+  let raw6 = index raw 6 in
+  let raw8 = index raw 8 in
+  // (set high nibble of raw6 to 4, top two bits of raw8 to 10)
+  // ...byte mutation via list update; F* helper code...
+
+// Source of randomness — realised by OCaml's Random or HACL*'s
+// CSPRNG depending on whether crypto-strength is required.
+assume val random_bytes : n:nat -> ML (bs:list U8.t {length bs = n})
+
+val gen_v4 : unit -> ML uuid
+let gen_v4 () = mk_v4 (random_bytes 16)
+```
+
+The format function `uuid_v4_format` is decidable; we can prove
+`mk_v4 raw` produces a `uuid` satisfying it for any 16-byte input.
+The OCaml side is one realisation: `random_bytes` calls
+`Random.bits` (non-crypto) or `Hacl_star.Hacl.RandomBuffer`
+(CSPRNG), depending on the use site.
+
+CLAUDE.md issue #63 (`63_regex_hash_uuid_stubs.sh`) currently
+realises UUID via OCaml; this design replaces that patch with a
+verified F\* byte-format function plus a single `assume val
+random_bytes` realisation.
+
+## Regex — keep `assume val regex_match`
+
+Regex matching is **explicitly host-defined** by the SPARQL 1.1
+spec. The pattern language and matching semantics are deferred
+to the implementation's regex engine, with a small subset
+mandated. Verifying the regex semantics ourselves is therefore
+not just hard but **wrong** — it would create a divergence from
+what every other SPARQL engine does.
+
+The right pattern:
+
+```fstar
+// SPARQL REGEX call-out. Pattern flags: "i" (case-insensitive),
+// "s" (dot matches newline), etc. Semantics defined by the host
+// regex engine; no F* proof obligations on the matcher itself.
+assume val regex_match
+  (pattern : string)
+  (input   : string)
+  (flags   : string)
+  : ML bool
+```
+
+The OCaml side calls `Str.regexp_string` / `Str.string_match` (or
+better, `Re` for PCRE compatibility). Other targets:
+- C extraction: link against POSIX `<regex.h>` or PCRE2.
+- WASM: ship a regex engine with the WASM bundle (or use the
+  host's via JS interop).
+
+This is rule #11(a) — an `assume val` realisation of pure I/O
+(in this case, "I/O" with the regex engine as the foreign service).
+It is correctly **not** in scope for migration into F\*.
+
+CLAUDE.md issue #63 covers this. Resolution for the issue: drop
+the migration goal; accept that regex semantics are externally
+defined.
+
+## Random — `assume val` per quality tier
+
+Two distinct uses:
+
+**Cryptographic randomness** (used by UUID v4, future
+challenge/nonce flows):
+```fstar
+assume val random_bytes_csprng : n:nat -> ML (bs:list U8.t {length bs = n})
+```
+OCaml realisation: `Hacl_star.Hacl.RandomBuffer.randombytes`.
+Same on C-extraction (HACL\* native).
+
+**Non-crypto randomness** (test data, blank-node naming where
+collision-resistance ≠ security):
+```fstar
+assume val random_bytes_weak : n:nat -> ML (bs:list U8.t {length bs = n})
+```
+OCaml realisation: `Random.bits`. C-extraction: `arc4random` or
+similar.
+
+Two distinct `assume val`s rather than one parameterized by a
+quality flag, because mistakenly reaching for the weak source in
+a security context would be a silent vulnerability.
+
+## `formal/third_party/` — vendoring directory pattern
+
+```
+formal/third_party/
+├── README.md                        -- vendoring policy
+├── hacl-star/                       -- (vendored when Mode B kicks in)
+│   ├── VERSION                      -- upstream commit pin
+│   ├── LICENSE                      -- HACL*'s Apache 2.0
+│   └── sha2/                        -- only the SHA-256 .fst files we use
+└── (future) everparse/              -- when an on-disk format wants verified parsing
+    └── ...
+```
+
+Policy (in `formal/third_party/README.md`):
+
+1. Each dependency lives in its own subdirectory.
+2. Each subdir has `VERSION` (upstream commit + date),
+   `LICENSE` (verbatim from upstream), and just-enough `.fst`
+   files for our actual usage.
+3. **No editing.** If a vendored file needs to change, propose
+   the change upstream first; if blocked, document the local
+   deviation in `LOCAL_PATCHES.md` next to the file.
+4. Bumping a dependency is a single PR with the new VERSION,
+   the new `.fst` content, and any forced re-extractions.
+5. The main extract step in `build-ocaml.sh` includes
+   `formal/third_party/<dep>/*.fst` automatically.
+
+For now (Mode A) only the README is needed; the actual vendoring
+waits until we want a closed-loop verification chain.
+
+## Boundary audit taxonomy update
+
+Phase 0 of the recovery plan classifies every OCaml-side function.
+Add these categories to the audit's classification scheme:
+
+| Category | Example | Status |
+|---|---|---|
+| `assume val` realisation — pure I/O | `write_bytes`, `read_bytes`, system clock | ALLOWED |
+| `assume val` realisation — host-engine call-out | `regex_match` | ALLOWED (semantics deferred to host) |
+| `assume val` realisation — vendored crypto | `sha256` via HACL\* | ALLOWED (Mode A) |
+| `assume val` realisation — randomness | `random_bytes_csprng`, `random_bytes_weak` | ALLOWED (per quality tier) |
+| Companion-file writer with byte-layout logic | (current Vav3 reality TBD by audit) | VIOLATION — migrate to F\* serialise + `write_bytes` realisation |
+| Consumer / binding | `factoidal_cli.ml`, runners | OUT OF SCOPE — relocate to `bin/` |
+| Semantic shadow | Yod6/Tet3/Lamed3/Mem5/Pe5/Bet7/Tav5/Heth3 | VIOLATION — migrate per recovery plan |
+
+The hash-based round-trip witness applies to every "companion-file
+writer" entry: once the byte layout moves to F\* and the OCaml
+side becomes a `write_bytes` realisation, we run a CI test that
+hashes the F\*-computed bytes against the on-disk bytes. Passing
+the test is the proof the boundary holds.
+
+## What this gives the recovery plan
+
+- **Phase 0 (boundary audit)** classifies every OCaml file
+  against the table above. The "VIOLATION" rows enumerate the
+  remaining migration work.
+- **Phases 1-7** retire violations. Each companion-file writer
+  migration adds:
+  - F\* `serialize` + parse + roundtrip lemma
+  - `assume val write_bytes` realisation
+  - CI test using `expected_digest` ↔ `sha256 (read_bytes path)`
+- **Phase 8 (consumer relocation)** physically separates the
+  things that aren't in scope (CLI, runners) from the verified
+  library proper.
+- **Phase 9 (drop the qualifier)** — when the audit shows zero
+  VIOLATION rows and the round-trip tests are green in CI, the
+  rule #11 caveat comes off and the project can call itself
+  "verified RDF/SPARQL" without footnotes.
+
+## Summary of the third-party policy
+
+| Need | Source | Trust model |
+|---|---|---|
+| SHA-256 | `hacl-star` opam package (Mode A) → vendored `.fst` (Mode B) | Trust HACL\* upstream proof; verify locally via Mode B if compliance demands |
+| Verified parsers (future) | EverParse | Trust upstream; vendor when used |
+| UUID format | Implement in F\* (RFC 4122 byte assembly) | Self-verified |
+| Regex matching | `assume val regex_match` realised by host (`Str` / PCRE2 / JS) | Host-engine-defined per SPARQL 1.1 |
+| Crypto random bytes | HACL\* `RandomBuffer` realisation of `assume val random_bytes_csprng` | HACL\* upstream |
+| Weak random bytes | OCaml `Random.bits` realisation of `assume val random_bytes_weak` | Non-crypto by design |
+
+Under this policy the project never silently mixes verified and
+unverified code paths. Every external dependency is named, its
+trust model documented, and the migration target known.
+
+## References
+
+- [HACL\* — formally verified cryptographic library](https://github.com/hacl-star/hacl-star)
+- [HACL\*/EverCrypt manual](https://hacl-star.github.io/index.html)
+- [`hacl-star` opam package (0.6.x)](https://ocaml.org/p/hacl-star/0.6.1)
+- [EverParse — verified secure parsers](https://github.com/project-everest/everparse)
+- [Project Everest](https://project-everest.github.io/)
+- [RFC 4122 — UUID URN Namespace](https://datatracker.ietf.org/doc/html/rfc4122)
+- [Brzozowski-derivative regex — verified Idris implementation](https://github.com/MathiasVP/idris-regex)
+  (reference for if/when we want a fully F\*-verified regex)

--- a/docs/designissues/2026-05-07-query-planning-fstar-recovery.md
+++ b/docs/designissues/2026-05-07-query-planning-fstar-recovery.md
@@ -1,0 +1,258 @@
+# 2026-05-07 — Query planning & storage abstraction: recovery into F\*
+
+## Status
+Plan. Drafted in response to "this was a disaster" feedback on the
+project's drift of query-planning + access-method logic into
+post-extraction OCaml patches.
+
+## What went wrong
+
+Between roughly 2026-04-25 and 2026-04-26, the COTTAS on-disk path
+acquired a series of "fast paths" — predicate-presence row-group
+prune, subject/object-presence prune, per-RG predicate offset index,
+estimate-from-presence-bitmap, --explain mode, lazy hashtable
+populate, row-cap circuit breaker, SIGALRM timeout. Each landed as
+an `experimental_ocaml_glue/*.sh` patch that ran *after* F\*
+extraction and inserted the optimization directly into
+`formal/fstar/ocaml-output/RDF_CottasStore.ml` (or sibling files).
+
+This had three consequences, all bad:
+
+1. **The verified core became dead code.** The F\* implementation
+   of `cottas_ondisk_search` / `_estimate` is faithful but slow.
+   The OCaml-side shadows are fast but unverified. Production
+   queries flow through the shadows. The F\* module is decorative.
+2. **The "verified" claim collapsed.** A query against a COTTAS
+   store can take a wrong-answer path through the shadow that the
+   F\* spec never sanctioned. CLAUDE.md rule #11 acknowledges this
+   with a "qualified verified" footnote that has to appear on
+   every README, demo page, and talk slide.
+3. **Multi-target extraction is impossible.** KaRaMeL extracts
+   F\* modules to C; `js_of_ocaml` extracts the OCaml files. The
+   shadow patches are post-extraction OCaml manipulations — they
+   cannot extract to C, Rust, or WASM. The SPARQL evaluator a C
+   consumer would link against is the slow F\*-only path.
+
+The shadow patches were also internally tagged with subagent
+codenames (Yod6, Tet3, Lamed3, Mem5, Pe5, Bet7, Tav5, Heth3) that
+communicate nothing to a reader. The codenames stuck in trace tags,
+commit messages, and even in `docs/code-name-glossary.md`.
+
+This plan retires the entire pattern.
+
+## Principle
+
+> **Every RDF/SPARQL semantic decision lives in F\*. OCaml is a
+> realisation language for `assume val` declarations only. Tools
+> that wrap the verified library (CLI, HTTP server, runners) are
+> consumers — they may live in any host language and are not
+> claimed to be verified.**
+
+Concrete consequences:
+
+- A "query plan" is an F\* value of an F\* type. The planner is a
+  pure F\* function. The evaluator consumes that value.
+- A "storage abstraction" is an F\* signature. Each concrete store
+  (in-memory, COTTAS, HDT, future Parquet) implements it.
+- An "optimization" is an F\* function from a storage view + a
+  query fragment to a faster equivalent computation, with a
+  correctness lemma `denote(optimised) = denote(naive)`.
+- The only OCaml inside `formal/fstar/ocaml-output/` is what F\*
+  extracts. Hand-written `factoidal_*.ml`, `*_runner.ml` etc. move
+  to `bin/<consumer>/`. They become call-sites, not logic.
+
+## Storage abstraction map
+
+The recovery makes "which operations require which storage
+capabilities" explicit. Capabilities compose: a COTTAS store has
+all of them; an in-memory store has the bottom row only.
+
+| Capability | Operation | Required by |
+|---|---|---|
+| **Term lookup** | `lookup : tp -> bindings list` | every store |
+| **Counting** | `count : tp -> nat` | every store |
+| **Cheap estimate** | `estimate : tp -> nat` (may be approximate) | optional; falls back to `count` |
+| **RG enumeration** | `row_groups : list rg_id` | columnar stores |
+| **Presence bitmap** | `presence : (col, rg) -> bitmap` | columnar stores w/ presence |
+| **Offset index** | `offset_of : (rg, predicate_id) -> option offset` | columnar stores w/ offset index |
+| **Page cache** | `page_for : (rg, col, page_id) -> bytes` | columnar stores w/ paging |
+| **Companion files** | `read_companion : path -> bytes` | columnar stores w/ on-disk artifacts |
+
+Capabilities are F\* type classes / record-of-functions / refinement
+predicates depending on which extracts cleanest to C. Initial
+proposal: a record of optional functions, with each capability
+detected via `Some f`. This avoids polymorphism KaRaMeL doesn't like.
+
+## Proposed module layout
+
+Descriptive names, no codenames. Storage axis is explicit in the
+hierarchy. New modules listed below; existing modules retained
+verbatim where they already make sense.
+
+```
+RDF.Store/
+  RDF.Store.Capabilities.fst         -- the contract (record of capability-fns)
+  RDF.Store.InMemory.fst             -- (renames RDF.CottasInMem)
+  RDF.Store.Columnar/
+    RDF.Store.Columnar.RowGroup.fst       -- RG-level operations (existing pieces collected)
+    RDF.Store.Columnar.PresenceBitmap.fst -- (existing) + prune predicates
+    RDF.Store.Columnar.CompoundPresence.fst -- (existing)
+    RDF.Store.Columnar.OffsetIndex.fst    -- NEW: per-RG predicate row-offset index
+    RDF.Store.Columnar.PageCache.fst      -- (existing)
+    RDF.Store.Columnar.CompanionFiles.fst -- file format spec for on-disk artifacts
+  RDF.Store.COTTAS.fst              -- (renames RDF.CottasStore) wires Columnar.*
+  RDF.Store.HDT.fst                 -- (existing-ish; explicit Capabilities instance)
+
+SPARQL.Plan/
+  SPARQL.Plan.BoundStatus.fst       -- (lifted from SPARQL.Explain) BS_Var/Hit/Miss/Other
+  SPARQL.Plan.Pruning.fst           -- "can this RG possibly match this tp?" predicate
+  SPARQL.Plan.Estimate.fst          -- cardinality estimation (cheap path + naive fallback)
+  SPARQL.Plan.AccessPath.fst        -- "given a tp + a Capabilities, what's the cheapest reader?"
+  SPARQL.Plan.Explain.fst           -- plan introspection, JSON renderer
+  SPARQL.Plan.Loader.fst            -- companion-file-present? if not, fall back to in-RAM build
+
+SPARQL.Eval/
+  SPARQL.Eval.Iterator.fst          -- streaming iteration primitives (take, drop, fold)
+  SPARQL.Eval.Limits.fst            -- row-cap circuit breaker (a LIMIT for evaluation policy)
+  SPARQL.Eval.TimeBudget.fst        -- cooperative cancellation; assume val now : ML clock
+```
+
+Notes:
+- `SPARQL.Plan.*` are pure F\*. They take a `Capabilities` value
+  and a `triple_pattern` / sub-query and produce a plan or estimate.
+  Multi-target extractable.
+- `SPARQL.Eval.*` are also pure F\* except `TimeBudget`, which
+  requires a single `assume val now_ms : unit -> ML int`. That
+  realisation is the ONLY allowed OCaml/C-side thing.
+- Storage hierarchy mirrors the access-pattern hierarchy: an
+  in-memory store implements only `Capabilities.basic`; a
+  COTTAS store implements `Capabilities.basic + columnar +
+  presence + offset_index + page_cache`.
+
+## Mapping the disaster onto real names
+
+| Old codename | What it is | Right F\* home | Effort |
+|---|---|---|---|
+| **Yod6** | Predicate-presence RG-skip predicate | `SPARQL.Plan.Pruning.fst`, consuming `RDF.Store.Columnar.PresenceBitmap` | S |
+| **Tet3** | Subject/object-presence RG-skip predicate | same module + `CompoundPresence` | S |
+| **Lamed3** | Per-RG predicate row-offset index lookup | new `RDF.Store.Columnar.OffsetIndex.fst` reader + `SPARQL.Plan.AccessPath` chooses it | M |
+| **Mem5** | Cardinality estimate from presence bitmap | `SPARQL.Plan.Estimate.fst`, calls into `Columnar.PresenceBitmap` | S |
+| **Pe5** | --explain mode plan dump | `SPARQL.Plan.Explain.fst` (extends what's already in `SPARQL.Explain.fst`) | M |
+| **Bet7** | Lazy hashtable populate when companion file missing | `SPARQL.Plan.Loader.fst` decision; `RDF.Store.InMemory.fst` builder | S |
+| **Tav5** | Result-row cap | `SPARQL.Eval.Limits.fst` (a `take n stream` combinator) | XS |
+| **Heth3** | Per-query timeout | `SPARQL.Eval.TimeBudget.fst` + `assume val now_ms` realisation | M |
+
+Effort: XS=<30min, S=<2h, M=half-day, L=multi-day.
+
+Total effort estimate to retire all 8: ~2-3 weeks of focused work
+plus reviews. Most modules build on `RDF.Store.Columnar.*` and
+`RDF.Store.Capabilities.fst`, which themselves are ~1 week of
+careful design + proof.
+
+## Sequencing
+
+Strictly ordered; later steps depend on earlier ones.
+
+| Phase | Deliverable | Output | Blockers |
+|---|---|---|---|
+| **0. Boundary audit** | `docs/designissues/fstar-ocaml-boundary-audit.md`: every OCaml fn classified (extracted-pure / `assume val` realisation / consumer / **violation-must-migrate**); every shadow patch enumerated. | One doc PR. | None. Unblocks rule #11 freeze. |
+| **1. Capabilities contract** | `RDF.Store.Capabilities.fst`: the record-of-functions interface. `RDF.Store.InMemory.fst` retitled and made the reference impl (lowest capability set). | One PR. | Audit complete. |
+| **2. Columnar layer** | `RDF.Store.Columnar.RowGroup.fst` + reorg of existing `Columnar.PresenceBitmap`, `CompoundPresence`, `PageCache`. No semantic change yet — pure namespace + capability binding. | One PR. | Phase 1. |
+| **3. Easy violators** | Migrate Tav5 + Bet7 in parallel. Each retires its glue patch. | 2 PRs. | Phase 2 (Bet7); Phase 1 (Tav5). |
+| **4. Pruning + estimate** | `SPARQL.Plan.Pruning.fst` + `SPARQL.Plan.Estimate.fst`. Retires Yod6, Tet3, Mem5 simultaneously (they share the presence-bitmap reader). | 1 PR. | Phase 2. |
+| **5. Time budget** | `SPARQL.Eval.TimeBudget.fst` design PR + `assume val now_ms` realisation glue + `SPARQL.Eval.Limits.fst` for `--max-rows` interaction. Retires Heth3. | 2 PRs (design + migration). | Phase 3 done. |
+| **6. Offset index** | `RDF.Store.Columnar.OffsetIndex.fst` (new file format spec + verified reader) + `SPARQL.Plan.AccessPath.fst` chooses it. Retires Lamed3. **Performance-critical**: must preserve the 6s → 200ms win. Benchmark required. | 1-2 PRs. | Phase 4. |
+| **7. Explain** | `SPARQL.Plan.Explain.fst`: plan dump with all access-path decisions surfaced. Retires Pe5. | 1 PR. | Phases 4 + 6. |
+| **8. Consumer relocation** | Move `factoidal_*.ml`, `*_runner.ml` from `formal/fstar/ocaml-output/` to `bin/<consumer>/`. Update build-ocaml.sh. Tighten CI gate so `formal/fstar/ocaml-output/` accepts only F\*-extracted output + a fixed list of `assume val` realisation files. | 1 large PR. | Phase 7. |
+| **9. Drop the qualifier** | Delete the "qualified verified" footnote from CLAUDE.md rule #11, READMEs, demo pages. CI gate now enforces the property. | 1 doc PR. | Phase 8 + audit shows zero violators. |
+
+After Phase 9, the project can credibly say "verified RDF/SPARQL"
+without footnotes. The C-build pilot (separate plan,
+`2026-05-07-c-build-and-roaring-plan.md`) becomes meaningful — the
+verified library is genuinely host-language-agnostic.
+
+## Done criteria
+
+- `experimental_ocaml_glue/*.sh` contains zero patches that touch
+  `RDF_CottasStore.ml`'s `cottas_ondisk_*` functions, or any
+  function in `factoidal_explain.ml` or `factoidal_http.ml` that
+  involves SPARQL evaluation, planning, or storage decisions.
+- `find experimental_ocaml_glue/ -type f` shows only:
+  - `_*_assume_val_*.sh` files (each realising one `assume val`)
+  - the file-system / clock realisations
+  - `_runner_io_glue.sh` (or whatever's left for raw I/O)
+- `find formal/fstar/ocaml-output/ -name '*.ml'` shows only files
+  with a "GENERATED BY F\*" header. No hand-written `.ml` files.
+- `bin/factoidal-cli/`, `bin/w3c-runner/`, `bin/rdfc10-runner/`,
+  `bin/owl-runner/` exist; their `.ml` files contain only
+  argv-parsing, file I/O, and calls to F\*-extracted functions.
+- The CI workflow `check-fstar-purity.yml` enforces all of the
+  above.
+- For every operation in the storage-abstraction-map table, the
+  set of stores that implement it is recorded in
+  `RDF.Store.Capabilities.fst` and a unit test exercises it on
+  each store.
+- Codenames Yod6, Tet3, Lamed3, Mem5, Pe5, Bet7, Tav5, Heth3 do
+  not appear in any code path. They survive only in `git log`
+  archaeology and in `docs/code-name-glossary.md` as historical
+  notes.
+
+## What this plan does NOT do
+
+- It does not replace existing in-flight Track-1 quick-win PRs
+  (`bs_json`, `tp_explain`, `term_nq`, `escape_literal_lexical`,
+  `kind_label` + `is_test_type_iri`). Those are pure renderers /
+  classifiers. They're forward-compatible: they migrate logic
+  from OCaml into F\* in modules that this plan keeps.
+- It does not replace the C-build pilot plan
+  (`2026-05-07-c-build-and-roaring-plan.md`). The two plans
+  reinforce each other: this plan removes the OCaml-only logic
+  that blocks C extraction; the C-build plan exercises the
+  resulting cleanly-extractable F\* modules.
+- It does not propose a rewrite of existing F\* modules that are
+  already well-named (`RDF.CottasStore.PresenceBitmap.fst`,
+  `RDF.CottasStore.OnDiskIndex.fst`, etc.). The "Columnar"
+  reorg in Phase 2 is namespace-level — it moves modules under
+  `RDF.Store.Columnar.*` without changing their content.
+
+## Open questions
+
+1. **Capabilities encoding for KaRaMeL.** F\* type classes don't
+   extract well to C. Records-of-functions do, but require
+   monomorphisation. Decision: record-of-functions, with each
+   `Capabilities` instance constructed at top level (no
+   polymorphism over `Capabilities`).
+2. **Cancellation semantics.** Cooperative-checkpoint vs hard
+   interrupt. The current Heth3 uses SIGALRM (process-global).
+   The proposed `TimeBudget` polls. Polling needs the evaluator
+   to call `check_budget` between every N tuples. Where to put
+   the polling call sites? Decision: the iterator combinators in
+   `SPARQL.Eval.Iterator.fst` poll at every yield boundary.
+3. **Offset-index format.** Reuse the existing `.p.offsets` mmap
+   format if it's already specified somewhere; otherwise spec it
+   in F\* and migrate the writer at the same time. Per the
+   corrected taxonomy from this morning's discussion, the
+   serialiser must be in F\*; OCaml only does `write`.
+4. **Companion-file writer audit.** Vav3-style writers may
+   contain byte-encoding logic in OCaml today. Phase 0's audit
+   must enumerate which writers are pure-I/O (acceptable) vs
+   contain layout logic (must migrate). For migrating ones, add
+   `serialize : data -> Tot (list u8)` in F\* + reduce OCaml to
+   `write_bytes`.
+
+## How this fits with the corrected taxonomy
+
+Earlier today we corrected the "acceptable glue" taxonomy from
+three categories to one:
+
+> **Inside the verified library boundary, the only acceptable
+> OCaml is an `assume val` realisation. Companion-file writers
+> with byte-layout logic are not a separate category — they're
+> `assume val`s with structured signatures, where the structuring
+> belongs in F\*. "Trivial dispatch shims" aren't part of the
+> verified library at all — they're the consumer/binding layer
+> and belong outside `formal/fstar/ocaml-output/`.**
+
+This plan operationalises that taxonomy. Phase 0's audit applies
+the new rule. Phases 1-7 migrate logic. Phase 8 separates the
+consumer layer. Phase 9 ratifies the new state.


### PR DESCRIPTION
## Summary

CLAUDE.md was 456 lines and growing — too long for every-session preamble loading. Refactored to 194 lines covering only what every session must keep in working memory.

### Kept in CLAUDE.md
- Project identity (1 paragraph).
- F* comment-syntax + reserved-word pitfalls (silently corrupt files; must stay in main).
- Iron rules 1–12.
- Anti-pattern one-liners (quick lookup is load-bearing).
- Pointer index to skills + expanded docs.

### Moved to skills (auto-loaded on demand)
- `.claude/skills/build-and-test/SKILL.md` (NEW) — `build-ocaml.sh`, W3C runner, extraction notes, common failures.
- `.claude/skills/github-and-prs/SKILL.md` (NEW) — `gh` device-flow auth recipe, `--repo` flag requirement, branch + PR conventions, branch-cleanup workflow.
- `.claude/skills/repo-tour/SKILL.md` (NEW) — directory layout, "where do I add a new X?" table, codename decoder pointer.
- `.claude/skills/markdown-style/SKILL.md` (NEW) — links must be unambiguously clickable; no `**` adjacent to `]` or to bare-URL final char. Per recurring-feedback issue.
- `.claude/skills/fstar-env/SKILL.md` (existing, unchanged).

### Iron Rule #11 corrected
- Old #10 + #11 had overlapping intent — merged into one rule.
- Drops the "three acceptable forms" framing (companion-file writers and trivial dispatch shims were category errors).
- States the single rule: inside the verified library boundary, OCaml is `assume val` realisations only.
- Points at the recovery plan + I/O verification annex (already on main from #166).

## Test plan

- [x] Skills render correctly (auto-discovered by Claude Code; `Available skills` listing confirms registration).
- [x] No broken links in CLAUDE.md.
- [x] Old rule numbering preserved (1–12) so existing commit-message references like "per rule #17" still resolve via `docs/claude-rules/anti-patterns.md`.