### PR TITLE
ci: harden w3c-tests so the dashboard updates reliably

### DIFF
--- a/.github/workflows/w3c-tests.yml
+++ b/.github/workflows/w3c-tests.yml
@@ -2,20 +2,38 @@ name: W3C Test Suite
 
 on:
   push:
-    branches: [main, master, claude/main, 'claude/**']
+    # Only main lines. Feature-branch pushes (claude/<topic>) used to
+    # trigger this workflow too, but each branch push triggered a full
+    # ~30-minute W3C suite run AND cancelled in-flight main runs via
+    # the concurrency rule below — so the dashboard's data became
+    # stale even when no real CI failure was present. Restrict to the
+    # branches whose results actually feed the public dashboard.
+    branches: [main, master, claude/main]
   schedule:
-    # Run daily at 06:00 UTC
+    # Daily 06:00 UTC safety-net run regardless of merge cadence.
     - cron: '0 6 * * *'
   workflow_dispatch:
 
 permissions:
   contents: write
 
-# Avoid two pushes from the same branch racing each other to commit
-# CI artifacts. Newer pushes cancel older in-flight runs.
+# Concurrency policy:
+#   - Per-ref grouping (so different branches don't fight each other).
+#   - cancel-in-progress is FALSE for refs/heads/claude/main: main
+#     runs always complete, so docs/test-results/latest.json gets
+#     committed for every merge. If two main pushes land within the
+#     same suite duration, the second queues until the first finishes.
+#   - For the schedule + workflow_dispatch case (github.ref defaults
+#     to claude/main / main), cancel-in-progress also ends up false,
+#     which is what we want.
+#
+# Old policy was cancel-in-progress: true unconditionally, which
+# (combined with rapid PR-merge cadence to claude/main) meant the
+# scheduled and post-merge runs got pre-empted by the next push and
+# the dashboard hadn't been updated since 2026-05-01 19:00 UTC.
 concurrency:
   group: w3c-tests-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/claude/main' && github.ref != 'refs/heads/main' && github.ref != 'refs/heads/master' }}
 
 jobs:
   native-shadow:


### PR DESCRIPTION
## Summary

`docs/test-results/latest.json` (and the public dashboard at https://danbri.github.io/factoidal/test-results/) hasn't been updated since 2026-05-01 19:00 UTC despite merges happening throughout that period. Two interacting causes:

### Cause 1 (real failure since 2026-05-06): factoidal_http.ml:859 Z.t/int

Already fixed in #172. Every w3c-tests run since PR #151 merged on 2026-05-06 hit `FAIL: ocamlopt factoidal (exit 2)` because the call site for `render_response_head` passed OCaml-native `int`s where the F\*-extracted code expected `Prims.int = Z.t`. Workflow correctly failed; dashboard couldn't update.

### Cause 2 (workflow design): aggressive cancellation + wildcard trigger

This PR addresses cause 2 so the failure mode in cause 1 doesn't recur.

**Drop the `'claude/**'` push wildcard.** Every feature-branch push was triggering a full ~30-minute W3C suite run. Wasted CI minutes; no value (those branches' results don't feed the public dashboard).

**Disable `cancel-in-progress` for main-line refs.** Old policy was unconditional `cancel-in-progress: true`. With rapid PR-merge cadence, a merge to `claude/main` would pre-empt the previous main run before it could commit `latest.json`. New expression:

```yaml
concurrency:
  group: w3c-tests-${{ github.ref }}
  cancel-in-progress: ${{ github.ref != 'refs/heads/claude/main' && github.ref != 'refs/heads/main' && github.ref != 'refs/heads/master' }}
```

Cancellation still applies to non-main refs (so push storms on feature branches still drop stale runs), but main runs queue and complete.

## Test plan

- [x] Workflow YAML lints (validated via `gh api repos/...` round-trip).
- [ ] Verify post-merge: a push to `claude/main` should produce a completed (not cancelled) run that commits `docs/test-results/latest.json` with a fresh timestamp.
- [ ] Verify the cancel-in-progress expression evaluates correctly for both branches and main; if syntactically rejected, GitHub Actions falls back to literal-true (existing behaviour). Worst case = no regression.

## What this does NOT do

- Doesn't add a fast PR validation workflow. If we want short feedback for `claude/<topic>` branches, that's a separate, lighter workflow (extract + compile, no W3C suite). Out of scope here.
- Doesn't change the daily 06:00 UTC schedule trigger.