### PR TITLE
fix: cast status + String.length to Z.t at factoidal_http.ml:859

### DIFF
--- a/formal/fstar/ocaml-output/factoidal_http.ml
+++ b/formal/fstar/ocaml-output/factoidal_http.ml
@@ -856,7 +856,7 @@ let write_response ?(extra_headers=[]) oc ~status ~content_type ~body =
      SPARQL.HTTP.Response.render_response_head. *)
   let head =
     SPARQL_HTTP_Response.render_response_head
-      status content_type (String.length body) extra_headers
+      (Z.of_int status) content_type (Z.of_int (String.length body)) extra_headers
   in
   output_string oc head;
   output_string oc body;


### PR DESCRIPTION
## Summary

PR #151 migrated `render_response_head` to F\* (extracted to OCaml as `SPARQL_HTTP_Response.render_response_head`, with `Prims.int = Z.t` for all int args). The call site in `factoidal_http.ml`'s `write_response` still passed the OCaml-native ints from `status` and `String.length body`, so the `factoidal` CLI build broke on `claude/main`.

Wrap both ints in `Z.of_int`. Smallest possible fix.

```diff
-      status content_type (String.length body) extra_headers
+      (Z.of_int status) content_type (Z.of_int (String.length body)) extra_headers
```

## Test plan

- [x] Confirmed during track-1 quick-win migrations by A1 (#170) and A3 (#169) agents independently — both reported the same compile-time type error blocking `factoidal_http.cmx`.
- [x] Targeted fix; one file, one line.

## Why now

This blocks the CLI build but no one's CI errored (the workflows pass extraction → JS, not the native CLI). Caught only because subagents tried `./build-ocaml.sh compile` end-to-end during their migration smoke tests.