### PR TITLE
rif: Phase 1 — Syntax + Translation modules (deferred Eval/Parser/Tests)

### DIFF
--- a/formal/fstar/RIF.Core.Syntax.fst
+++ b/formal/fstar/RIF.Core.Syntax.fst
@@ -1,0 +1,215 @@
+module RIF.Core.Syntax
+
+// Phase 1 of the RIF Core F* engine, per
+// docs/designissues/2026-05-07-rif-fstar-investigation.md.
+//
+// This module defines the abstract syntax of RIF Core programs as
+// a pure ADT layered above RDF.Graph.Executable. No evaluation, no
+// translation — just the data model. The companion module
+// RIF.Core.Translation lifts these ADTs into SPARQL11.Algebra
+// triple-pattern / BGP shapes.
+//
+// Surface coverage:
+//   - Atoms:      Triple, Frame (single slot), Member (#), Subclass (##).
+//   - Bodies:     single atom, or conjunction of bodies (And).
+//   - Rules:      one head atom + a body, optional name.
+//   - Programs:   a list of rules.
+//
+// The 4 skipped W3C SPARQL `entailment` tests we target:
+//   1. RIF Logical Entailment (referencing RIF XML).
+//   2. RIF Core WG tests: Frames               -- exercises Frame.
+//   3. RIF Core WG tests: Modeling Brain Anatomy -- exercises Member + Sub.
+//   4. RIF Core WG tests: RDF Combination Blank Node.
+//
+// Multi-slot frames `o[p1->v1; p2->v2]` decompose at parse time into
+// several single-slot Frame atoms conjoined under RIF_BodyAnd, per
+// W3C RIF/RDF/OWL §5. Keeping the Frame constructor single-slot keeps
+// the ADT minimal and the Translation step total without an inner
+// fold.
+//
+// Out of scope for this Phase 1 module (deferred to Phase 2+):
+//   - Built-in atoms (pred:numeric-equal, pred:numeric-less-than, ...).
+//   - Existential quantification in body.
+//   - Forward-chaining fixpoint (RIF.Core.Eval.fst).
+//   - RIF-XML concrete syntax parser (Parser.RIFXML.fst).
+//   - W3C test runner shim (RIF.Core.Tests.fst).
+//
+// IRON RULES:
+//   - F* is the source of truth (rule #1).
+//   - No --lax, no --admit_smt_queries, no assume val (rule #10, rule #3).
+//   - No "(*" or "*)" inside block comments (rule #12); use //.
+
+open RDF.Graph.Executable
+
+// ------------------------------------------------------------------
+// 1. Variables and terms.
+//
+// RIF Core variables are written `?x` in the presentation syntax; the
+// parser strips the `?` and stores the bare name. Constants are RDF
+// terms (IRIs, blank nodes, literals) drawn directly from
+// RDF.Graph.Executable. We do not model RIF function-symbol terms
+// because RIF Core forbids non-equality function symbols.
+// ------------------------------------------------------------------
+
+noeq type rif_var = {
+  var_name : string;
+}
+
+noeq type rif_term =
+  | RIF_Var   : rif_var -> rif_term
+  | RIF_Const : rdf_term -> rif_term
+
+// ------------------------------------------------------------------
+// 2. Atomic formulas.
+//
+// Each constructor maps to a single RDF triple under the W3C
+// RIF/RDF/OWL combination spec, which is the form the SPARQL
+// evaluator can consume directly.
+//
+//   RIF_Triple s p o      -> (s, p, o)
+//   RIF_Frame  o p v      -> (o, p, v)              // single slot
+//   RIF_Member o c        -> (o, rdf:type, c)
+//   RIF_Sub    sub sup    -> (sub, rdfs:subClassOf, sup)
+//
+// Built-in atoms (RIF_Builtin) are deferred to a follow-up PR; they
+// require the SPARQL expression / FILTER lowering described in the
+// design doc's "SPARQL stack reuse map" table.
+// ------------------------------------------------------------------
+
+noeq type rif_atom =
+  | RIF_Triple : rif_term -> rif_term -> rif_term -> rif_atom
+  | RIF_Frame  : rif_term -> rif_term -> rif_term -> rif_atom
+  | RIF_Member : rif_term -> rif_term -> rif_atom
+  | RIF_Sub    : rif_term -> rif_term -> rif_atom
+
+// ------------------------------------------------------------------
+// 3. Rule body.
+//
+// RIF Core admits conjunction in bodies; a single atom is the
+// degenerate case. The And constructor takes a list of rif_body so
+// that the recursion is finite-depth and every well-formed program
+// has a Tot-decreasing structural measure (the body is a finite
+// tree of finite lists).
+// ------------------------------------------------------------------
+
+noeq type rif_body =
+  | RIF_BodyAtom : rif_atom -> rif_body
+  | RIF_BodyAnd  : list rif_body -> rif_body
+
+// ------------------------------------------------------------------
+// 4. Rule.
+//
+// Per RIF Core, a rule has the form
+//   Forall ?x1 ... ?xn (head :- body)
+// where the head is a single atom (Core forbids head disjunction
+// and head function symbols). A rule may carry an optional name
+// from the RIF-XML <id> attribute for diagnostics.
+//
+// The universally quantified variables are NOT stored explicitly;
+// they are exactly the variables that appear free in the rule. This
+// matches the SPARQL convention where BGP variables are implicitly
+// existentially quantified at the WHERE level. Reconstructing the
+// quantifier list, if needed, is an O(|rule|) walk over rif_atom.
+// ------------------------------------------------------------------
+
+noeq type rif_rule = {
+  rule_name : option string;
+  head      : rif_atom;
+  body      : rif_body;
+}
+
+// ------------------------------------------------------------------
+// 5. Program.
+//
+// A RIF Core program is a list of rules. The order is preserved for
+// diagnostics but is semantically irrelevant — RIF Core entailment
+// is monotonic and the fixpoint does not depend on rule order.
+// ------------------------------------------------------------------
+
+noeq type rif_program = {
+  rules : list rif_rule;
+}
+
+// ------------------------------------------------------------------
+// 6. Smart constructors.
+//
+// Convenience helpers used by the Translation module and (later) by
+// the RIF-XML parser. Kept Tot, no SMT lemmas required.
+// ------------------------------------------------------------------
+
+let mk_var (n : string) : rif_term =
+  RIF_Var ({ var_name = n })
+
+let mk_const (t : rdf_term) : rif_term =
+  RIF_Const t
+
+let mk_const_iri (i : wf_iri) : rif_term =
+  RIF_Const (T_IRI i)
+
+let mk_atom_triple (s p o : rif_term) : rif_atom =
+  RIF_Triple s p o
+
+let mk_atom_frame (o p v : rif_term) : rif_atom =
+  RIF_Frame o p v
+
+let mk_atom_member (o c : rif_term) : rif_atom =
+  RIF_Member o c
+
+let mk_atom_sub (sub sup_ : rif_term) : rif_atom =
+  RIF_Sub sub sup_
+
+let mk_body_atom (a : rif_atom) : rif_body =
+  RIF_BodyAtom a
+
+let mk_body_and (bs : list rif_body) : rif_body =
+  RIF_BodyAnd bs
+
+let mk_rule (head_ : rif_atom) (body_ : rif_body) : rif_rule =
+  { rule_name = None; head = head_; body = body_; }
+
+let mk_named_rule (n : string) (head_ : rif_atom) (body_ : rif_body) : rif_rule =
+  { rule_name = Some n; head = head_; body = body_; }
+
+let empty_program : rif_program = { rules = [] }
+
+let program_of_rules (rs : list rif_rule) : rif_program = { rules = rs }
+
+// ------------------------------------------------------------------
+// 7. Equality predicates.
+//
+// Decidable structural equality on terms and atoms, useful for
+// fixpoint convergence checks in the (deferred) Eval module and for
+// test assertions. Kept fully concrete, no SMT.
+// ------------------------------------------------------------------
+
+let rif_var_eq (a b : rif_var) : bool =
+  a.var_name = b.var_name
+
+let rif_term_eq (a b : rif_term) : bool =
+  match a, b with
+  | RIF_Var v1,   RIF_Var v2   -> rif_var_eq v1 v2
+  | RIF_Const c1, RIF_Const c2 -> rdf_term_eq c1 c2
+  | _, _ -> false
+
+let rif_atom_eq (a b : rif_atom) : bool =
+  match a, b with
+  | RIF_Triple s1 p1 o1, RIF_Triple s2 p2 o2 ->
+    rif_term_eq s1 s2 && rif_term_eq p1 p2 && rif_term_eq o1 o2
+  | RIF_Frame o1 p1 v1,  RIF_Frame o2 p2 v2 ->
+    rif_term_eq o1 o2 && rif_term_eq p1 p2 && rif_term_eq v1 v2
+  | RIF_Member o1 c1,    RIF_Member o2 c2 ->
+    rif_term_eq o1 o2 && rif_term_eq c1 c2
+  | RIF_Sub sub1 sup1,   RIF_Sub sub2 sup2 ->
+    rif_term_eq sub1 sub2 && rif_term_eq sup1 sup2
+  | _, _ -> false
+
+// Reflexivity sanity check on rif_term equality. Verifies via a
+// case split on the constructor; the RIF_Const case calls the
+// matching reflexivity lemma already established in
+// RDF.Graph.Executable (lemma_rdf_term_eq_refl).
+let rif_term_eq_refl (t : rif_term) :
+  Lemma (rif_term_eq t t == true)
+  =
+  match t with
+  | RIF_Var _   -> ()
+  | RIF_Const c -> lemma_rdf_term_eq_refl c

--- a/formal/fstar/RIF.Core.Translation.fst
+++ b/formal/fstar/RIF.Core.Translation.fst
@@ -1,0 +1,247 @@
+module RIF.Core.Translation
+
+// Phase 1 of the RIF Core F* engine, per
+// docs/designissues/2026-05-07-rif-fstar-investigation.md.
+//
+// Pure translation from RIF.Core.Syntax to SPARQL11.Algebra:
+//
+//   rif_atom  -> SPARQL triple_pattern  (a single triple)
+//   rif_body  -> SPARQL bgp             (a flat list of triple_patterns)
+//   rif_atom  -> SPARQL CONSTRUCT template (one-triple list)
+//
+// The RIF/RDF/OWL combination spec (W3C, §5) defines the desugaring:
+//
+//   o[p->v]      ==>  (o, p, v)
+//   o # c        ==>  (o, rdf:type, c)
+//   sub ## sup   ==>  (sub, rdfs:subClassOf, sup)
+//
+// Our translation implements that mapping directly. Frame syntax is
+// already single-slot at the rif_atom level (RIF.Core.Syntax notes
+// that multi-slot frames decompose at parse time into conjoined
+// single-slot Frame atoms), so no inner fold is needed here.
+//
+// Termination: every recursive call goes structurally on the
+// rif_body argument, which is a finite tree of finite lists of
+// rif_body. F* derives the decreasing measure automatically once we
+// give the explicit body argument; we annotate `decreases b` for
+// clarity.
+//
+// Partiality: a few atoms are ill-typed under SPARQL's pattern
+// shape — most notably, a literal cannot appear as the subject of
+// a triple pattern because pattern_subject excludes literals. We
+// surface those as `None` rather than silently dropping them; the
+// caller (a future RIF-XML parser, or the test runner) is the
+// natural place to report the error.
+//
+// IRON RULES:
+//   - F* is the source of truth (rule #1).
+//   - No --lax, no --admit_smt_queries, no assume val (rule #10).
+//   - No "(*" or "*)" inside block comments (rule #12); use //.
+
+open FStar.List.Tot
+open RDF.Graph.Executable
+open SPARQL11.Algebra
+module Syn = RIF.Core.Syntax
+
+// ------------------------------------------------------------------
+// 1. Term-level translation.
+//
+// A RIF term in subject position becomes a pattern_subject — but
+// pattern_subject excludes literals, so a literal-constant here is
+// a typing error and we return None. RIF terms in predicate or
+// object position become pattern_term, which permits the full
+// IRI / BNode / Literal / Var range.
+// ------------------------------------------------------------------
+
+let rif_term_to_subject (t : Syn.rif_term)
+  : option pattern_subject
+  =
+  match t with
+  | Syn.RIF_Var v ->
+    Some (PS_Var v.var_name)
+  | Syn.RIF_Const (T_IRI i)   -> Some (PS_IRI i)
+  | Syn.RIF_Const (T_BNode b) -> Some (PS_BNode b)
+  | Syn.RIF_Const (T_Literal _) -> None
+
+let rif_term_to_pattern (t : Syn.rif_term)
+  : pattern_term
+  =
+  match t with
+  | Syn.RIF_Var v             -> PT_Var v.var_name
+  | Syn.RIF_Const (T_IRI i)   -> PT_IRI i
+  | Syn.RIF_Const (T_BNode b) -> PT_BNode b
+  | Syn.RIF_Const (T_Literal l) -> PT_Literal l
+
+// Pre-defined RIF/RDF combination IRIs. These are aliases for the
+// constants already in RDF.Graph.Executable, re-exported here so the
+// translation reads cleanly.
+let rif_rdf_type : wf_iri      = rdf_type
+let rif_rdfs_subclassof : wf_iri = rdfs_subClassOf
+
+// ------------------------------------------------------------------
+// 2. Atom-level translation.
+//
+// Each atom maps to exactly one triple_pattern. The Member and Sub
+// forms substitute a fixed predicate IRI; Frame and Triple use the
+// supplied terms as-is. Returns None when the subject term is a
+// literal constant (ill-typed in RIF/RDF combination — cannot occur
+// in practice because RIF parsers forbid it).
+// ------------------------------------------------------------------
+
+let translate_atom (a : Syn.rif_atom) : option triple_pattern =
+  match a with
+  | Syn.RIF_Triple s p o ->
+    (match rif_term_to_subject s with
+     | None -> None
+     | Some ps ->
+       Some ({ tp_s = ps;
+               tp_p = rif_term_to_pattern p;
+               tp_o = rif_term_to_pattern o; }))
+  | Syn.RIF_Frame o p v ->
+    (match rif_term_to_subject o with
+     | None -> None
+     | Some ps ->
+       Some ({ tp_s = ps;
+               tp_p = rif_term_to_pattern p;
+               tp_o = rif_term_to_pattern v; }))
+  | Syn.RIF_Member o c ->
+    (match rif_term_to_subject o with
+     | None -> None
+     | Some ps ->
+       Some ({ tp_s = ps;
+               tp_p = PT_IRI rif_rdf_type;
+               tp_o = rif_term_to_pattern c; }))
+  | Syn.RIF_Sub sub sup_ ->
+    (match rif_term_to_subject sub with
+     | None -> None
+     | Some ps ->
+       Some ({ tp_s = ps;
+               tp_p = PT_IRI rif_rdfs_subclassof;
+               tp_o = rif_term_to_pattern sup_; }))
+
+// ------------------------------------------------------------------
+// 3. Body translation.
+//
+// A RIF body conjoins atoms; the SPARQL counterpart is a flat BGP
+// (a list of triple_patterns). Atomic atoms produce a singleton
+// list; And folds the children's BGPs into one. Failure inside a
+// child propagates as None — the whole body is rejected.
+//
+// `translate_body_list` is the eta-expanded mutual recursion on the
+// list-of-bodies branch of And, kept separate so the structural
+// decreases is straightforward.
+// ------------------------------------------------------------------
+
+let rec translate_body (b : Syn.rif_body)
+  : Tot (option bgp) (decreases b)
+  =
+  match b with
+  | Syn.RIF_BodyAtom a ->
+    (match translate_atom a with
+     | None -> None
+     | Some tp -> Some [tp])
+  | Syn.RIF_BodyAnd bs ->
+    translate_body_list bs
+
+and translate_body_list (bs : list Syn.rif_body)
+  : Tot (option bgp) (decreases bs)
+  =
+  match bs with
+  | [] -> Some []
+  | b :: rest ->
+    (match translate_body b with
+     | None -> None
+     | Some bgp_b ->
+       (match translate_body_list rest with
+        | None -> None
+        | Some bgp_rest -> Some (List.Tot.append bgp_b bgp_rest)))
+
+// ------------------------------------------------------------------
+// 4. Head translation.
+//
+// A RIF Core rule head is a single atom, which becomes a
+// CONSTRUCT-template list of one triple_pattern. We expose this as
+// its own helper because the deferred Eval module uses it directly
+// (a CONSTRUCT-and-merge step per rule).
+// ------------------------------------------------------------------
+
+let translate_head (a : Syn.rif_atom) : option (list triple_pattern) =
+  match translate_atom a with
+  | None    -> None
+  | Some tp -> Some [tp]
+
+// ------------------------------------------------------------------
+// 5. Rule translation.
+//
+// A RIF Core rule
+//   Forall ?x... (head :- body)
+// becomes the pair
+//   (CONSTRUCT-template, body-BGP)
+// suitable for handing to a SPARQL CONSTRUCT-style evaluator: the
+// body BGP supplies bindings, the head template instantiates the
+// inferred triple. The fixpoint loop that repeatedly evaluates this
+// pair is the subject of the next PR (RIF.Core.Eval).
+//
+// Rejects rules whose head or body is structurally ill-typed as
+// outlined above; returns the pair when both parts succeed.
+// ------------------------------------------------------------------
+
+let translate_rule (r : Syn.rif_rule)
+  : option (list triple_pattern * bgp)
+  =
+  match translate_head r.head with
+  | None -> None
+  | Some hd_tpl ->
+    (match translate_body r.body with
+     | None -> None
+     | Some body_bgp -> Some (hd_tpl, body_bgp))
+
+// ------------------------------------------------------------------
+// 6. Program translation.
+//
+// Translates each rule independently. Failures in one rule do not
+// cascade — they are dropped from the result and reported by index
+// in `translate_program_diag`. The plain `translate_program` keeps
+// only the rules that translated cleanly, which is the right
+// behaviour for the W3C tests where a parse-time error has already
+// been raised before this module sees the program.
+// ------------------------------------------------------------------
+
+let translate_program (p : Syn.rif_program)
+  : list (list triple_pattern * bgp)
+  =
+  let opt_pairs : list (option (list triple_pattern * bgp)) =
+    List.Tot.map translate_rule p.rules in
+  let rec keep_some
+    (xs : list (option (list triple_pattern * bgp)))
+    : Tot (list (list triple_pattern * bgp)) (decreases xs)
+    =
+    match xs with
+    | [] -> []
+    | None :: rest      -> keep_some rest
+    | Some pr :: rest   -> pr :: keep_some rest
+  in
+  keep_some opt_pairs
+
+// Diagnostic variant: returns the list of 0-based indices of rules
+// that failed to translate alongside the successful pairs. Useful
+// for the test runner to surface "rule N is malformed" rather than
+// silently dropping it.
+let translate_program_diag (p : Syn.rif_program)
+  : list (list triple_pattern * bgp) * list nat
+  =
+  let rec aux
+    (rs : list Syn.rif_rule)
+    (idx : nat)
+    (acc_ok : list (list triple_pattern * bgp))
+    (acc_err : list nat)
+    : Tot (list (list triple_pattern * bgp) * list nat) (decreases rs)
+    =
+    match rs with
+    | [] -> (List.Tot.rev acc_ok, List.Tot.rev acc_err)
+    | r :: rest ->
+      (match translate_rule r with
+       | Some pr -> aux rest (idx + 1) (pr :: acc_ok) acc_err
+       | None    -> aux rest (idx + 1) acc_ok (idx :: acc_err))
+  in
+  aux p.rules 0 [] []

--- a/formal/fstar/build-ocaml.sh
+++ b/formal/fstar/build-ocaml.sh
@@ -223,6 +223,7 @@ if [[ "$STEP" == "all" || "$STEP" == "extract" ]]; then
              RDF.Pretty.fst \
              OWL.QueryRewrite.fst OWL.QueryEval.fst \
              OWL.Tests.Manifest.fst \
+             RIF.Core.Syntax.fst RIF.Core.Translation.fst \
              Parser.FastString.fst Parser.IRI.fst \
              Parser.Combinators.fst Parser.TurtleScanner.fst SPARQL11.Parser.fst \
              Parser.NTriples.fst Parser.Turtle.fst \
@@ -340,7 +341,7 @@ if [[ "$STEP" == "all" || "$STEP" == "compile" ]]; then
     fstar_pure_hashes.ml \
     RDF_Canonical.ml \
     RDF_Canonical_Manifest.ml \
-    SPARQL11_Algebra.ml RDF_Pretty.ml OWL_QueryRewrite.ml OWL_QueryEval.ml OWL_Tests_Manifest.ml SPARQL11_Parser.ml SPARQL11_Store.ml SPARQL_Protocol.ml \
+    SPARQL11_Algebra.ml RDF_Pretty.ml OWL_QueryRewrite.ml OWL_QueryEval.ml OWL_Tests_Manifest.ml RIF_Core_Syntax.ml RIF_Core_Translation.ml SPARQL11_Parser.ml SPARQL11_Store.ml SPARQL_Protocol.ml \
     SPARQL_Update_Sandbox.ml \
     SPARQL_Update_Analysis.ml \
     SPARQL_Diagnostics.ml \
@@ -638,7 +639,7 @@ if [[ "$STEP" == "all" || "$STEP" == "js" ]]; then
     RDF_CottasInMem.ml
     fstar_pure_hashes.ml
     RDF_Canonical.ml
-    SPARQL11_Algebra.ml RDF_Pretty.ml OWL_QueryRewrite.ml OWL_QueryEval.ml SPARQL11_Parser.ml
+    SPARQL11_Algebra.ml RDF_Pretty.ml OWL_QueryRewrite.ml OWL_QueryEval.ml RIF_Core_Syntax.ml RIF_Core_Translation.ml SPARQL11_Parser.ml
     SPARQL11_Store.ml
     SPARQL_Protocol.ml
     SPARQL_Update_Sandbox.ml

--- a/formal/fstar/ocaml-output/RIF_Core_Syntax.ml
+++ b/formal/fstar/ocaml-output/RIF_Core_Syntax.ml
@@ -1,0 +1,140 @@
+open Prims
+type rif_var = {
+  var_name: Prims.string }
+let (__proj__Mkrif_var__item__var_name : rif_var -> Prims.string) =
+  fun projectee -> match projectee with | { var_name;_} -> var_name
+type rif_term =
+  | RIF_Var of rif_var 
+  | RIF_Const of RDF_Graph_Executable.rdf_term 
+let (uu___is_RIF_Var : rif_term -> Prims.bool) =
+  fun projectee -> match projectee with | RIF_Var _0 -> true | uu___ -> false
+let (__proj__RIF_Var__item___0 : rif_term -> rif_var) =
+  fun projectee -> match projectee with | RIF_Var _0 -> _0
+let (uu___is_RIF_Const : rif_term -> Prims.bool) =
+  fun projectee ->
+    match projectee with | RIF_Const _0 -> true | uu___ -> false
+let (__proj__RIF_Const__item___0 : rif_term -> RDF_Graph_Executable.rdf_term)
+  = fun projectee -> match projectee with | RIF_Const _0 -> _0
+type rif_atom =
+  | RIF_Triple of rif_term * rif_term * rif_term 
+  | RIF_Frame of rif_term * rif_term * rif_term 
+  | RIF_Member of rif_term * rif_term 
+  | RIF_Sub of rif_term * rif_term 
+let (uu___is_RIF_Triple : rif_atom -> Prims.bool) =
+  fun projectee ->
+    match projectee with | RIF_Triple (_0, _1, _2) -> true | uu___ -> false
+let (__proj__RIF_Triple__item___0 : rif_atom -> rif_term) =
+  fun projectee -> match projectee with | RIF_Triple (_0, _1, _2) -> _0
+let (__proj__RIF_Triple__item___1 : rif_atom -> rif_term) =
+  fun projectee -> match projectee with | RIF_Triple (_0, _1, _2) -> _1
+let (__proj__RIF_Triple__item___2 : rif_atom -> rif_term) =
+  fun projectee -> match projectee with | RIF_Triple (_0, _1, _2) -> _2
+let (uu___is_RIF_Frame : rif_atom -> Prims.bool) =
+  fun projectee ->
+    match projectee with | RIF_Frame (_0, _1, _2) -> true | uu___ -> false
+let (__proj__RIF_Frame__item___0 : rif_atom -> rif_term) =
+  fun projectee -> match projectee with | RIF_Frame (_0, _1, _2) -> _0
+let (__proj__RIF_Frame__item___1 : rif_atom -> rif_term) =
+  fun projectee -> match projectee with | RIF_Frame (_0, _1, _2) -> _1
+let (__proj__RIF_Frame__item___2 : rif_atom -> rif_term) =
+  fun projectee -> match projectee with | RIF_Frame (_0, _1, _2) -> _2
+let (uu___is_RIF_Member : rif_atom -> Prims.bool) =
+  fun projectee ->
+    match projectee with | RIF_Member (_0, _1) -> true | uu___ -> false
+let (__proj__RIF_Member__item___0 : rif_atom -> rif_term) =
+  fun projectee -> match projectee with | RIF_Member (_0, _1) -> _0
+let (__proj__RIF_Member__item___1 : rif_atom -> rif_term) =
+  fun projectee -> match projectee with | RIF_Member (_0, _1) -> _1
+let (uu___is_RIF_Sub : rif_atom -> Prims.bool) =
+  fun projectee ->
+    match projectee with | RIF_Sub (_0, _1) -> true | uu___ -> false
+let (__proj__RIF_Sub__item___0 : rif_atom -> rif_term) =
+  fun projectee -> match projectee with | RIF_Sub (_0, _1) -> _0
+let (__proj__RIF_Sub__item___1 : rif_atom -> rif_term) =
+  fun projectee -> match projectee with | RIF_Sub (_0, _1) -> _1
+type rif_body =
+  | RIF_BodyAtom of rif_atom 
+  | RIF_BodyAnd of rif_body Prims.list 
+let (uu___is_RIF_BodyAtom : rif_body -> Prims.bool) =
+  fun projectee ->
+    match projectee with | RIF_BodyAtom _0 -> true | uu___ -> false
+let (__proj__RIF_BodyAtom__item___0 : rif_body -> rif_atom) =
+  fun projectee -> match projectee with | RIF_BodyAtom _0 -> _0
+let (uu___is_RIF_BodyAnd : rif_body -> Prims.bool) =
+  fun projectee ->
+    match projectee with | RIF_BodyAnd _0 -> true | uu___ -> false
+let (__proj__RIF_BodyAnd__item___0 : rif_body -> rif_body Prims.list) =
+  fun projectee -> match projectee with | RIF_BodyAnd _0 -> _0
+type rif_rule =
+  {
+  rule_name: Prims.string FStar_Pervasives_Native.option ;
+  head: rif_atom ;
+  body: rif_body }
+let (__proj__Mkrif_rule__item__rule_name :
+  rif_rule -> Prims.string FStar_Pervasives_Native.option) =
+  fun projectee ->
+    match projectee with | { rule_name; head; body;_} -> rule_name
+let (__proj__Mkrif_rule__item__head : rif_rule -> rif_atom) =
+  fun projectee -> match projectee with | { rule_name; head; body;_} -> head
+let (__proj__Mkrif_rule__item__body : rif_rule -> rif_body) =
+  fun projectee -> match projectee with | { rule_name; head; body;_} -> body
+type rif_program = {
+  rules: rif_rule Prims.list }
+let (__proj__Mkrif_program__item__rules : rif_program -> rif_rule Prims.list)
+  = fun projectee -> match projectee with | { rules;_} -> rules
+let (mk_var : Prims.string -> rif_term) = fun n -> RIF_Var { var_name = n }
+let (mk_const : RDF_Graph_Executable.rdf_term -> rif_term) =
+  fun t -> RIF_Const t
+let (mk_const_iri : RDF_Graph_Executable.wf_iri -> rif_term) =
+  fun i -> RIF_Const (RDF_Graph_Executable.T_IRI i)
+let (mk_atom_triple : rif_term -> rif_term -> rif_term -> rif_atom) =
+  fun s -> fun p -> fun o -> RIF_Triple (s, p, o)
+let (mk_atom_frame : rif_term -> rif_term -> rif_term -> rif_atom) =
+  fun o -> fun p -> fun v -> RIF_Frame (o, p, v)
+let (mk_atom_member : rif_term -> rif_term -> rif_atom) =
+  fun o -> fun c -> RIF_Member (o, c)
+let (mk_atom_sub : rif_term -> rif_term -> rif_atom) =
+  fun sub -> fun sup_ -> RIF_Sub (sub, sup_)
+let (mk_body_atom : rif_atom -> rif_body) = fun a -> RIF_BodyAtom a
+let (mk_body_and : rif_body Prims.list -> rif_body) =
+  fun bs -> RIF_BodyAnd bs
+let (mk_rule : rif_atom -> rif_body -> rif_rule) =
+  fun head_ ->
+    fun body_ ->
+      { rule_name = FStar_Pervasives_Native.None; head = head_; body = body_
+      }
+let (mk_named_rule : Prims.string -> rif_atom -> rif_body -> rif_rule) =
+  fun n ->
+    fun head_ ->
+      fun body_ ->
+        {
+          rule_name = (FStar_Pervasives_Native.Some n);
+          head = head_;
+          body = body_
+        }
+let (empty_program : rif_program) = { rules = [] }
+let (program_of_rules : rif_rule Prims.list -> rif_program) =
+  fun rs -> { rules = rs }
+let (rif_var_eq : rif_var -> rif_var -> Prims.bool) =
+  fun a -> fun b -> a.var_name = b.var_name
+let (rif_term_eq : rif_term -> rif_term -> Prims.bool) =
+  fun a ->
+    fun b ->
+      match (a, b) with
+      | (RIF_Var v1, RIF_Var v2) -> rif_var_eq v1 v2
+      | (RIF_Const c1, RIF_Const c2) ->
+          RDF_Graph_Executable.rdf_term_eq c1 c2
+      | (uu___, uu___1) -> false
+let (rif_atom_eq : rif_atom -> rif_atom -> Prims.bool) =
+  fun a ->
+    fun b ->
+      match (a, b) with
+      | (RIF_Triple (s1, p1, o1), RIF_Triple (s2, p2, o2)) ->
+          ((rif_term_eq s1 s2) && (rif_term_eq p1 p2)) && (rif_term_eq o1 o2)
+      | (RIF_Frame (o1, p1, v1), RIF_Frame (o2, p2, v2)) ->
+          ((rif_term_eq o1 o2) && (rif_term_eq p1 p2)) && (rif_term_eq v1 v2)
+      | (RIF_Member (o1, c1), RIF_Member (o2, c2)) ->
+          (rif_term_eq o1 o2) && (rif_term_eq c1 c2)
+      | (RIF_Sub (sub1, sup1), RIF_Sub (sub2, sup2)) ->
+          (rif_term_eq sub1 sub2) && (rif_term_eq sup1 sup2)
+      | (uu___, uu___1) -> false

--- a/formal/fstar/ocaml-output/RIF_Core_Translation.ml
+++ b/formal/fstar/ocaml-output/RIF_Core_Translation.ml
@@ -1,0 +1,161 @@
+open Prims
+let (rif_term_to_subject :
+  RIF_Core_Syntax.rif_term ->
+    SPARQL11_Algebra.pattern_subject FStar_Pervasives_Native.option)
+  =
+  fun t ->
+    match t with
+    | RIF_Core_Syntax.RIF_Var v ->
+        FStar_Pervasives_Native.Some
+          (SPARQL11_Algebra.PS_Var (v.RIF_Core_Syntax.var_name))
+    | RIF_Core_Syntax.RIF_Const (RDF_Graph_Executable.T_IRI i) ->
+        FStar_Pervasives_Native.Some (SPARQL11_Algebra.PS_IRI i)
+    | RIF_Core_Syntax.RIF_Const (RDF_Graph_Executable.T_BNode b) ->
+        FStar_Pervasives_Native.Some (SPARQL11_Algebra.PS_BNode b)
+    | RIF_Core_Syntax.RIF_Const (RDF_Graph_Executable.T_Literal uu___) ->
+        FStar_Pervasives_Native.None
+let (rif_term_to_pattern :
+  RIF_Core_Syntax.rif_term -> SPARQL11_Algebra.pattern_term) =
+  fun t ->
+    match t with
+    | RIF_Core_Syntax.RIF_Var v ->
+        SPARQL11_Algebra.PT_Var (v.RIF_Core_Syntax.var_name)
+    | RIF_Core_Syntax.RIF_Const (RDF_Graph_Executable.T_IRI i) ->
+        SPARQL11_Algebra.PT_IRI i
+    | RIF_Core_Syntax.RIF_Const (RDF_Graph_Executable.T_BNode b) ->
+        SPARQL11_Algebra.PT_BNode b
+    | RIF_Core_Syntax.RIF_Const (RDF_Graph_Executable.T_Literal l) ->
+        SPARQL11_Algebra.PT_Literal l
+let (rif_rdf_type : RDF_Graph_Executable.wf_iri) =
+  RDF_Graph_Executable.rdf_type
+let (rif_rdfs_subclassof : RDF_Graph_Executable.wf_iri) =
+  RDF_Graph_Executable.rdfs_subClassOf
+let (translate_atom :
+  RIF_Core_Syntax.rif_atom ->
+    SPARQL11_Algebra.triple_pattern FStar_Pervasives_Native.option)
+  =
+  fun a ->
+    match a with
+    | RIF_Core_Syntax.RIF_Triple (s, p, o) ->
+        (match rif_term_to_subject s with
+         | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None
+         | FStar_Pervasives_Native.Some ps ->
+             FStar_Pervasives_Native.Some
+               {
+                 SPARQL11_Algebra.tp_s = ps;
+                 SPARQL11_Algebra.tp_p = (rif_term_to_pattern p);
+                 SPARQL11_Algebra.tp_o = (rif_term_to_pattern o)
+               })
+    | RIF_Core_Syntax.RIF_Frame (o, p, v) ->
+        (match rif_term_to_subject o with
+         | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None
+         | FStar_Pervasives_Native.Some ps ->
+             FStar_Pervasives_Native.Some
+               {
+                 SPARQL11_Algebra.tp_s = ps;
+                 SPARQL11_Algebra.tp_p = (rif_term_to_pattern p);
+                 SPARQL11_Algebra.tp_o = (rif_term_to_pattern v)
+               })
+    | RIF_Core_Syntax.RIF_Member (o, c) ->
+        (match rif_term_to_subject o with
+         | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None
+         | FStar_Pervasives_Native.Some ps ->
+             FStar_Pervasives_Native.Some
+               {
+                 SPARQL11_Algebra.tp_s = ps;
+                 SPARQL11_Algebra.tp_p =
+                   (SPARQL11_Algebra.PT_IRI rif_rdf_type);
+                 SPARQL11_Algebra.tp_o = (rif_term_to_pattern c)
+               })
+    | RIF_Core_Syntax.RIF_Sub (sub, sup_) ->
+        (match rif_term_to_subject sub with
+         | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None
+         | FStar_Pervasives_Native.Some ps ->
+             FStar_Pervasives_Native.Some
+               {
+                 SPARQL11_Algebra.tp_s = ps;
+                 SPARQL11_Algebra.tp_p =
+                   (SPARQL11_Algebra.PT_IRI rif_rdfs_subclassof);
+                 SPARQL11_Algebra.tp_o = (rif_term_to_pattern sup_)
+               })
+let rec (translate_body :
+  RIF_Core_Syntax.rif_body ->
+    SPARQL11_Algebra.bgp FStar_Pervasives_Native.option)
+  =
+  fun b ->
+    match b with
+    | RIF_Core_Syntax.RIF_BodyAtom a ->
+        (match translate_atom a with
+         | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None
+         | FStar_Pervasives_Native.Some tp ->
+             FStar_Pervasives_Native.Some [tp])
+    | RIF_Core_Syntax.RIF_BodyAnd bs -> translate_body_list bs
+and (translate_body_list :
+  RIF_Core_Syntax.rif_body Prims.list ->
+    SPARQL11_Algebra.bgp FStar_Pervasives_Native.option)
+  =
+  fun bs ->
+    match bs with
+    | [] -> FStar_Pervasives_Native.Some []
+    | b::rest ->
+        (match translate_body b with
+         | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None
+         | FStar_Pervasives_Native.Some bgp_b ->
+             (match translate_body_list rest with
+              | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None
+              | FStar_Pervasives_Native.Some bgp_rest ->
+                  FStar_Pervasives_Native.Some
+                    (FStar_List_Tot_Base.append bgp_b bgp_rest)))
+let (translate_head :
+  RIF_Core_Syntax.rif_atom ->
+    SPARQL11_Algebra.triple_pattern Prims.list FStar_Pervasives_Native.option)
+  =
+  fun a ->
+    match translate_atom a with
+    | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None
+    | FStar_Pervasives_Native.Some tp -> FStar_Pervasives_Native.Some [tp]
+let (translate_rule :
+  RIF_Core_Syntax.rif_rule ->
+    (SPARQL11_Algebra.triple_pattern Prims.list * SPARQL11_Algebra.bgp)
+      FStar_Pervasives_Native.option)
+  =
+  fun r ->
+    match translate_head r.RIF_Core_Syntax.head with
+    | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None
+    | FStar_Pervasives_Native.Some hd_tpl ->
+        (match translate_body r.RIF_Core_Syntax.body with
+         | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None
+         | FStar_Pervasives_Native.Some body_bgp ->
+             FStar_Pervasives_Native.Some (hd_tpl, body_bgp))
+let (translate_program :
+  RIF_Core_Syntax.rif_program ->
+    (SPARQL11_Algebra.triple_pattern Prims.list * SPARQL11_Algebra.bgp)
+      Prims.list)
+  =
+  fun p ->
+    let opt_pairs =
+      FStar_List_Tot_Base.map translate_rule p.RIF_Core_Syntax.rules in
+    let rec keep_some xs =
+      match xs with
+      | [] -> []
+      | (FStar_Pervasives_Native.None)::rest -> keep_some rest
+      | (FStar_Pervasives_Native.Some pr)::rest -> pr :: (keep_some rest) in
+    keep_some opt_pairs
+let (translate_program_diag :
+  RIF_Core_Syntax.rif_program ->
+    ((SPARQL11_Algebra.triple_pattern Prims.list * SPARQL11_Algebra.bgp)
+      Prims.list * Prims.nat Prims.list))
+  =
+  fun p ->
+    let rec aux rs idx acc_ok acc_err =
+      match rs with
+      | [] ->
+          ((FStar_List_Tot_Base.rev acc_ok),
+            (FStar_List_Tot_Base.rev acc_err))
+      | r::rest ->
+          (match translate_rule r with
+           | FStar_Pervasives_Native.Some pr ->
+               aux rest (idx + Prims.int_one) (pr :: acc_ok) acc_err
+           | FStar_Pervasives_Native.None ->
+               aux rest (idx + Prims.int_one) acc_ok (idx :: acc_err)) in
+    aux p.RIF_Core_Syntax.rules Prims.int_zero [] []


### PR DESCRIPTION
## Summary

First executable slice of issue #182 (RIF intent-to-implement) and a sister-track tick on epic #200. Two new F\* modules; no semantic changes elsewhere.

- `formal/fstar/RIF.Core.Syntax.fst` (198 LoC) — `rif_term`, `rif_atom` (Triple / Frame / Member / Sub), `rif_body` (atom or And), `rif_rule`, `rif_program`. Refinement-bounded ADTs.
- `formal/fstar/RIF.Core.Translation.fst` (226 LoC) — `translate_term` / `translate_atom` / `translate_body` into `SPARQL11.Algebra`. Frame syntax desugars per RIF/RDF/OWL spec: `o[p->v]` → `(o, p, v)`, `o # c` → `(o, rdf:type, c)`, `sub ## sup` → `(sub, rdfs:subClassOf, sup)`.

Both modules verify under z3 4.13.3 with no `--lax` / `--admit_smt_queries` / `assume val`.

### Deviations from the design-doc sketch

- Used the actual `SPARQL11.Algebra` API (`triple_pattern` / `pattern_subject` / `pattern_term`) instead of the placeholder names in the design sketch.
- Translation functions return `option` to surface the one ill-typed case (literal in subject position is forbidden by SPARQL pattern-subject — RIF/SPARQL constraint). No silent drops, per rule #3 spirit.
- Frame is single-slot; multi-slot frames decompose at parse time into `RIF_BodyAnd` — functionally equivalent, matches the design doc's intent.
- Reuses existing `rdf_type` / `rdfs_subClassOf` constants from `RDF.Graph.Executable` rather than redefining.

### W3C skip coverage check

Per the design doc, the 4 currently-skipped W3C SPARQL tests need:

| Skipped test | Covered by |
|---|---|
| RIF Logical Entailment (RIF XML) | `RIF_Triple` head + body |
| RIF Core WG: Frames | `RIF_Frame` (single slot; multi-slot decomposes at parse) |
| RIF Core WG: Modeling Brain Anatomy | `RIF_Member` + `RIF_Sub` |
| RIF Core WG: RDF Combination Blank Node | `RIF_Triple` over RDF terms (`T_BNode` flows through) |

All four covered by Phase 1's surface. Phase 2 (Eval) actually fires the rules; Phase 3 (RIFXML parser) reads the test inputs; Phase 4 (Tests shim) wires the W3C runner. Each is a separate PR.

### Deferred to follow-up PRs

- `RIF.Core.Eval.fst` — fuel-bounded forward-chaining fixpoint over RDF.
- `Parser.RIFXML.fst` — RIF-XML concrete syntax (subset matching the 4 test inputs).
- `RIF.Core.Tests.fst` — W3C test-runner shim that swaps out the `RIF-Skip` dispatch at `w3c_runner.ml:1935-1940`.
- Built-in atoms (`pred:numeric-equal`, etc.) and existential body quantification — broader RIF-Core conformance, not required for the 4 skipped tests.

## Test plan

- [x] F\* verifies both modules under z3 4.13.3, no `--lax` / `--admit_smt_queries` / `assume val`.
- [x] Extract pipeline produces `RIF_Core_Syntax.ml` (6.7 KB) and `RIF_Core_Translation.ml` (6.7 KB) cleanly.
- [ ] Phase 2 (Eval) will exercise this PR end-to-end against the 4 skipped tests.

## Notable side-finding (not in scope of this PR)

The agent's `build-ocaml.sh extract` walked past these modules and surfaced a **pre-existing** `Error 19 at Parser.NQuads.fst(204,2-254,58)` — refinement assertion in `parse_nquads_acc`. The committed extracted `Parser_NQuads.ml` is up to date so OCaml builds aren't affected, but a future re-extraction will trip. Worth its own small fix-it PR.