### PR TITLE
fstar-purity: lift kind_label + is_test_type_iri to F* manifest modules

### DIFF
--- a/formal/fstar/OWL.Tests.Manifest.fst
+++ b/formal/fstar/OWL.Tests.Manifest.fst
@@ -1,0 +1,28 @@
+module OWL.Tests.Manifest
+
+// Test-type-IRI classifier for the W3C OWL test suite. Migrated
+// from owl_runner.ml. Per CLAUDE.md rule #11 OCaml glue may not
+// classify test type IRIs.
+
+module S = FStar.String
+
+let test_ns : string = "http://www.w3.org/2007/OWL/testOntology#"
+
+// FStar.String.sub : s:string -> i:nat -> l:nat{i + l <= length s} -> Tot (r:string {length r = l})
+// FStar.String.substring is in the Ex (exception) effect; we use sub
+// to stay in Tot. The proof obligations on i+l<=length s are
+// discharged by the il<pl / pl<=il guards.
+
+let is_test_type_iri (iri : string) : Tot bool =
+  let prefix = test_ns in
+  let pl = S.length prefix in
+  let il = S.length iri in
+  if il < pl then false
+  else if S.sub iri 0 pl <> prefix then false
+  else
+    let suffix = S.sub iri pl (il - pl) in
+    suffix = "PositiveEntailmentTest" ||
+    suffix = "NegativeEntailmentTest" ||
+    suffix = "ConsistencyTest" ||
+    suffix = "InconsistencyTest" ||
+    suffix = "ProfileIdentificationTest"

--- a/formal/fstar/RDF.Canonical.Manifest.fst
+++ b/formal/fstar/RDF.Canonical.Manifest.fst
@@ -1,0 +1,30 @@
+module RDF.Canonical.Manifest
+
+// Test-manifest helpers for the W3C RDF-canon (RDFC-1.0) suite.
+// Migrated from rdfc10_runner.ml. Per CLAUDE.md rule #11 OCaml
+// glue may not classify test kinds.
+
+type test_kind =
+  | TK_Eval
+  | TK_NegEval
+  | TK_Map
+  | TK_Unknown
+
+let rdfc_ns : string = "https://w3c.github.io/rdf-canon/tests/vocab#"
+
+let rdfc_eval_test     : string = "https://w3c.github.io/rdf-canon/tests/vocab#RDFC10EvalTest"
+let rdfc_neg_eval_test : string = "https://w3c.github.io/rdf-canon/tests/vocab#RDFC10NegativeEvalTest"
+let rdfc_map_test      : string = "https://w3c.github.io/rdf-canon/tests/vocab#RDFC10MapTest"
+
+let kind_of_iri (iri : string) : Tot test_kind =
+  if iri = rdfc_eval_test then TK_Eval
+  else if iri = rdfc_neg_eval_test then TK_NegEval
+  else if iri = rdfc_map_test then TK_Map
+  else TK_Unknown
+
+let kind_label (k : test_kind) : Tot string =
+  match k with
+  | TK_Eval    -> "Eval"
+  | TK_NegEval -> "NegEval"
+  | TK_Map     -> "Map"
+  | TK_Unknown -> "Unknown"

--- a/formal/fstar/build-ocaml.sh
+++ b/formal/fstar/build-ocaml.sh
@@ -218,9 +218,11 @@ if [[ "$STEP" == "all" || "$STEP" == "extract" ]]; then
              RDF.Graph.Executable.fst Parquet.Footer.fst \
              RDF.NQuads.Serialize.fst \
              RDF.Canonical.fst \
+             RDF.Canonical.Manifest.fst \
              Tableau.fst SPARQL11.Algebra.fst \
              RDF.Pretty.fst \
              OWL.QueryRewrite.fst OWL.QueryEval.fst \
+             OWL.Tests.Manifest.fst \
              Parser.FastString.fst Parser.IRI.fst \
              Parser.Combinators.fst Parser.TurtleScanner.fst SPARQL11.Parser.fst \
              Parser.NTriples.fst Parser.Turtle.fst \
@@ -337,7 +339,8 @@ if [[ "$STEP" == "all" || "$STEP" == "compile" ]]; then
     RDF_CottasInMem.ml \
     fstar_pure_hashes.ml \
     RDF_Canonical.ml \
-    SPARQL11_Algebra.ml RDF_Pretty.ml OWL_QueryRewrite.ml OWL_QueryEval.ml SPARQL11_Parser.ml SPARQL11_Store.ml SPARQL_Protocol.ml \
+    RDF_Canonical_Manifest.ml \
+    SPARQL11_Algebra.ml RDF_Pretty.ml OWL_QueryRewrite.ml OWL_QueryEval.ml OWL_Tests_Manifest.ml SPARQL11_Parser.ml SPARQL11_Store.ml SPARQL_Protocol.ml \
     SPARQL_Update_Sandbox.ml \
     SPARQL_Update_Analysis.ml \
     SPARQL_Diagnostics.ml \

--- a/formal/fstar/ocaml-output/OWL_Tests_Manifest.ml
+++ b/formal/fstar/ocaml-output/OWL_Tests_Manifest.ml
@@ -1,0 +1,19 @@
+open Prims
+let (test_ns : Prims.string) = "http://www.w3.org/2007/OWL/testOntology#"
+let (is_test_type_iri : Prims.string -> Prims.bool) =
+  fun iri ->
+    let prefix = test_ns in
+    let pl = FStar_String.strlen prefix in
+    let il = FStar_String.strlen iri in
+    if il < pl
+    then false
+    else
+      if (FStar_String.sub iri Prims.int_zero pl) <> prefix
+      then false
+      else
+        (let suffix = FStar_String.sub iri pl (il - pl) in
+         ((((suffix = "PositiveEntailmentTest") ||
+              (suffix = "NegativeEntailmentTest"))
+             || (suffix = "ConsistencyTest"))
+            || (suffix = "InconsistencyTest"))
+           || (suffix = "ProfileIdentificationTest"))

--- a/formal/fstar/ocaml-output/RDF_Canonical_Manifest.ml
+++ b/formal/fstar/ocaml-output/RDF_Canonical_Manifest.ml
@@ -1,0 +1,36 @@
+open Prims
+type test_kind =
+  | TK_Eval 
+  | TK_NegEval 
+  | TK_Map 
+  | TK_Unknown 
+let (uu___is_TK_Eval : test_kind -> Prims.bool) =
+  fun projectee -> match projectee with | TK_Eval -> true | uu___ -> false
+let (uu___is_TK_NegEval : test_kind -> Prims.bool) =
+  fun projectee -> match projectee with | TK_NegEval -> true | uu___ -> false
+let (uu___is_TK_Map : test_kind -> Prims.bool) =
+  fun projectee -> match projectee with | TK_Map -> true | uu___ -> false
+let (uu___is_TK_Unknown : test_kind -> Prims.bool) =
+  fun projectee -> match projectee with | TK_Unknown -> true | uu___ -> false
+let (rdfc_ns : Prims.string) = "https://w3c.github.io/rdf-canon/tests/vocab#"
+let (rdfc_eval_test : Prims.string) =
+  "https://w3c.github.io/rdf-canon/tests/vocab#RDFC10EvalTest"
+let (rdfc_neg_eval_test : Prims.string) =
+  "https://w3c.github.io/rdf-canon/tests/vocab#RDFC10NegativeEvalTest"
+let (rdfc_map_test : Prims.string) =
+  "https://w3c.github.io/rdf-canon/tests/vocab#RDFC10MapTest"
+let (kind_of_iri : Prims.string -> test_kind) =
+  fun iri ->
+    if iri = rdfc_eval_test
+    then TK_Eval
+    else
+      if iri = rdfc_neg_eval_test
+      then TK_NegEval
+      else if iri = rdfc_map_test then TK_Map else TK_Unknown
+let (kind_label : test_kind -> Prims.string) =
+  fun k ->
+    match k with
+    | TK_Eval -> "Eval"
+    | TK_NegEval -> "NegEval"
+    | TK_Map -> "Map"
+    | TK_Unknown -> "Unknown"

--- a/formal/fstar/ocaml-output/owl_runner.ml
+++ b/formal/fstar/ocaml-output/owl_runner.ml
@@ -119,7 +119,7 @@ let parse_catalog path =
 (* Triple projections. *)
 
 let rdf_type_iri   = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
-let test_ns        = "http://www.w3.org/2007/OWL/testOntology#"
+let test_ns        = OWL_Tests_Manifest.test_ns
 let test_identifier = test_ns ^ "identifier"
 let test_profile    = test_ns ^ "profile"
 let test_premise    = test_ns ^ "rdfXmlPremiseOntology"
@@ -141,21 +141,9 @@ let object_literal_opt (t : rdf_term) : string option =
   | T_Literal l -> Some l.lexical_form
   | _ -> None
 
-(* Does this IRI name one of the five OWL-test test types? *)
-let is_test_type_iri (iri : string) : bool =
-  let prefix = test_ns in
-  let pl = String.length prefix in
-  let il = String.length iri in
-  if il < pl then false
-  else if String.sub iri 0 pl <> prefix then false
-  else
-    match String.sub iri pl (il - pl) with
-    | "PositiveEntailmentTest"
-    | "NegativeEntailmentTest"
-    | "ConsistencyTest"
-    | "InconsistencyTest"
-    | "ProfileIdentificationTest" -> true
-    | _ -> false
+(* Does this IRI name one of the five OWL-test test types?
+   Delegates to F* per CLAUDE.md rule #11. *)
+let is_test_type_iri = OWL_Tests_Manifest.is_test_type_iri
 
 let short_type (iri : string) : string =
   let pl = String.length test_ns in

--- a/formal/fstar/ocaml-output/rdfc10_runner.ml
+++ b/formal/fstar/ocaml-output/rdfc10_runner.ml
@@ -70,9 +70,9 @@ let rdf_type_iri = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
 let mf_action = mf_ns ^ "action"
 let mf_result = mf_ns ^ "result"
 let mf_name   = mf_ns ^ "name"
-let rdfc_eval_test         = rdfc_ns ^ "RDFC10EvalTest"
-let rdfc_neg_eval_test     = rdfc_ns ^ "RDFC10NegativeEvalTest"
-let rdfc_map_test          = rdfc_ns ^ "RDFC10MapTest"
+let rdfc_eval_test     = RDF_Canonical_Manifest.rdfc_eval_test
+let rdfc_neg_eval_test = RDF_Canonical_Manifest.rdfc_neg_eval_test
+let rdfc_map_test      = RDF_Canonical_Manifest.rdfc_map_test
 
 (* The manifest is a Turtle file; parser yields a list of triples (the
    default graph). All identifiers come out as IRIs. *)
@@ -91,19 +91,14 @@ let parse_manifest path =
 (* ------------------------------------------------------------------ *)
 (* Per-test record. *)
 
-type test_kind = TK_Eval | TK_NegEval | TK_Map | TK_Unknown
+type test_kind = RDF_Canonical_Manifest.test_kind =
+  | TK_Eval
+  | TK_NegEval
+  | TK_Map
+  | TK_Unknown
 
-let kind_of_iri (iri : string) : test_kind =
-  if iri = rdfc_eval_test then TK_Eval
-  else if iri = rdfc_neg_eval_test then TK_NegEval
-  else if iri = rdfc_map_test then TK_Map
-  else TK_Unknown
-
-let kind_label = function
-  | TK_Eval    -> "Eval"
-  | TK_NegEval -> "NegEval"
-  | TK_Map     -> "Map"
-  | TK_Unknown -> "Unknown"
+let kind_of_iri = RDF_Canonical_Manifest.kind_of_iri
+let kind_label  = RDF_Canonical_Manifest.kind_label
 
 type rdfc_test = {
   iri        : string;


### PR DESCRIPTION
## Summary

Last of the Track-1.1 quick wins from the recovery plan. Two new F\* manifest modules; two runners now delegate.

### New F\* modules

- `RDF.Canonical.Manifest.fst` — RDFC-1.0 `test_kind` ADT, `kind_of_iri`, `kind_label`, IRI constants. Lifted from `rdfc10_runner.ml`.
- `OWL.Tests.Manifest.fst` — OWL test-type-IRI classifier and `test_ns` constant. Lifted from `owl_runner.ml`.

### OCaml delegations

- `rdfc10_runner.ml`: `test_kind` ADT, `kind_of_iri`, `kind_label`, the three IRI constants now delegate to `RDF_Canonical_Manifest`.
- `owl_runner.ml`: `test_ns` and `is_test_type_iri` delegate to `OWL_Tests_Manifest`.

`build-ocaml.sh`: added the two new modules to the extract for-loop and `COMMON_MODULES`.

Per CLAUDE.md rule #11 OCaml glue may not classify test types or test kinds.

## Test plan

- [x] F\* verifies both modules under z3 4.13.3 with no `--lax` / `--admit_smt_queries` / `assume val`.
- [x] Extract pipeline produces `RDF_Canonical_Manifest.ml` and `OWL_Tests_Manifest.ml` cleanly.
- [x] `rdfc10_runner` and `owl_runner` compile and link with the delegations.

Closes Track-1.1 quick-win #3 (the only one of the original 5 still outstanding after #168/#169/#170).