### PR TITLE
audit: F*/OCaml boundary classification — recovery plan Phase 0

### DIFF
--- a/docs/designissues/fstar-ocaml-boundary-audit.md
+++ b/docs/designissues/fstar-ocaml-boundary-audit.md
@@ -1,552 +1,342 @@
-# F\*/OCaml boundary audit
+# 2026-05-07 — F\*/OCaml Boundary Audit
 
-**Status:** **mostly resolved** as of 2026-05-01 — Phases 2.5-2.7
-landed; the COTTAS on-disk runtime is now F\*-resident, and four of
-the five "must-be-F\*" items in `factoidal_http.ml` have been migrated
-(PRs #126 merged, #127/#128/#129 awaiting review; update sandboxing
-in flight on `claude/http-update-sandbox-to-fstar`). See **Status
-update 2026-05-01** section near the bottom for the post-unwind LoC
-delta and the relaxed verification claim.
+**Phase 0** of
+[`2026-05-07-query-planning-fstar-recovery.md`](2026-05-07-query-planning-fstar-recovery.md).
+Catalogue only — no proposed code, no F\* modules. Surfaces the migration backlog
+that Phases 1-9 of the recovery plan consume.
 
-**Original status (2026-04-26):** active, written 2026-04-26 in
-response to reviewer feedback demanding a function-by-function
-inventory of what is F\*-authoritative, what is mechanically
-extracted, and what is hand-written OCaml that encodes semantics or
-policy.
+This is a fresh audit applying the **corrected taxonomy** from
+[CLAUDE.md](../../CLAUDE.md) Iron Rule #11 (only `assume val` realisations
+are acceptable inside the verified library boundary; companion-file writers
+with byte-layout logic are violations; consumer/binding code belongs
+outside `formal/fstar/ocaml-output/`). It supersedes the 2026-04-26 →
+2026-05-06 status updates that previously occupied this filename, which
+applied the older A/P/S taxonomy and have served their purpose.
+The earlier text is preserved in `git log`.
 
-**Original trigger:** the project drifted from "F\* is the source of
-truth" to "~3000 LoC of OCaml shims override the F\* runtime path."
-Reviewer 2026-04-26 noted this extends beyond `experimental_ocaml_glue/`
-to `factoidal_http.ml` and `RDF_CottasStore.ml`. CLAUDE.md rule #11
-froze new semantic growth in these files until the audit was done.
-That freeze has held; the unwind is complete enough to lift it
-selectively (see status update).
+## Status
+Done (audit). Recovery Phases 1-9 unblocked.
 
-**Companion docs:**
-- `fstar-purity-unwind.md` — the migration plan (Phases 2.2 → 2.8).
-- `debugging-perf-ecosystem.md` — debugging frameworks per target.
-- `claude-rules/anti-patterns.md` — the 25 numbered anti-patterns.
+## Method
 
----
+Every hand-written `.ml` file in the audit brief and every `.sh` patch under
+`formal/fstar/experimental_ocaml_glue/` and
+`formal/fstar/minimal_regrettable_glue_code_each_with_an_open_issue/` was
+classified against the taxonomy in
+[`CLAUDE.md`](../../CLAUDE.md) Iron Rule #11 augmented by the
+boundary-audit-taxonomy table in
+[`2026-05-07-io-verification-and-third-party.md`](2026-05-07-io-verification-and-third-party.md).
 
-## The load-bearing distinction (reviewer 2026-04-26, second pass)
+Approach:
+- `wc -l` + `grep -nE "^(let|and) "` to enumerate top-level defs.
+- Read first 30 lines of every file (intent + context).
+- Sampled bodies for any function whose role was non-obvious.
+- Read every glue patch end-to-end (they are short).
+- For `w3c_runner.ml`, `factoidal_cli.ml`, `rdfc10_runner.ml`, `owl_runner.ml`:
+  classified at file granularity (CONSUMER, RELOCATE Phase 8) per the audit
+  brief's instruction not to walk them line-by-line.
 
-Two further-sharpened buckets that the rest of this doc applies. **Get
-this distinction right and the rest is mechanical; get it wrong and we
-either over-classify trivial wiring as "must-be-F\*" (paralysis) or
-under-classify real semantics as "glue" (the drift this audit
-unwinds).**
+The codename glossary referenced throughout is
+[`docs/code-name-glossary.md`](../code-name-glossary.md).
+No new short-codes are introduced here.
 
-### Reasonable OCaml glue
+## Classification taxonomy
 
-Application/runtime concerns that COMPOSE already-defined components
-without changing their meaning:
-
-- Parsing CLI flags
-- Opening files
-- Choosing which configured stores to mount
-- Unioning already-defined backends into a running server instance
-  (e.g. `build_dataset_backend`)
-- Rendering HTTP / JSON / static assets
-- Threading runtime mutable state (refs, mutexes) through request
-  handlers
-
-Even when these involve "policy" choices (union order, dedup behavior,
-empty-list shortcut), they're **composition** policies, not
-**meaning** policies. They decide how a server is wired together at
-process start; they do not decide what a stored dataset is.
-
-### Should move to F\*
-
-Anything that defines what the data MEANS or what operations on the
-data are SOUND:
-
-- Definition of companion index file formats (Vav3's `.dict`,
-  Yod6/Tet3's `.presence`, Lamed3's `.offsets`).
-- Encode/decode rules for those files.
-- Soundness conditions for using presence/offset/row-id indexes
-  (e.g. "a row group with predicate-bit X clear definitely contains
-  no rows with predicate=X" — invariant binding the bitmap to the
-  parquet payload).
-- Pruning and candidate-selection logic.
-- Invariants connecting the parquet payload to the sidecar indexes.
-- Query-evaluation logic (search, estimate, decode).
-- Termination/completeness conditions for the BGP walker.
-- Cancellation semantics — when is a query allowed to be aborted?
-
-The crux: **once the on-disk representation includes sidecar
-structures (dictionaries, bitmaps, offsets, row-id maps), the format
-semantics have expanded and the meaning of a stored dataset depends
-on those structures and their reader logic.** That's exactly what F\*
-is for.
-
-### Why this distinction matters more than `build_dataset_backend`
-
-My initial audit conflated "policy" (any choice with consequences)
-with "semantics" (decisions about what the data means). The reviewer
-sharpened: backend-composition decisions are application policy,
-acceptable in OCaml; representation-and-access decisions define
-semantics, must be in F\*.
-
-Worked example: `build_dataset_backend` chooses iteration order. That
-affects observable iteration-order behavior. But it does NOT change
-what triples exist in the dataset. Glue.
-
-Counter-example: Yod6's pred-presence prune decides which row groups
-to skip. That's a **soundness** claim — if the prune is wrong, the
-query returns wrong results. The bitmap format and the prune
-condition together define what a "valid" companion file means and
-what queries a reader is allowed to short-circuit. **Semantic.**
-
-So the load-bearing audit question for any OCaml-side function is:
-**does it merely route already-defined values, or does it encode
-soundness/format invariants?**
-
-## Why this matters — the provenance framing (reviewer 2026-04-26)
-
-Every backend behaviour must be traceable to exactly **one** of four
-provenance categories:
-
-1. **Verified source of truth** — F\* `.fst` files with proofs.
-2. **Generated artifact** — `.ml` mechanically extracted by F\*.
-   Should NEVER be edited directly (rule #13).
-3. **Handwritten implementation** — `.ml` files written by humans
-   (`factoidal_http.ml`, `factoidal_cli.ml`, `w3c_runner.ml`). Today
-   these live in `formal/fstar/ocaml-output/`, **which is a path-
-   naming bug**: the directory implies "generated" but contains hand-
-   authored code mixed with extracted code. Hard to tell apart by
-   directory alone.
-4. **Temporary prototype glue** — `experimental_ocaml_glue/*.sh`
-   patches that mutate extracted `.ml` post-extraction. By
-   construction these contradict #2 — they make extracted files no
-   longer extraction-faithful.
-
-**Three reasons clean provenance matters** (reviewer's framing):
-
-- **Debugging clarity.** When a query is slow / wrong / crashes, the
-  first question is "where does this behaviour live?" Today's answer
-  for the COTTAS backend is often "depends on which patch order
-  applied, which OCaml shim overrides which F\* function." Q03's
-  diagnosis took 30 minutes longer than necessary because Pe5's
-  `--explain` reimplemented the planner in OCaml; the dump showed
-  one decision while F\* made a different one.
-- **Assurance clarity.** A user / auditor / colleague hearing "F\*
-  backend" reasonably assumes the critical path is governed by F\*
-  source. When timeout policy, row-cache behaviour, disk index
-  loading, or pruning logic are materially implemented in handwritten
-  OCaml, the assurance claim is qualified at best, false at worst.
-- **Refactoring discipline.** If fixes land in handwritten OCaml
-  because it's faster to patch, the de-facto source of truth migrates
-  away from F\* without anyone deciding that. Velocity comes from
-  reuse; reuse depends on a stable source of truth; the source of
-  truth has to be explicit, not assumed.
-
-The A/P/S classifications in this audit are about WHAT TO DO with each
-piece. The four provenance categories above are about WHAT IT IS. Both
-are needed.
-
-**Structural follow-up worth doing post-unwind:** the
-`formal/fstar/ocaml-output/` directory should be split or signposted
-to make provenance category 2 vs 3 obvious by location:
-
-- Option A: move handwritten files to `formal/fstar/ocaml-driver/` or
-  `formal/fstar/server-glue/`.
-- Option B: every handwritten `.ml` opens with
-  `(* HANDWRITTEN — NOT extracted; safe to edit. *)`. Every extracted
-  one opens with `(* GENERATED by F* extraction — DO NOT EDIT. *)`.
-- Option C: both. Best.
-
-Tracked as a Phase 2.9 follow-up (post-unwind cosmetic / structural).
-
-## Audit method
-
-Each function or code section gets one of three classifications, based
-on the reviewer's scheme:
-
-- **A — Acceptable glue.** I/O, syscalls, library bindings, format
-  rendering, or trivial dispatch. Doesn't encode semantics or policy.
-  May stay in OCaml indefinitely.
-- **P — Temporary prototype logic.** Semantics or policy, but a quick
-  prototype landed in OCaml before F\* could absorb it. Migration
-  scheduled in `fstar-purity-unwind.md` Phases 2.2–2.8.
-- **S — Semantic / core backend logic that MUST move to F\* before more
-  work proceeds.** The most serious category. Frozen until lifted.
-
-Classification decisions favour **S** when ambiguous. The cost of
-mis-classifying glue as semantics is a careful F\* re-write; the cost
-of mis-classifying semantics as glue is the drift we're correcting.
+| Code | Category | Action |
+|---|---|---|
+| `EXTRACTED` | F\*-extracted `.ml` (must carry GENERATED header). | Verify only. |
+| `ASSUME-IO` | OCaml realisation of an `assume val` for pure I/O / OS primitive. | ALLOWED. |
+| `ASSUME-HOST` | OCaml realisation of an `assume val` calling a host engine (regex, etc.). | ALLOWED. |
+| `ASSUME-CRYPTO` | OCaml realisation of an `assume val` for a vendored crypto primitive. | ALLOWED. |
+| `CONSUMER` | Hand-written consumer / binding (argv, file I/O, dispatch shim around F\* extract). Not part of the verified library. | RELOCATE to `bin/<consumer>/`. |
+| `VIOLATION-SEM` | Carries an RDF/SPARQL semantic decision (planning, optimisation, prune, byte-layout for an on-disk format, etc.). | MIGRATE to F\*. |
+| `MIXED` | Mostly consumer but with semantic decisions inline. | SPLIT — extract the semantic part to F\*; keep consumer scaffolding. |
+| `UNCLEAR` | Role not yet determined; flag for follow-up. | INVESTIGATE before migrating. |
 
 ---
 
-## Audit target 1 — `formal/fstar/ocaml-output/factoidal_http.ml` (~2500 LoC, hand-written)
+## 1. Per-file summary
 
-This file is hand-written OCaml despite living in `ocaml-output/`. It
-imports F\*-extracted modules (`SPARQL11_Parser`, `SPARQL11_Algebra`,
-`SPARQL11_Store`, etc.) and wraps them in HTTP plumbing.
+| File | LoC | Top-level defs | EXTRACTED | ASSUME-* | CONSUMER | VIOLATION-SEM | MIXED |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| `factoidal_http.ml` | 2598 | 108 | 0 | 0 | 95 | 8 | 5 |
+| `factoidal_cli.ml` | 1135 | 34 | 0 | 0 | 33 | 0 | 1 |
+| `factoidal_explain.ml` | 671 | 19 | 0 | 0 | 14 | 4 | 1 |
+| `factoidal_dump_nq.ml` | 113 | 7 | 0 | 0 | 7 | 0 | 0 |
+| `factoidal_serve.ml` | 20 | 1 | 0 | 0 | 1 | 0 | 0 |
+| `w3c_runner.ml` | 2851 | 96 | 0 | 0 | 96 | 0 | 0 |
+| `rdfc10_runner.ml` | 474 | 38 | 0 | 0 | 38 | 0 | 0 |
+| `owl_runner.ml` | 516 | 42 | 0 | 0 | 42 | 0 | 0 |
+| `cottas_ondisk_smoketest.ml` | 95 | 4 | 0 | 0 | 4 | 0 | 0 |
+| **Totals (audited)** | **8473** | **349** | **0** | **0** | **330** | **12** | **7** |
 
-| Section | Lines (approx) | Class | Reasoning |
+Notes:
+
+1. **Zero `EXTRACTED` files in this audit set.** All 9 hand-written `.ml` files
+   are consumers / runners / glue. The actual extracted output (`SPARQL11_*`,
+   `RDF_*`, `Parser_*`, `Parquet_*`, etc.) is *not* in this audit list because
+   it is auto-generated — the audit's job is to classify the hand-written
+   layer that calls into it.
+2. **Zero `ASSUME-*` realisations in this audit set.** All `assume val`
+   realisations live in the glue-patch directories
+   (`experimental_ocaml_glue/` + `minimal_regrettable_glue_code_each_with_an_open_issue/`),
+   which patch already-extracted modules in place — see Section 3.
+3. The 12 `VIOLATION-SEM` + 7 `MIXED` rows are the migration backlog.
+   Section 2 enumerates them.
+4. The 8 codename violators (Yod6, Tet3, Lamed3, Mem5, Pe5, Bet7, Tav5, Heth3)
+   are not all in this audit set's `.ml` files — most live in the glue-patch
+   layer that injects post-extraction OCaml semantic logic into already-
+   extracted `.ml` files (see Section 3, e.g.
+   `cottas_ondisk_zzzzzz_lamed3_offset_idx.sh`). The OCaml-side surface those
+   patches expose lives mostly in `RDF_CottasStore.ml` (extracted, then
+   patched) — a file the recovery plan calls out explicitly.
+
+---
+
+## 2. Violator inventory (the migration backlog)
+
+The 8 codename violators (Yod6, Tet3, Lamed3, Mem5, Pe5, Bet7, Tav5, Heth3)
+all confirmed present and matched to target F\* modules.
+
+The "File:line" column points to where the violator surfaces in the audit set
+(`factoidal_http.ml`, `factoidal_explain.ml`); the underlying logic also lives
+in `experimental_ocaml_glue/*.sh` (Section 3) which post-extraction patch the
+F\*-extracted COTTAS modules. Phase 4-7 migrations replace both.
+
+| File:line | Function | What it does (one sentence) | Target F\* module | Effort | Codename |
+|---|---|---|---|---|---|
+| `factoidal_http.ml:735` | `exception Query_timeout` + `with_query_timeout` (l. 1433) | Per-query SIGALRM-based wall-clock cancellation. | `SPARQL.Eval.TimeBudget.fst` (+ `assume val now_ms`) | M | **Heth3** |
+| `factoidal_http.ml:950` | `result_cap_response` | Result-row-cap circuit breaker (HTTP 413 when row count > cap). | `SPARQL.Eval.Limits.fst` (`take n` combinator) | XS | **Tav5** |
+| `factoidal_http.ml:961` | `exceeds_cap` | Decision predicate "row count > cap". | `SPARQL.Eval.Limits.fst` | XS | **Tav5** |
+| `factoidal_http.ml:1013, 1052` | inline `match exceeds_cap … with Some n -> result_cap_response` | Cap policy applied to SELECT and CONSTRUCT/DESCRIBE branches. | `SPARQL.Eval.Limits.fst` (consumer call site only post-migration) | XS | **Tav5** |
+| `factoidal_http.ml:1407` | `query_timeout_response` | Heth3 504-body construction (delegates the JSON shape to `SPARQL_HTTP_Response.query_timeout_response_body`, but the OCaml `with_query_timeout` retains the SIGALRM decision logic). | `SPARQL.Eval.TimeBudget.fst` | M | **Heth3** |
+| `factoidal_http.ml:613` | `prewarm_cottas_columns` | Calls Vav3-companion-boot prewarm; thin wrapper, but it embeds the policy "always prewarm on open" decision. | `SPARQL.Plan.Loader.fst` (companion-file-present? + decide load mode) | S | **Bet7** (lazy-populate side) |
+| `factoidal_explain.ml:205` | `cottas_estimate_quick` | "Quick" cardinality estimate via `cottas_ondisk_estimate`; OCaml-side wrapper around an F\* call but the call-site policy "use the bitmap fast path here, fall back below" lives here. | `SPARQL.Plan.Estimate.fst` | S | **Mem5** |
+| `factoidal_explain.ml:246` | `explain_triple_pattern_against_store` | Per-pattern bound-status classification + estimate composition. The bound-status classification (`BS_Var/Hit/Miss/Other`) is in F\* (`SPARQL_Explain`) post-PR #170, but the *driver* that walks `tp.tp_s/tp_p/tp_o` and composes the result is still here. | `SPARQL.Plan.Explain.fst` | M | **Pe5** |
+| `factoidal_explain.ml:373` | `optimiser_order_via_fstar` | Iteratively calls `S.choose_best_tp_backend` to recover join order — wraps F\* but the "iterate till empty" loop is the planner-replay logic. | `SPARQL.Plan.Explain.fst` | S | **Pe5** |
+| `factoidal_explain.ml:385` | `optimiser_order_for_bgp_from_explains` | Parallel re-implementation of the F\* planner using pre-computed estimates ("DIVERGES from F\*" diagnostic). Explicitly a known-divergent shadow per its own comment. | `SPARQL.Plan.Explain.fst` (delete; rely on F\* ground truth alone) | S | **Pe5** |
+| `factoidal_explain.ml:473` | `print_index_use_summary` | Hard-codes which `.dict`/`.presence`/`.offsets` companion files the planner consults given the per-pattern bound-status. Pure semantic mapping (which capabilities apply for which bound shape). | `SPARQL.Plan.Explain.fst` | S | **Pe5** |
+| `factoidal_explain.ml:508` | `explain_query` | Top-level driver: parse, open, walk algebra, compute estimates, render. MIXED — outer scaffolding is consumer (open files, print headers, time it); inner per-BGP loop carries the semantic plan-replay decision. | `SPARQL.Plan.Explain.fst` (semantic core) + `bin/factoidal-explain/` (consumer) | M | **Pe5** |
+| `factoidal_http.ml:467` | `load_cottas_dataset` | Walks COTTAS `quad_row` cache, rebuilds an `rdf_dataset` with default + named-graph buckets. Bucketing by `qr_g` is a semantic decision: "no `qr_g` → default graph; `Some gid` → named graph keyed by IRI." | `RDF.Store.Loader.fst` (or `Parser.BallyhooCOTTAS` extension) | S | — (drift, not codename) |
+| `factoidal_http.ml:544` | `load_cottas_part` | Folds multiple `--data-cottas` files into one `rdf_dataset`. The "default-graph triples concatenate; named graphs append (first-match wins)" rule is a semantic merge decision. | `RDF.Store.Loader.fst` | S | — |
+| `factoidal_http.ml:669` | `build_dataset_backend` | MIXED — combines in-memory + cottas-ondisk into one `dataset_backend` with explicit `GB_Union`. The dispatch policy (when to use `GB_Union`, how to fold per-graph backends) is a semantic decision; the `Hashtbl`-based grouping is consumer scaffolding. | `RDF.Store.Capabilities.fst` (Phase 1) + `RDF.Store.Combine.fst` | M | — |
+| `factoidal_http.ml:908` | `select_vars` | MIXED — explicit-projection branch dispatches to `SPARQL11_Algebra.select_item_vars` (good); the star-projection fallback (collect-distinct-vars-in-first-seen-order) is in OCaml. SPARQL spec defines this; should be in F\*. | `SPARQL11.Algebra.fst` (`star_project_vars`) | XS | — |
+| `factoidal_http.ml:1330` | `parse_and_run_timed` | MIXED — outer scaffolding is timing instrumentation (consumer); the dispatch on `query.q_form` and the per-form timing-record construction is semantic. The `qt_form` string and the rows-from-body heuristic carry decisions. | Mostly `bin/factoidal-http/` after extracting `parse_and_run` core to F\*. The `run_query` body holds the SELECT/ASK/CONSTRUCT/DESCRIBE dispatch — also a violator (next row). | M | — |
+| `factoidal_http.ml:967` | `run_query` | MIXED — query-form dispatch + serialiser selection + cap policy + result-format selection. The serialiser dispatch logic (which serialiser per `RF_*` value) is genuine F\*-territory; the per-call eprintf trace is consumer. | `SPARQL.HTTP.RunQuery.fst` (new) calling `SPARQL.Protocol.serialise_response_*`. | M | — |
+| `factoidal_http.ml:2070` | `try_static_route` | MIXED — outer routing dispatch is consumer; the URL-path-to-route mapping (`/sparql`, `/admin`, `/backend-info.json`, `/parliament-queries.json`) is part of the SPARQL Protocol surface and arguably belongs in `SPARQL.HTTP.Routes.fst`. | `SPARQL.HTTP.Routes.fst` for the path table; consumer for the `Some/None` dispatch. | S | — |
+
+### Codename violator confirmation
+
+| Codename | Confirmed at | Target F\* module |
+|---|---|---|
+| **Yod6** | `experimental_ocaml_glue/cottas_ondisk_zzzzz_ondisk_index.sh` (`.p.presence` writer) + `factoidal_explain.ml:491` (Yod6 label in summary) | `SPARQL.Plan.Pruning.fst` over `RDF.Store.Columnar.PresenceBitmap` |
+| **Tet3** | `experimental_ocaml_glue/cottas_ondisk_zzzzz_ondisk_index.sh` (`.s.presence` + `.o.presence` writers) + `factoidal_explain.ml:488,494` | `SPARQL.Plan.Pruning.fst` + `RDF.Store.Columnar.CompoundPresence.fst` |
+| **Lamed3** | `experimental_ocaml_glue/cottas_ondisk_zzzzzz_lamed3_offset_idx.sh` (writer + reader) + `factoidal_explain.ml:497` | `RDF.Store.Columnar.OffsetIndex.fst` (NEW) + `SPARQL.Plan.AccessPath.fst` |
+| **Mem5** | `experimental_ocaml_glue/cottas_ondisk_runtime.sh` (estimate fast path) + `factoidal_explain.ml:205,366` | `SPARQL.Plan.Estimate.fst` |
+| **Pe5** | `factoidal_explain.ml` (entire file, named for `--explain`) | `SPARQL.Plan.Explain.fst` (extends what's in `SPARQL.Explain.fst` post-PR #170) |
+| **Bet7** | `experimental_ocaml_glue/cottas_ondisk_z_lazy_open.sh` (lazy-populate dictionaries) + `factoidal_http.ml:613` | `SPARQL.Plan.Loader.fst` decision + `RDF.Store.InMemory.fst` builder |
+| **Tav5** | `factoidal_http.ml:950,961,1013,1052` (result-cap circuit breaker) | `SPARQL.Eval.Limits.fst` (`take n stream` combinator) |
+| **Heth3** | `factoidal_http.ml:735,1407,1433` (SIGALRM, exception, with_query_timeout, query_timeout_response) | `SPARQL.Eval.TimeBudget.fst` + `assume val now_ms` realisation |
+
+All 8 codename violators present. No additional codename violators discovered
+during the audit (the `Sade3` mention in
+`experimental_ocaml_glue/cottas_ondisk_runtime.sh` refers to a *completed*
+Phase B migration of `cottas_ondisk_search`/`_estimate` to F\* — not an open
+violator).
+
+---
+
+## 3. Glue-patch inventory
+
+### `formal/fstar/experimental_ocaml_glue/` — backend / on-disk shadows
+
+| Patch file | What it does (one sentence) | Category | Action |
 |---|---|---|---|
-| Type definitions (`config`, `cottas_ondisk_loaded`, etc.) | 1–200 | **A** | Plain records / variants for OCaml runtime state. No semantics. |
-| CLI argument parsing (`parse_args`) | 200–420 | **A** | Standard option handling. Stores config; doesn't decide query semantics. |
-| Trace helpers (`Printf.eprintf [qof3-trace]` etc.) | scattered | **A** | Diagnostic I/O. Replace with Util.Log.* over time. |
-| Backend composition (`build_dataset_backend`) | 668–725 | **A** (composition glue, per refined reviewer guidance) | **Refined classification 2026-04-26 (later reviewer note):** This function takes already-defined backend values (`indexed_dataset_backend`, `cottas_ondisk_dataset_backend`) and wires them into a single `dataset_backend` for the running server. It does NO semantic transformation beyond assembly. The order policy, named-graph dedup, and empty-cottas shortcut are **application/runtime composition concerns**, not dataset semantics. The reviewer drew the line: glue composes already-defined components; semantics defines what the data MEANS. This stays in OCaml. (My previous "S" reclassification over-corrected; the reviewer's first note was a probe of my reasoning, the second tightened it.) |
-| `prewarm_cottas_columns` | 620–660 | **P** | Calls `ensure_*_loaded` hooks. With Vav3's mmap'd dicts, this becomes obsolete (Phase 2.7). |
-| `open_cottas_ondisk_files` | 646–670 | **A** | Opens each cottas file, builds `cottas_ondisk_loaded` records. Pure I/O glue. |
-| Query timeout (`with_query_timeout`, SIGALRM handler) | 1100–1300 | **S** | Encodes correctness policy: when does a long query get aborted? Process-global signal-based. Should be F\*-side cancellation token + OCaml timer flips flag. (Phase 2.6+.) |
-| Result-row cap (`exceeds_cap`, `result_cap_response`) | 950–1000 | **S** | Encodes safety policy: refuse to materialise >N rows. The DECISION belongs in F\*; the rendering of HTTP 413 is glue. |
-| `count_dataset_triples` | upstream | **A** | Walks an `rdf_dataset` and counts. Pure traversal of an F\*-typed value. |
-| `cottas_stores_total_quads` (just added) | 2000–2010 | **A/borderline** | Sums `cas_num_quads` across COTTAS stores. Two-source aggregation; arguably should be a single F\* function `dataset_summary`. Borderline glue / borderline policy. |
-| `serve_backend_info_json` (just edited) | 2017–2065 | **A/borderline** | Renders aggregated state as JSON. The aggregation is borderline (see above); the JSON rendering is pure glue. **Reviewer 2026-04-26 flagged the bug here.** |
-| `serve_parliament_queries_json` | 1670–1865 | **A** | Walks two filesystem dirs, builds JSON. Pure I/O + JSON glue. |
-| Static file serving (`try_static_route`, `serve_static_demo`) | 2073–2135 | **A** | HTTP routing + filesystem reads. Genuinely OCaml's job. |
-| `parse_and_run` | 1100–1180 | **A** | Calls `SPARQL11_Parser.parse_sparql` (F\*-extracted) and `run_query`. Glue. |
-| `run_query` | 950–1100 | **S** | Dispatches to `eval_select_query_backend_dataset` etc., applies cap, picks serialiser. The dispatch is glue; the cap-check policy and serialiser-choice policy are semantic decisions. Currently mixed. |
-| `handle_connection` (HTTP request loop) | 2150–2300 | **A** | Reads request, parses HTTP, calls handlers, writes response. HTTP I/O is OCaml's job. |
-| Worker-thread coordination during COTTAS load | 2400–2480 | **S** | The 503/Retry-After policy during loading IS a server-correctness decision. Today it's gated by a `loading` mutex. Decision (when to 503) should be F\*-typed; mutex is glue. |
-| `main`, `Unix.bind`/`accept` loop | 2280–2495 | **A** | Standard daemon scaffolding. |
+| `ballyhoo_hdt_runtime.sh` | Adds an HDT runtime-cache module to `Parser_BallyhooHDT.ml` (Hashtbl-backed term cache populated from F\*-verified probes). | `VIOLATION-SEM` (cache shape + ID-allocation policy is a semantic decision; the original probes are F\*-pure) | MIGRATE — `RDF.Store.HDT.fst` runtime view; cache becomes `assume val open_hdt_handle`. |
+| `cottas_column_seq_runtime.sh` | Realises four `assume val`s in `RDF.CottasStore.ColumnSeq.fst`: abstract `cottas_column` ≈ `string option array`, `_length`, `_get`, and `probe_parquet_column_decode_in_row_group_seq` (calls existing list-shape decoder + `Array.of_list`). | `ASSUME-IO` (rule #11(c) thin glue: `Array.length` / `Array.unsafe_get` + a list→array shim) | ALLOWED — leave in place, ensure the matching `assume val`s remain in `RDF.CottasStore.ColumnSeq.fst`. |
+| `cottas_inmem_encoder_runtime.sh` | Realises the `cottas_inmem_open` `assume val`. Phase A: stub returns `None`. Phase A.5 (per the comment) will land the real encoder + buffer registry. | `MIXED` (today: `ASSUME-IO` stub; tomorrow: byte-layout writer if Phase A.5 lands here) | INVESTIGATE — when Phase A.5 lands, the byte-encoding goes into F\* (`serialize : data -> Tot (list u8)`); the OCaml realisation reduces to `write_bytes`. Currently a stub, so no immediate action. |
+| `cottas_ondisk_runtime.sh` | (1) Implements `cottas_ondisk_open` (parquet decode + dict/revmap construction). (2) **Replaces** the F\*-extracted `cottas_ondisk_search` / `_estimate` / `_decode_*` with `Hashtbl`-backed equivalents. Per the patch's own header: "PERFORMANCE: replace the extracted F\* … the F\* definitions in `RDF.CottasStore.fst` remain the verification spec." | `VIOLATION-SEM` (the explicit reason `RDF.CottasStore.fst` is "decorative" per the recovery-plan disaster note) | MIGRATE — Phases 4-7. The cottas_ondisk_open piece can be split: pure-IO `read_parquet_column` `assume val` realisations + F\*-side dictionary + revmap build. The Hashtbl overlay must go away (the F\* spec already exists). |
+| `cottas_ondisk_z_lazy_open.sh` | **Bet7.** Rewrites `build_handle_and_tables` to skip subject + object dictionary populate at open; adds `Cottas_ondisk_lazy` module that builds them on first call. | `VIOLATION-SEM` | MIGRATE — `SPARQL.Plan.Loader.fst` (Phase 3). |
+| `cottas_ondisk_zzzzz_ondisk_index.sh` | **Vav3.** (1) Realises 6 `assume val` byte-range I/O primitives in `RDF.CottasStore.OnDiskIndex.fst` (mmap, read u32/u64/byte/string, file size). (2) Adds an OCaml `Cottas_companion_writer` that **encodes the byte-format** for `.dict` + `.presence` files. (3) Adds a boot orchestrator. | `MIXED` — (1) is `ASSUME-IO` and ALLOWED. (2) is `VIOLATION-SEM` per the rule #11 corrected taxonomy: byte-format-spec must be in F\* (`serialize : data -> Tot (list u8)`); OCaml does only `write_bytes`. (3) is consumer `MIXED` (when-to-build is a Loader policy decision). | SPLIT — (1) keep; (2) MIGRATE the dict/presence byte-encoding to F\* (`RDF.Store.Columnar.OnDiskIndex.serialize`); (3) MIGRATE the policy to `SPARQL.Plan.Loader.fst`. See Section 4 for companion-file audit detail. |
+| `cottas_ondisk_zzzzzz_lamed3_offset_idx.sh` | **Lamed3.** Builds a third companion file `<cottas>.p.offsets` with per-(row_group, predicate) row positions. Both the **byte format** (`COTO` magic + headers + offsets array + data) and the **reader** are entirely in OCaml. | `VIOLATION-SEM` | MIGRATE — `RDF.Store.Columnar.OffsetIndex.fst` NEW, with F\* `serialize`/`parse` and roundtrip lemma; OCaml reduced to `write_bytes`/`read_bytes` (Phase 6, performance-critical: must preserve 6 s → 200 ms win). |
+| `cottas_ondisk_zzzzzzzzzzzzz_compound_po_writer.sh` | **Compound (predicate, object) presence-bitmap writer (`.po.presence`).** Writer-only patch; reader is a future commit. Entirely OCaml byte-format. | `VIOLATION-SEM` | MIGRATE — extend `RDF.CottasStore.CompoundPresenceBitmap.fst` with `serialize`/`parse` + roundtrip lemma; OCaml writer reduces to `write_bytes`. |
+| `cottas_ondisk_zzzzzzzzzzzzzzzzz_token_lookup_runtime.sh` | Realises four `ondisk_lookup_{subj,pred,obj,graph}_id_global` `assume val`s by calling Bet7's `ensure_*_loaded` + `Hashtbl.find_opt`. | `MIXED` (`ASSUME-IO` shape but the `ensure_*_loaded` semantics depend on Bet7's lazy-populate decision) | SPLIT — once Bet7 is migrated to `SPARQL.Plan.Loader.fst`, this collapses to a pure `assume val` realisation. |
+| `cottas_pagecache_global_runtime.sh` | Realises `assume val pcache_decode_in_row_group_global`: a process-level mutable `ref` holding the page-cache record; thread-safe wrapper. Pure plumbing; F\* owns LRU/clock semantics. | `ASSUME-IO` (rule #11(c) thin dispatch shim) | ALLOWED — leave in place. |
+| `cottas_runtime.sh` | Adds `Ballyhoo_cottas_runtime` module to `Parser_BallyhooCOTTAS.ml`: runtime caches + backend hooks materialised from F\*-verified probes. | `MIXED` — runtime caches with ID-allocation policy are semantic decisions; underlying probes are F\*-pure. | SPLIT — fold the cache-shape decisions into F\* (capability-record), keep file I/O as `assume val`s. |
+| `parquet_footer_runtime.sh` | Realises `parquet_read_tail_hex` (raw file I/O over the parquet footer). | `ASSUME-IO` | ALLOWED — pure I/O. |
+| `util_log_runtime.sh` | Realises `assume val emit` for `Util.Log.fst`: env-var-controlled log level, ISO-8601 timestamp, file-or-stderr, mutex. | `ASSUME-IO` (logging is the canonical "I/O sink" example) | ALLOWED. |
+| `parquet_zstd_stubs.c` | C stubs for libzstd. (Not a `.sh` patch but lives in the directory.) | `ASSUME-IO` (vendored binding to libzstd, akin to HACL\* policy) | ALLOWED — document under `formal/third_party/` policy when the README is added. |
 
-**factoidal_http.ml summary (revised post-reviewer):** of ~2500 LoC,
-roughly 350 LoC are classified **S** (semantic decisions that must
-lift to F\*) — including `build_dataset_backend`'s composition
-policies which I initially mis-classified as glue. A further ~150
-LoC are borderline. The rest is acceptable glue.
+### `formal/fstar/minimal_regrettable_glue_code_each_with_an_open_issue/`
 
-**The single biggest S item** is now ambiguous between the
-**query timeout / cancellation policy** (signal-based, hard to
-reason about under concurrency) and **`build_dataset_backend`'s
-union/order/dedup policies** (silently observable in iteration
-order and named-graph collisions). Both must lift to F\*. Phase
-2.6 covers them.
-
-**Reviewer caution applied:** when classifying, default to S or
-A/borderline rather than A. The cost of mis-classifying glue as
-semantics is a careful F\* re-write; the cost of mis-classifying
-semantics as glue is the drift this audit is supposed to unwind.
-A second pass over this table is warranted before the unwind
-starts — likely revealing more S items.
+| Patch file | What it does (one sentence) | Category | Action |
+|---|---|---|---|
+| `53_blank_node_variable_rewriting.sh` | Rewrites `PS_BNode`/`PT_BNode` in query patterns to fresh variables for entailment regimes (issue #53). | `VIOLATION-SEM` (explicitly self-labelled "KNOWN VIOLATION"; this is RDF/RDFS entailment semantics) | MIGRATE — `SPARQL11.Entailment.fst` or `SPARQL11.Algebra.fst`; tracked by issue #53. |
+| `57_service_client_bind.sh` | Realises `assume val service_endpoint_lookup` via OCaml mutable hashtable populated by the runner from `qt:serviceData` declarations. | `ASSUME-HOST` (host-engine call-out: in real deployments this becomes an HTTP fetch — explicitly "host-defined" per SPARQL Federated Query spec) | ALLOWED — keep `assume val service_endpoint_lookup` and document it under the `ASSUME-HOST` category in `RDF.Store.Capabilities`. |
+| `62_forward_ref_wiring.sh` | Wires forward-ref `assume val`s for mutual recursion in `SPARQL11_Algebra.ml` (eval_expr_ebv, eval_expr_fwd, eval_exists_fwd, eval_property_path_fwd, eval_subselect_fwd). | `MIXED` — the mutable-ref dispatch is `ASSUME-IO`-shaped (host-language plumbing for cyclic deps F\* extraction emits as failwith); the resolution is "wire to the real implementation," which means the implementation IS in F\*. | ALLOWED-with-caveat — the dispatch shim is rule-#11(c)-compliant; track issue #62 to either (a) collapse the muts in F\*'s extraction model or (b) document this as a permanent realisation pattern. |
+| `63_regex_hash_uuid_stubs.sh` | Replaces failwith stubs for `regex_match`, `regex_replace`, `hash_md5`/`sha1`/…/`sha512`, UUID/STRUUID. | `MIXED` — `regex_*` are `ASSUME-HOST` (correctly host-defined per SPARQL 1.1, per IO-verification doc); `hash_*` should become `ASSUME-CRYPTO` (HACL\* binding); UUID should become an F\*-defined `mk_v4` + `assume val random_bytes` per the IO-verification doc. | SPLIT — keep regex realisations; migrate UUID byte-format to F\* (`ThirdParty.UUID`); migrate hashes to HACL\* binding (`ThirdParty.HACL`). Issue #63. |
+| `64_sparql_parser_escape_stubs.sh` | Realises `utf8_of_codepoint`, `process_iri_escapes`, `process_string_escapes` (with surrogate validation) for `SPARQL11_Parser.ml`. | `VIOLATION-SEM` — escape processing is part of the SPARQL grammar; belongs in F\* per rule #4 (parsers in F\*). | MIGRATE — `SPARQL11.Parser.Escapes.fst`. Issue #64. |
+| `65_base_iri_resolution.sh` | BASE IRI resolution for `SPARQL11_Algebra.ml` and `SPARQL11_Parser.ml` via mutable ref + `resolve_tok_iri` helper. | `VIOLATION-SEM` — IRI resolution is part of the SPARQL spec. | MIGRATE — `SPARQL11.IRI.Resolve.fst`. Issue #65. |
+| `66_zero_length_property_path.sh` | Augments zero-length property-path matching to include reflexive pairs from constant IRIs/BNodes in the query pattern even on empty graphs. | `VIOLATION-SEM` — explicitly self-labelled "Category: SPARQL semantics fix (should be in F\*)". | MIGRATE — `SPARQL11.Algebra.PropertyPath.fst`. Issue #66. |
+| `67_rdfxml_validation.sh` | Adds NCName checks + forbidden-name validation to `Parser_RDFXML.ml`. | `VIOLATION-SEM` — RDF/XML validation rules are part of the parser spec. | MIGRATE — `Parser.RDFXML.Validation.fst`. Issue #67. |
+| `68_unicode_boundary_workarounds.sh` | (1) `0xD7FF` → `0xD800` boundary fix in `Parser_NTriples.ml`. (2) Surrogate-validation guards in 4 string-parser sites in `Parser_Turtle.ml`. | `VIOLATION-SEM` — Unicode boundary semantics are part of the parser spec; each are tiny but they're in OCaml today. | MIGRATE — fix the underlying F\* `char` model + surrogate guards in `Parser.NTriples.fst` / `Parser.Turtle.fst`. Issue #68. |
+| `69_runner_io_glue.sh` | I/O-glue patches to `w3c_runner.ml`: namespace constants, expanded entailment-regime detection (sd:entailmentRegime), `file_to_base_uri` helper, query-file-as-base, exception handling for negative syntax tests. | `CONSUMER` — `w3c_runner.ml` is itself the consumer; this glue is consumer-on-consumer. | RELOCATE — when `w3c_runner.ml` moves to `bin/w3c-runner/` (Phase 8), inline this patch into the relocated source tree. |
+| `89_fast_string_primitives.sh` | Realises 6 `assume val`s in `Parser.FastString.fst` (`fs_byte_*`, `fs_cp_*`) via direct OCaml `String.length` / `String.unsafe_get` / `String.sub` + an inline UTF-8 decoder. | `ASSUME-IO` (byte-indexed primitives — host-language fast-path for what F\* already proves correct) | ALLOWED — keep; document under `assume val` realisation policy. |
+| `95_stack_safe_list_ops.sh` | Replaces 3 non-tail-rec list ops in `SPARQL11_Algebra.ml` with tail-rec equivalents (`List.rev (fold_left …)`). Self-described as "purely mechanical and preserves observational equivalence." | `MIXED` — strictly speaking these are post-extraction OCaml rewrites of F\* code, not `assume val` realisations. The semantic content is unchanged but the patch IS modifying extracted output. | INVESTIGATE — preferred fix is to add `extract_as` annotations or rephrase the F\* definitions so KaRaMeL/OCaml extracts the tail-rec form natively. Issue #95. |
+| `103_parquet_ascii_string_fast_path.sh` | ASCII-only fast-path for `FStar_String` ops in `Parquet_Footer.ml` (works because hex-encoded payloads are pure ASCII). | `ASSUME-IO`-ish — observationally equivalent host-language optimisation; same caveat as #95. | INVESTIGATE — same fix as #95: route through `Parser.FastString` `assume val`s instead of post-extraction `sed`. Issue #103. |
+| `README.md` | Documentation. | n/a | n/a |
 
 ---
 
-## Audit target 2 — `formal/fstar/ocaml-output/RDF_CottasStore.ml` (extracted + heavily patched)
+## 4. Companion-file writer audit
 
-This file is **extracted** from `RDF.CottasStore.fst` BUT then
-mutated by every patch in `experimental_ocaml_glue/` (Vav3 adds modules,
-Bet7 adds lazy populate, Yod6/Tet3 add presence Hashtbls, Lamed3 adds
-offset readers, Mem5 wraps estimate, etc.). The post-patch file is
-~2500 LoC, but only the head ~1500 of those are extraction-faithful.
+Per Iron Rule #11 corrected taxonomy (and the IO-verification doc): byte-format
+spec MUST be in F\* (`serialize : data -> Tot (list u8)`); OCaml is reduced to
+`write_bytes`. The hash-based round-trip witness pattern then proves the
+on-disk bytes match the F\*-computed bytes.
 
-| Section | Class | Reasoning |
-|---|---|---|
-| Pure F\*-extracted types (`cottas_ondisk_handle`, `cottas_ondisk_store`, etc.) | **A** | Faithfully extracted. Must not be edited directly (rule #13). |
-| Pure F\*-extracted lookup fns (`cottas_ondisk_decode_subject` etc., spec body) | **A** | Faithfully extracted from F\* source. Spec-correct. |
-| `Cottas_ondisk_runtime` module (added by `cottas_ondisk_runtime.sh`) | **S** | 688 LoC of `search_fast`, `estimate_fast`, `decode_*_fast`, `encode_*_fast` that REPLACE the F\* runtime path. The largest single rule-#11 violation. **Phase 2.5 retires this.** |
-| `Cottas_ondisk_lazy` module (added by Bet7's patch) | **P** | Lazy populate of in-RAM Hashtbls. Largely obsolete with Vav3's mmap'd dicts. **Phase 2.7 retires.** |
-| `Cottas_companion_*` modules (added by Vav3) | **A** | Mostly companion-file readers. The reader path SHOULD call F\*'s `OnDiskIndex.dict_decode_token` etc. — verify this in Phase 2.3. |
-| `Cottas_offset_idx` module (added by Lamed3) | **S** | Offset-index reader+use logic. Should be an F\* module `RDF.CottasStore.OffsetIndex.fst`. **Phase 2.6 lifts.** |
-| Yod6 pred-presence Hashtbls + helpers | **S** | Should be F\* presence-bitmap consult. **Phase 2.6 lifts.** |
-| Tet3 subj/obj-presence Hashtbls + helpers | **S** | Same. **Phase 2.6 lifts.** |
-| Mem5 estimate fast-path body replacement | **P** | F\* version exists in source; OCaml override is redundant once `cottas_ondisk_runtime.sh` is retired. **Phase 2.5 covers.** |
-| Aleph6 streaming COUNT + LIMIT pushdown | **P** | F\* implementations exist; OCaml mostly perf routing. **Phase 2.4 retires.** |
+| Artifact | Byte-format-spec location | Writer location | Round-trip witness exists? | Action |
+|---|---|---|---|---|
+| `<cottas>.s.dict` (subjects) | F\* `RDF.CottasStore.OnDiskIndex.fst` defines `dict_header` + `dict_decode_token` (READER side) | OCaml `Cottas_companion_writer.build_companion_pair` in `cottas_ondisk_zzzzz_ondisk_index.sh` (WRITER) | NO | MIGRATE — add `serialize_dict : dict_data -> Tot (list u8)` to `RDF.CottasStore.OnDiskIndex.fst`; add roundtrip lemma; reduce OCaml writer to `write_bytes`. Add CI hash-roundtrip test. |
+| `<cottas>.p.dict` (predicates) | same | same | NO | same |
+| `<cottas>.o.dict` (objects) | same | same | NO | same |
+| `<cottas>.g.dict` (graphs) | same | same | NO | same |
+| `<cottas>.s.presence` (subject presence bitmap) | F\* `RDF.CottasStore.OnDiskIndex.fst` defines `presence_header` + `presence_test_bit` (READER side); F\* `RDF.CottasStore.PresenceBitmap.fst` defines abstract bitmap operations | OCaml writer (same patch as above) | NO | same — `serialize_presence` to F\*, hash roundtrip test |
+| `<cottas>.p.presence` (Yod6 — predicate presence) | same | same | NO | same |
+| `<cottas>.o.presence` (object presence) | same | same | NO | same |
+| `<cottas>.g.presence` (graph presence) | same | same | NO | same |
+| `<cottas>.p.offsets` (Lamed3 — per-rg predicate row offsets) | **Nowhere in F\*** — format defined entirely in `cottas_ondisk_zzzzzz_lamed3_offset_idx.sh` comment block (`COTO` magic, `num_rgs`, offsets array, packed u32 row positions) | OCaml writer in same patch | NO | MIGRATE — `RDF.Store.Columnar.OffsetIndex.fst` NEW (Phase 6); F\* `serialize_offsets` + parse + roundtrip lemma; OCaml writer reduces to `write_bytes`. Performance-critical (6 s → 200 ms win must be preserved). |
+| `<cottas>.po.presence` (compound predicate-object presence) | F\* `RDF.CottasStore.CompoundPresenceBitmap.fst` defines abstract bitmap + `rg_could_contain_pair_sound` lemma; **byte format** (`COPO` magic, header, sparse-roaring sorted (p_id,o_id) pair lists per RG) defined only in `cottas_ondisk_zzzzzzzzzzzzz_compound_po_writer.sh` comment | OCaml writer in same patch (writer-only; no reader yet) | NO | MIGRATE — extend `RDF.CottasStore.CompoundPresenceBitmap.fst` with `serialize`/`parse`/roundtrip; OCaml writer reduces to `write_bytes`. |
+| COTTAS in-memory encoder (`cottas_inmem_open` Phase A.5) | Phase A: stub returns `None`. Phase A.5 deferred. | OCaml stub today; would land in `cottas_inmem_encoder_runtime.sh` | NO (no writer yet) | INVESTIGATE — when Phase A.5 lands, keep byte assembly in F\* per rule #11. Coordinate with Phase 6 of recovery plan. |
 
-**RDF_CottasStore.ml summary:** the extracted F\*-faithful core is
-acceptable; everything appended by the `experimental_ocaml_glue/`
-patches falls into S (must lift) or P (transition obsolete). The
-unwind plan addresses every entry.
-
----
-
-## Audit target 3 — `experimental_ocaml_glue/*.sh`
-
-Inventory already documented in `fstar-purity-unwind.md`. Brief
-classification:
-
-| Patch | Class | Phase to retire / lift |
-|---|---|---|
-| `cottas_ondisk_runtime.sh` (688 LoC) | **S** | 2.5 |
-| `cottas_ondisk_z_lazy_open.sh` (324 LoC) | **P** | 2.7 |
-| `cottas_ondisk_zz_aleph6_count_limit.sh` (~150 LoC) | **P** | 2.4 |
-| `cottas_ondisk_zzz_yod6_pred_presence_prune.sh` (412 LoC) | **S** | 2.6 |
-| `cottas_ondisk_zzzz_tet3_subj_obj_prune.sh` (310 LoC) | **S** | 2.6 |
-| `cottas_ondisk_zzzzz_ondisk_index.sh` (~250 LoC) | **A/P** | 2.3 verifies; writer can stay |
-| `cottas_ondisk_zzzzzz_lamed3_offset_idx.sh` (~300 LoC) | **S** | 2.6 |
-| `cottas_ondisk_zzzzzzz_mem5_estimate_presence.sh` (~80 LoC) | **P** | 2.5 |
-| `util_log_runtime.sh` (~100 LoC, just added) | **A** | Stays — pure I/O realisation of F\* `assume val emit`. |
-| `cottas_ondisk_zzzzzzzz_nun3_row_ids.sh` (incomplete WIP) | **DELETE** | Aborted; remove file. |
+**Summary:** 11 companion-file artifacts across 3 distinct byte formats
+(`.dict`, `.presence`, `.offsets`, `.po.presence`). All 11 currently have
+their **byte assembly in OCaml**; reader sides are partially in F\*
+(headers + bit-tests for `.dict` / `.presence`; nothing for `.offsets` or
+`.po.presence`). Zero round-trip witnesses exist today.
 
 ---
 
-## Aggregate summary
+## 5. Done-criteria progress meter
 
-|  | Bytes / LoC | Class A | Class P | Class S |
-|---|---:|---:|---:|---:|
-| `factoidal_http.ml` | 2500 | ~2100 | ~50 | ~350 |
-| `RDF_CottasStore.ml` (post-patch) | 2500 | ~1400 | ~150 | ~950 |
-| `experimental_ocaml_glue/*.sh` | ~2700 | ~350 | ~310 | ~2000 |
-| **Total** | ~7700 | ~3850 (50%) | ~510 (7%) | ~3300 (43%) |
+Re-stated from the recovery plan; current numbers below.
 
-**~43% of OCaml-side bytes are class S** — semantics that must lift
-back to F\* before the project can be honestly described as F\*-verified
-on the on-disk backend.
+| Metric | Target (Phase 9) | Current |
+|---|---:|---:|
+| `VIOLATION-SEM` entries (Section 2) | 0 | 12 |
+| `MIXED` entries (Section 2) | 0 | 7 |
+| Hand-written `.ml` files in `formal/fstar/ocaml-output/` (excluding `EXTRACTED`) | 0 (all under `bin/<consumer>/`) | 9 (the audit set; plus `factoidal_http_client.ml`, `factoidal_http_main.ml`, `factoidal_serve_debug.ml`, `factoidal_serve_jsoo.ml`, `OWL_QueryEval.ml`, `OWL_QueryRewrite.ml` — see note below) |
+| Glue patches that aren't `ASSUME-*` (Section 3) | 0 | 13 (in `experimental_ocaml_glue/`: `cottas_ondisk_runtime.sh`, `cottas_ondisk_z_lazy_open.sh`, `cottas_ondisk_zzzzz_ondisk_index.sh` (writer half), `cottas_ondisk_zzzzzz_lamed3_offset_idx.sh`, `cottas_ondisk_zzzzzzzzzzzzz_compound_po_writer.sh`, `ballyhoo_hdt_runtime.sh`, `cottas_inmem_encoder_runtime.sh`, `cottas_runtime.sh`. In `minimal_regrettable_glue_code_each_with_an_open_issue/`: #53, #64, #65, #66, #67, #68. Plus `MIXED` ones #62, #63, #95, #103.) |
+| Companion-file artifacts with byte-format-spec in F\* (Section 4) | 11 / 11 | 0 / 11 (readers partially in F\*; writers all OCaml) |
+| Hash-based round-trip witnesses in CI (Section 4) | 11 | 0 |
+| Codename violators retired (Yod6, Tet3, Lamed3, Mem5, Pe5, Bet7, Tav5, Heth3) | 8 / 8 | 0 / 8 |
 
----
+Notes on the hand-written-`.ml` count:
 
-## "Verified" claim qualification (mandatory until unwind complete)
-
-Until Phases 2.2–2.8 land, every README, demo page, talk slide, and PR
-description that mentions verification must use this qualified
-language:
-
-> Factoidal's RDF parsers (N-Triples, Turtle, N-Quads, TriG, RDF/XML,
-> CSV/TSV results) and SPARQL 1.1 algebra are formally verified in
-> F\* and extracted to OCaml/JS/WASM via mechanical extraction. The
-> COTTAS on-disk backend currently has unverified OCaml-side
-> caching, indexing, and optimisation layers (~3300 LoC) that are
-> being migrated back to F\* (tracked in
-> docs/designissues/fstar-purity-unwind.md). Until that migration is
-> complete, the "verified" claim applies to the parser/algebra
-> stack but not yet to the COTTAS on-disk runtime path.
-
-Removing the qualifier requires Phases 2.5–2.7 done at minimum.
+- The recovery plan's Phase 8 target is "0 hand-written `.ml` in
+  `formal/fstar/ocaml-output/`." The audit set has 9 hand-written `.ml`
+  files. There are several additional small hand-written files
+  (`factoidal_http_client.ml`, `factoidal_http_main.ml`,
+  `factoidal_serve_debug.ml`, `factoidal_serve_jsoo.ml`,
+  `OWL_QueryEval.ml`, `OWL_QueryRewrite.ml`) that were not in the audit
+  brief; a Phase 8 sweep should classify and relocate those too.
+- After Phase 8 the only `.ml` in `formal/fstar/ocaml-output/` should be
+  `EXTRACTED` files (auto-generated by F\*) plus a small fixed set of
+  `assume val` realisations the build allows in.
 
 ---
 
-## Status update 2026-05-01
+## 6. Sequencing addendum
 
-**Phases 2.5-2.7 done.** The COTTAS on-disk runtime is now F\*-resident:
+The recovery plan's default order is preserved:
 
-- Phase 2.5a-e: `cottas_ondisk_search` / `_estimate` / `_search_limited`
-  are F\*-extracted; the OCaml `search_fast` / `estimate_fast` / `walk_rg`
-  shadow shims are gone (PR #122).
-- Phase 2.6: F\* compound (p, o) presence-bitmap prune; Yod6/Tet3/Lamed3
-  redirected to F\* `PresenceBitmap` (PR #123, retired 11 dead patches +
-  −213 LoC dead OCaml shadow logic).
-- Phase 2.7: Bet7 lazy populate retired in spirit — page cache logic
-  lives in F\* `RDF.CottasStore.PageCache`; OCaml only owns the storage
-  cell.
+1. **Phase 1 — `RDF.Store.Capabilities.fst` contract.**
+   Dependency root. Blocks 2, 3, 4, 6.
+2. **Phase 2 — Columnar reorg.**
+   Pure namespace-level. Renames `RDF.CottasStore.PresenceBitmap.fst`,
+   `CompoundPresenceBitmap.fst`, `PageCache.fst` under `RDF.Store.Columnar.*`.
+   Required by 4, 6.
+3. **Phase 3 — Easy violators (parallel).**
+   - **Tav5** (`SPARQL.Eval.Limits.fst`, XS effort): retires Tav5 in
+     `factoidal_http.ml:950,961,1013,1052`. Independent of COTTAS work.
+   - **Bet7** (`SPARQL.Plan.Loader.fst`, S effort): retires
+     `cottas_ondisk_z_lazy_open.sh` + `factoidal_http.ml:613`. Depends on
+     Phase 2.
+4. **Phase 4 — Pruning + estimate (one PR).**
+   `SPARQL.Plan.Pruning.fst` + `SPARQL.Plan.Estimate.fst`. Retires
+   **Yod6**, **Tet3**, **Mem5** simultaneously (they share the
+   presence-bitmap reader).
+5. **Phase 5 — Time budget (2 PRs: design + migration).**
+   `SPARQL.Eval.TimeBudget.fst` + `assume val now_ms` realisation +
+   `SPARQL.Eval.Limits.fst` interaction. Retires **Heth3**.
+6. **Phase 6 — Offset index (1-2 PRs).**
+   `RDF.Store.Columnar.OffsetIndex.fst` (NEW) — file format spec +
+   verified reader + serialiser + roundtrip lemma + `SPARQL.Plan.AccessPath.fst`
+   chooser. Retires **Lamed3**. **Performance-critical**: must preserve
+   the 6 s → 200 ms win. Benchmark required.
+7. **Phase 6.5 (audit-suggested, slot between Phase 6 and 7).**
+   Companion-file-writer migration: per Section 4, all 11 artifacts must
+   gain `serialize`/`parse`/roundtrip lemma in F\* and a hash-roundtrip CI
+   test. The `.po.presence` writer (Compound) and `.p.offsets` writer
+   (Lamed3) are covered by Phases 4 + 6 respectively; this sub-phase
+   tackles the simpler `.dict` + `.presence` per-column writers
+   (`Cottas_companion_writer` in `cottas_ondisk_zzzzz_ondisk_index.sh`).
+8. **Phase 7 — Explain (1 PR).**
+   `SPARQL.Plan.Explain.fst` builds on Phases 4 + 6. Retires **Pe5**,
+   relocates `factoidal_explain.ml` to `bin/factoidal-explain/`.
+9. **Phase 8 — Consumer relocation (1 large PR).**
+   Move all hand-written `.ml` from `formal/fstar/ocaml-output/` to
+   `bin/<consumer>/`. Sweeps:
+   - `factoidal_http.ml` + `factoidal_http_main.ml` + `factoidal_serve.ml`
+     + `factoidal_serve_debug.ml` + `factoidal_serve_jsoo.ml` →
+     `bin/factoidal-http/`
+   - `factoidal_cli.ml` + `factoidal_dump_nq.ml` → `bin/factoidal-cli/`
+   - `factoidal_explain.ml` → `bin/factoidal-explain/` (after Phase 7
+     extracts the semantic core)
+   - `w3c_runner.ml` + `69_runner_io_glue.sh` → `bin/w3c-runner/`
+   - `rdfc10_runner.ml` → `bin/rdfc10-runner/`
+   - `owl_runner.ml` + `OWL_QueryEval.ml` + `OWL_QueryRewrite.ml` →
+     `bin/owl-runner/`
+   - `cottas_ondisk_smoketest.ml` → `bin/cottas-smoketest/`
+   - `factoidal_http_client.ml` → `bin/factoidal-http/` (or merge if dead).
+   Tighten `check-fstar-purity.yml` so `formal/fstar/ocaml-output/`
+   admits only `EXTRACTED` files and a fixed-list of `assume val`
+   realisations.
+10. **Phase 8.5 (audit-suggested) — Migrate remaining
+    minimal_regrettable `VIOLATION-SEM` patches.** Issues #53, #64, #65,
+    #66, #67, #68 each become a small F\*-only PR. None block earlier
+    phases (they're independent of the COTTAS planner work) but they
+    must be retired before Phase 9.
+11. **Phase 9 — Drop the qualifier.** Audit shows zero violators; CI gate
+    enforces; rule #11 caveat removed.
 
-**factoidal_http.ml unwind:** four small JSON-shaping migrations on top
-of the COTTAS work:
+### Adjustments suggested by this audit
 
-- PR #126 (merged): `json_escape` → `SPARQL.JSON.Escape.fst`.
-- PR #127 (open): `status_text` + `cors_headers` + `cors_policy`
-  → `SPARQL.HTTP.Response.fst`.
-- PR #128 (open): `/backend-info.json` renderer + aggregation rule
-  (addresses 2026-04-26 reviewer-flagged aggregation bug, now
-  auditable in F\*) → `SPARQL.HTTP.BackendInfo.fst`.
-- PR #129 (open): `parliament_label` + `render_queries_index`
-  → `SPARQL.HTTP.QueriesIndex.fst`.
-- In flight on `claude/http-update-sandbox-to-fstar`: `sandbox_op` +
-  `sandbox_update` + `expand_user_graph` (~170 LoC of update-policy
-  semantics) → `SPARQL.Update.Sandbox.fst`. After this, the largest
-  remaining S-class items in factoidal_http.ml (query timeout /
-  result-row cap / 503-Retry-After) need new F\*-typed infrastructure
-  before they can move.
-
-**LoC delta** (from the 2026-04-26 table; eyeballed):
-
-| File | Before (S-class) | After |
-|------|---:|---:|
-| `factoidal_http.ml` | ~350 | ~50 (after #127/#128/#129/sandbox land) |
-| `RDF_CottasStore.ml` (post-patch) | ~950 | ~0 (F\*-extracted; the .ml file is mechanical extract) |
-| `experimental_ocaml_glue/*.sh` | ~2000 | ~250 (rule-#11(c) thin glue: token Hashtbls, page-cache cell, lazy-populate hooks) |
-| **Total** | ~3300 | **~300** (≈10% of original) |
-
-**Relaxed verification claim** (replaces the 2026-04-26 qualified
-language above): once #127/#128/#129/sandbox are merged, READMEs /
-demos / talks may state:
-
-> Factoidal's RDF parsers, SPARQL 1.1 algebra, and the COTTAS on-disk
-> backend (search, estimate, page cache, presence-bitmap prune) are
-> formally verified in F\* and extracted to OCaml/JS/WASM via mechanical
-> extraction. The HTTP server and CLI are hand-written OCaml glue
-> (socket I/O, file open, argv parsing, CORS policy dispatch); the
-> semantic policy they implement (JSON rendering, response codes,
-> CORS allowlists, /backend-info aggregation, /parliament-queries
-> assembly, update sandboxing) is itself F\*-extracted.
-
-The pre-relaxation qualifier remains the safe choice for any document
-that goes out **before** PRs #127/#128/#129 merge.
-
-**Residual S-class items** still in OCaml (deferred, need F\* prep):
-
-- Query timeout / `with_query_timeout` (factoidal_http.ml:1201-1225) —
-  needs F\* cancellation-token type + `assume val` clock; signal
-  handling (SIGALRM) stays OCaml.
-- Result-row cap (`exceeds_cap`, `result_cap_response`,
-  factoidal_http.ml:1016-1037) — needs cap policy as F\*-typed value
-  threaded into the evaluator.
-- 503/Retry-After under loading (handle_connection ~2150-2300) —
-  needs F\*-typed server-state ADT.
-- `run_query` dispatch (factoidal_http.ml:1039-1136) — mixes glue
-  with policy; needs split first.
-
-These are the natural Phase 2.9 / 3.0 targets.
-
----
-
-## Status update 2026-05-06
-
-Five days after the 2026-05-01 update; further migrations have landed
-on `claude/main` plus three new ones are on this commit's branch
-queue. The "in flight" PRs from the previous status are all merged.
-
-### Landed on claude/main since 2026-05-01
-
-- **PR #126** (json_escape → SPARQL.JSON.Escape.fst) — was already
-  merged, included for completeness.
-- **PR #127** (status_text + cors_headers + cors_policy
-  → SPARQL.HTTP.Response.fst) — **merged**.
-- **PR #128** (/backend-info.json renderer + aggregation
-  → SPARQL.HTTP.BackendInfo.fst) — **merged**.
-- **PR #129** (parliament_label + render_queries_index
-  → SPARQL.HTTP.QueriesIndex.fst) — **merged**.
-- **claude/http-update-sandbox-to-fstar** (sandbox_op + sandbox_update
-  + expand_user_graph → SPARQL.Update.Sandbox.fst) — **merged**.
-- **PR #136** — per-stage query timing (Server-Timing header +
-  /admin/recent.json + admin landing page). Adds ~280 LoC of *thin
-  glue* to factoidal_http.ml (mutex-protected counters, ring buffer,
-  JSON renderers, admin page). The Phase 2.6 audit-by-process review
-  classified all of it as rule-#11(c)-acceptable per the "threading
-  runtime mutable state through request handlers" allowance. The
-  pre-existing SIGALRM-based `with_query_timeout` is grandfathered
-  pending the F\* `time_budget` / `cancellation_polled` infrastructure.
-  No net-new S-class drift. See `2026-05-06-fstar-drift-recheck.md`.
-- **PR #137** — Roaring bitmap F\* port Phase A under
-  `experimental/roaring-fstar/` (Spec, ArrayContainer, Bits,
-  IODemo, Test, all zero-admit / zero-assume). Doesn't modify any
-  existing F\* or OCaml runtime — purely additive experimental work.
-- **PR #138** — F\*-purity CI gate expanded to also watch
-  `factoidal_http.ml` and `factoidal_explain.ml`, with patterns for
-  re-introduction of migrated functions / SIGALRM regression /
-  planner-shape duplication. Soft-mode preserved. Plus the code-name
-  glossary at `docs/code-name-glossary.md`.
-- **PR #139** — `rdf_format` (the duplicated extension/short-label
-  table from factoidal_http.ml + factoidal_cli.ml) → `RDF.Format.fst`.
-  Net OCaml-side semantic LoC retired: -25.
-
-### In review on this audit's commit
-
-- **PR #140** — `term_short` / `term_to_ntriples` / `term_to_turtle`
-  / `pattern_*_short` / `triple_pattern_short`
-  → `RDF.Pretty.fst`. The two divergent prefix tables (CLI's
-  rdf/rdfs/xsd/owl/foaf/dcterms/dc/schema vs. explain's parliament-
-  corpus rdf/rdfs/xsd/owl/geo/`:`) become F\* `prefix_table`
-  constants; the algorithm becomes a single parameterised core.
-  Net OCaml-side semantic LoC retired: -95.
-- **PR #141** — `parse_cors_value` + `cors_mode_to_string` +
-  `select_vars`. The first two move to `SPARQL.HTTP.Response.fst`
-  (the .fst that already owns `cors_policy` / `cors_headers`); the
-  third learns to call the existing F\* `select_item_vars` instead
-  of reimplementing it inline. Net OCaml-side semantic LoC retired:
-  -21.
-
-### Updated LoC estimate
-
-| File | 2026-04-26 | 2026-05-01 | 2026-05-06 |
-|------|---:|---:|---:|
-| `factoidal_http.ml` (S-class only) | ~350 | ~50 | ~30 |
-| `factoidal_cli.ml` (S-class only) | n/a | n/a | ~10 (new from #140 audit) |
-| `factoidal_explain.ml` (S-class only) | ~580 (#2 in unwind) | ~580 | ~510 (after #140) |
-| `RDF_CottasStore.ml` | ~950 | ~0 | ~0 |
-| `experimental_ocaml_glue/*.sh` | ~2000 | ~250 | ~250 |
-| **Total** | ~3300 | ~300 | ~250 (incl. #140 / #141 once merged) |
-
-The biggest remaining S-class chunk is in `factoidal_explain.ml`'s
-optimiser/explain machinery (`bs_json`, `tpx_json`, the per-pattern
-estimator loop). The pretty-printers were the easy part of that
-file. Phase 2.2 of the unwind addresses the rest; it's the natural
-next migration target after #140 / #141 land.
-
-### Remaining "still S-class, blocked on new F\* infrastructure"
-
-Unchanged from 2026-05-01:
-
-- Query-timeout policy (`with_query_timeout`, factoidal_http.ml).
-  Needs `time_budget : nat` + `assume val cancellation_polled :
-  unit -> bool` discipline (audit §A).
-- Result-row cap enforcement (Tav5 / `--max-rows`). Same dependency
-  on the cancellation discipline.
-- 503-Retry-After dispatch. Same.
-
-These three are the only pieces of `factoidal_http.ml` that the
-audit still flags as S-class without a clear migration path on
-existing infrastructure.
-
-### Verification claim
-
-Once #140 / #141 land, the relaxed verification language from the
-2026-05-01 update is approximately accurate without further
-qualification beyond the standard rule-#11 caveat. The HTTP layer's
-remaining "S-class" surface is ~30 LoC of timeout/cap policy that's
-*architecturally* blocked rather than *engineering* blocked.
-
-**The CLAUDE.md rule-#11 FREEZE language can be lifted** for the
-migrate-to-F\* direction — the audit is substantively complete; the
-only remaining work is migrations enabled by new F\* infrastructure
-(timeout/cap/retry-after) and the planner duplication in
-`factoidal_explain.ml`. The agent-prompt-writing discipline (don't
-encourage "Shape A / Shape B" justifications for OCaml-side
-semantic logic) should remain — that was the original cause of the
-drift, and CI alone (omega3 gate) doesn't catch every shape.
-
-### Process signal: PR #135 (in-memory COTTAS Phase A.5 re-scope)
-
-Worth flagging as a **positive** signal of the audit-by-process
-working as intended. The dispatch prompt's plan would have required
-~6 OCaml-side patches across `Parquet_Footer.ml` + `RDF_CottasStore.ml`
-that "qualify as semantic glue rather than pure I/O routing."
-The agent recognised this and reported back recommending a re-scope
-to F\*-first (a new `GB_InMem` graph_backend variant) rather than
-landing patches. Doc at
-`docs/designissues/in-memory-cottas-phase-a5-block.md`.
-
-This is the sort of upstream gating the audit was meant to enable:
-the boundary classifications make the "is this glue or semantics?"
-question answerable before code lands, not after.
-
-### Next recheck
-
-After #140 / #141 / the timeout F\* infrastructure design lands; or
-in two weeks; whichever first.
+- The audit confirms the recovery plan's default order is correct. The
+  only addition is **Phase 6.5 (companion-file-writer migration for
+  `.dict`/`.presence`)** which the original plan implicitly assumed
+  Phase 4 covered but in fact Phase 4 only retires Yod6/Tet3/Mem5
+  (the *consumers* of the bitmaps); the *writers* (byte assembly) are
+  separate work.
+- Tav5 (Phase 3) genuinely is XS effort and could land before any of the
+  Capabilities/Columnar reorg. Suggest doing it as a kickoff PR to build
+  reviewer confidence.
+- Issue #95 (stack-safe list ops) and #103 (ASCII fast-path) are both
+  `MIXED` because they post-extraction-rewrite F\* output. The right fix
+  for both is to change the F\* source to extract correctly; this can
+  happen in parallel with the planner work and isn't in the recovery
+  plan's critical path.
 
 ---
 
-## Migration order (consolidated)
+## Cross-references
 
-Reproduces the unwind plan with this audit's classifications:
-
-1. **Phase 2.2 — Pe5 explain → F\* planner.** Class **S** in
-   `factoidal_explain.ml`. ~0.5 day.
-2. **Phase 2.3 — Vav3 read-path verify.** Class **A** confirmation. ~0.25 day.
-3. **Phase 2.4 — Aleph6 count-limit retire.** Class **P** removal. ~0.5 day.
-4. **Phase 2.5 — `cottas_ondisk_runtime.sh` retirement.** Class **S** lift, big one. ~1.5–2.5 days.
-5. **Phase 2.6 — Yod6/Tet3/Lamed3 to F\* + factoidal_http.ml policy lift.** Class **S** lifts. ~1.5–2 days. **Expanded scope per reviewer.**
-6. **Phase 2.7 — Bet7 lazy populate retire.** Class **P** removal. ~0.25 day.
-7. **Phase 2.8 — CI checks (rule-#11 grep + `bench_ukpar_modern.py` gate).** ~0.5 day.
-
-**Total agent-pace:** ~5.5–6 days. Human-pace would be ~3–4 weeks.
-
----
-
-## What this doc is not
-
-- An implementation plan. See `fstar-purity-unwind.md` for that.
-- A finished audit. Lines/LoC counts are eyeballed and approximate. A
-  follow-up that runs `tokei` or per-function size measurement would
-  give precise numbers.
-- An exhaustive list. Other OCaml-side files (e.g.
-  `factoidal_cli.ml`, `w3c_runner.ml`) may have similar drift; not
-  audited here. Add as separate audit targets if the unwind reveals
-  them.
-
----
-
-## Provenance
-
-- Reviewer feedback received and incorporated 2026-04-26.
-- Classifications by top-level Claude (the same agent that wrote the
-  prompts that caused the drift). Honest about that bias: I may
-  under-classify items as **A** because that minimises the unwind
-  scope I'm responsible for. Reviewer / human can re-classify.
-- Eyeballed LoC. Precise figures via `tokei` would be a small
-  follow-up.
+- [`CLAUDE.md`](../../CLAUDE.md) — Iron Rule #11 (corrected taxonomy)
+- [`docs/designissues/2026-05-07-query-planning-fstar-recovery.md`](2026-05-07-query-planning-fstar-recovery.md)
+  — 9-phase recovery plan; this audit is Phase 0
+- [`docs/designissues/2026-05-07-io-verification-and-third-party.md`](2026-05-07-io-verification-and-third-party.md)
+  — `assume val` taxonomy + hash-based round-trip pattern + HACL\* /
+  EverParse / UUID / regex policy
+- [`docs/code-name-glossary.md`](../code-name-glossary.md) — Yod6 / Tet3 /
+  Lamed3 / Mem5 / Pe5 / Bet7 / Tav5 / Heth3 decoder (historical;
+  **no new short-codes** per recovery plan)


### PR DESCRIPTION
## Summary

Phase 0 of the F\*-only query-planning recovery plan. Replaces the stale 552-line audit (2026-04-26 → 2026-05-06 vintage) with a 342-line classification of every hand-written `.ml` and every glue patch against the corrected taxonomy now on `claude/main` (per #166 + #171).

### Headline numbers

- **8,473 LoC** catalogued across 9 hand-written `.ml` files + 14 `experimental_ocaml_glue/*.sh` patches + 13 `minimal_regrettable_glue_code_each_with_an_open_issue/*.sh` patches.
- 330 `CONSUMER` defs (relocate Phase 8 to `bin/<consumer>/`)
- **12 `VIOLATION-SEM`** + 7 `MIXED` defs (the migration backlog)
- 13 glue patches that aren't `ASSUME-*` (must retire)
- **11 / 11 companion-file writers** carry byte-format logic in OCaml (per the I/O verification annex, all 11 must migrate the byte assembly into F\*)

### All 8 codename violators confirmed and matched to target F\* modules

| Codename | Target F* module |
|---|---|
| Yod6 | `SPARQL.Plan.Pruning.fst` |
| Tet3 | `SPARQL.Plan.Pruning.fst` + `RDF.Store.Columnar.CompoundPresence.fst` |
| Lamed3 | `RDF.Store.Columnar.OffsetIndex.fst` (NEW) + `SPARQL.Plan.AccessPath.fst` |
| Mem5 | `SPARQL.Plan.Estimate.fst` |
| Pe5 | `SPARQL.Plan.Explain.fst` |
| Bet7 | `SPARQL.Plan.Loader.fst` + `RDF.Store.InMemory.fst` |
| Tav5 | `SPARQL.Eval.Limits.fst` |
| Heth3 | `SPARQL.Eval.TimeBudget.fst` |

### Surprise findings

- **3 non-codename violators** in `factoidal_http.ml`: `load_cottas_dataset`, `load_cottas_part`, `build_dataset_backend`, `select_vars` star-projection fallback. New target: `RDF.Store.Loader.fst` + `RDF.Store.Combine.fst`.
- Audit recommends a **Phase 6.5** for `.dict` / `.presence` writer migration — the recovery plan's Phase 4 retires the *consumers* of those formats, but the *writers* are separate work.
- Several smaller hand-written `.ml` files weren't in the original brief but should be swept in Phase 8: `factoidal_http_client.ml`, `factoidal_http_main.ml`, `factoidal_serve_debug.ml`, `factoidal_serve_jsoo.ml`. Plus `OWL_QueryEval.ml` and `OWL_QueryRewrite.ml` are MIXED.

## What this unblocks

- All 8 codename-violator migrations (recovery plan Phases 4–7).
- Time-budget infra design (Phase 5) — Heth3 target now precisely scoped.
- Phase 8 consumer relocation — full file-by-file inventory now exists.
- Path to Phase 9 ("verified RDF/SPARQL" without footnotes).

## Test plan

Doc-only PR. Validation = the doc is internally consistent and matches `claude/main`'s file inventory.

- [x] All 8 codename violators present.
- [x] Companion-file writers enumerated (per the I/O verification annex's hash-based round-trip pattern).
- [x] Done-criteria progress meter present (currently `0/8` violators retired).