### PR TITLE
fstar-purity: SPARQL.Eval.TimeBudget + Limits — retire Tav5, unblock Heth3

### DIFF
--- a/formal/fstar/SPARQL.Eval.Limits.fst
+++ b/formal/fstar/SPARQL.Eval.Limits.fst
@@ -1,0 +1,128 @@
+module SPARQL.Eval.Limits
+
+// Row-cap circuit breaker for the SPARQL evaluator. Pure F*.
+//
+// Recovery plan Phase 5 (docs/designissues/2026-05-07-query-planning-
+// fstar-recovery.md). Retires codename Tav5 — the `--max-rows N`
+// circuit breaker that lives in `factoidal_http.ml` as the
+// `exceeds_cap` / `result_cap_response` pair. The OCaml-side decision
+// "should this oversized result set become an HTTP 413?" is the
+// rendering glue; the policy "stop after N rows" belongs in F*.
+//
+// This module exposes:
+//   - `row_cap` : a tiny record describing the cap, with `0 = unlimited`.
+//   - `cap_reached` : the predicate the caller polls between rows.
+//   - `take_capped` : a pure list combinator that keeps at most
+//     `c.max_rows` elements of its input list.
+//   - `take_capped_length_le_cap` : the bound is honoured when the cap
+//     is enabled.
+//   - `take_capped_unlimited_id` : a disabled cap is the identity.
+//
+// The `take_capped` shape matches the existing OCaml call sites in
+// `factoidal_http.ml`: `run_query` materialises the row list and then
+// applies the cap policy. A streaming combinator (lazy or
+// continuation-passing) is a future extension; the materialised-list
+// shape is what the current evaluator returns and what we need to
+// retire today.
+
+module L = FStar.List.Tot
+
+// ---------------------------------------------------------------------------
+// Cap value.
+//
+// `max_rows = 0` is the "unlimited" sentinel. The convention matches
+// the existing OCaml-side `cap <= 0` test: zero means "no cap".
+// ---------------------------------------------------------------------------
+
+type row_cap = { max_rows : nat }
+
+let no_cap : row_cap = { max_rows = 0 }
+
+let mk_cap (n : nat) : row_cap = { max_rows = n }
+
+// True iff the cap is enabled.
+let is_enabled (c : row_cap) : bool =
+  c.max_rows <> 0
+
+// True iff the cap is enabled and `n_rows` has reached or exceeded it.
+// Mirrors the shape of `exceeds_cap` in factoidal_http.ml but lives
+// here so the policy is a single F* predicate.
+let cap_reached (c : row_cap) (n_rows : nat) : bool =
+  is_enabled c && n_rows >= c.max_rows
+
+// ---------------------------------------------------------------------------
+// take_capped : keep only the first `c.max_rows` elements, or all of
+// them if the cap is disabled.
+//
+// Pure, total, structurally recursive on `rows`. The `taken_so_far`
+// accumulator threads how many we have already kept; this avoids
+// recomputing `List.length` each step.
+// ---------------------------------------------------------------------------
+
+let rec take_capped_aux (#a : Type) (c : row_cap)
+                        (rows : list a) (taken_so_far : nat)
+  : Tot (list a) (decreases rows) =
+  match rows with
+  | [] -> []
+  | x :: rest ->
+    if is_enabled c && taken_so_far >= c.max_rows then []
+    else x :: take_capped_aux c rest (taken_so_far + 1)
+
+let take_capped (#a : Type) (c : row_cap) (rows : list a) : Tot (list a) =
+  take_capped_aux c rows 0
+
+// ---------------------------------------------------------------------------
+// Properties.
+// ---------------------------------------------------------------------------
+
+// Helper lemma: if `take_capped_aux` is called with `taken_so_far`
+// already at or past the cap (and the cap is enabled), it returns the
+// empty list. Used in the length-bound proof below. Non-recursive —
+// both list shapes evaluate the predicate guard the same way.
+let take_capped_aux_at_cap (#a : Type) (c : row_cap)
+                           (rows : list a) (taken : nat)
+  : Lemma (requires is_enabled c /\ taken >= c.max_rows)
+          (ensures  take_capped_aux c rows taken == []) =
+  match rows with
+  | [] -> ()
+  | _ :: _ -> ()
+
+// Helper lemma: bound on `take_capped_aux` when the cap is enabled.
+// `length (take_capped_aux c rs taken) + taken <= max c.max_rows taken`.
+// Proves that the result plus what was already taken cannot exceed
+// the cap (or `taken` if `taken` already overshoots).
+let rec take_capped_aux_length_le (#a : Type) (c : row_cap)
+                                  (rows : list a) (taken : nat)
+  : Lemma (requires is_enabled c)
+          (ensures
+            (let r = take_capped_aux c rows taken in
+             if taken >= c.max_rows then L.length r = 0
+             else L.length r + taken <= c.max_rows))
+          (decreases rows) =
+  match rows with
+  | [] -> ()
+  | _ :: rest ->
+    if taken >= c.max_rows then
+      take_capped_aux_at_cap c rows taken
+    else
+      take_capped_aux_length_le c rest (taken + 1)
+
+// Top-level property: `length (take_capped c rs) <= c.max_rows` when
+// the cap is enabled.
+let take_capped_length_le_cap (#a : Type) (c : row_cap) (rows : list a)
+  : Lemma (requires is_enabled c)
+          (ensures  L.length (take_capped c rows) <= c.max_rows) =
+  take_capped_aux_length_le c rows 0
+
+// When the cap is disabled, `take_capped` is the identity.
+let rec take_capped_aux_unlimited (#a : Type) (rows : list a) (taken : nat)
+  : Lemma (requires True)
+          (ensures  take_capped_aux no_cap rows taken == rows)
+          (decreases rows) =
+  match rows with
+  | [] -> ()
+  | _ :: rest -> take_capped_aux_unlimited rest (taken + 1)
+
+let take_capped_unlimited_id (#a : Type) (rows : list a)
+  : Lemma (ensures take_capped no_cap rows == rows) =
+  take_capped_aux_unlimited rows 0

--- a/formal/fstar/SPARQL.Eval.TimeBudget.fst
+++ b/formal/fstar/SPARQL.Eval.TimeBudget.fst
@@ -1,0 +1,133 @@
+module SPARQL.Eval.TimeBudget
+
+open FStar.All
+
+// Cooperative cancellation primitive for the SPARQL evaluator.
+//
+// Recovery plan Phase 5 (docs/designissues/2026-05-07-query-planning-
+// fstar-recovery.md). Replaces the architecturally-wrong SIGALRM
+// per-query timeout (codename Heth3) in factoidal_http.ml with a
+// polling discipline: the evaluator checks the budget between yield
+// boundaries and bails out cleanly. No process-global signal handlers,
+// no surprise `raise Query_timeout` mid-traversal, safe under
+// concurrent workers.
+//
+// Verification surface: a single `assume val now_ms` for a wallclock
+// read. Everything else is pure F* — the deadline arithmetic, the
+// `is_expired` predicate, the result type. The OCaml realisation of
+// `now_ms` is rule-#11(a) acceptable: pure I/O. See issue #202 and
+// `formal/fstar/minimal_regrettable_glue_code_each_with_an_open_issue/
+// 202_now_ms.sh`.
+//
+// Heth3 retirement happens in a follow-up PR that consumes this module
+// at the call sites in factoidal_http.ml.
+
+// ---------------------------------------------------------------------------
+// Wallclock read.
+//
+// THE ONLY thing OCaml realises in this module. Returns the current
+// monotonic-ish millisecond reading. Realised by Unix.gettimeofday in
+// the patch. Not strictly monotonic — wallclock jumps are tolerated.
+// ---------------------------------------------------------------------------
+
+assume val now_ms : unit -> ML int
+
+// ---------------------------------------------------------------------------
+// Budget: wallclock deadline expressed in milliseconds.
+//
+// `deadline_ms = 0` is the convention for "no budget set" and is
+// always treated as "never expired". Any non-zero deadline is the
+// absolute wallclock time at which the budget elapses; consumers
+// compare the current clock against it.
+// ---------------------------------------------------------------------------
+
+type budget = { deadline_ms : int }
+
+let no_budget : budget = { deadline_ms = 0 }
+
+// Construct a budget that expires `secs` seconds from now.
+//
+// `secs = 0` returns `no_budget` rather than a deadline equal to the
+// current clock — the disabled-budget sentinel must round-trip
+// through `mk_budget_secs 0`.
+let mk_budget_secs (secs : nat) : ML budget =
+  if secs = 0 then no_budget
+  else
+    let now = now_ms () in
+    { deadline_ms = now + FStar.Mul.op_Star secs 1000 }
+
+// Same idea, but the caller provides the milliseconds directly. Useful
+// for tests that want sub-second budgets without going through `secs`.
+let mk_budget_ms (ms : nat) : ML budget =
+  if ms = 0 then no_budget
+  else
+    let now = now_ms () in
+    { deadline_ms = now + ms }
+
+// ---------------------------------------------------------------------------
+// Budget arithmetic — pure F*.
+//
+// `is_expired` is total in `(budget, int)`: given the current clock,
+// it answers whether the budget has elapsed. Splitting it from `poll`
+// keeps the pure logic verifiable and lets callers test it without
+// needing to mock the clock.
+// ---------------------------------------------------------------------------
+
+let is_expired (b : budget) (now : int) : bool =
+  b.deadline_ms <> 0 && now >= b.deadline_ms
+
+// `is_disabled b` iff the budget is the disabled sentinel.
+let is_disabled (b : budget) : bool =
+  b.deadline_ms = 0
+
+// Lemma: a disabled budget is never expired, regardless of the clock.
+let disabled_never_expires (b : budget) (now : int)
+  : Lemma (requires is_disabled b)
+          (ensures  not (is_expired b now))
+  = ()
+
+// Lemma: an enabled budget is expired iff `now` has reached its
+// deadline.
+let enabled_expires_at_deadline (b : budget) (now : int)
+  : Lemma (requires not (is_disabled b))
+          (ensures  is_expired b now = (now >= b.deadline_ms))
+  = ()
+
+// ---------------------------------------------------------------------------
+// ML-effect helper: read the clock + check.
+//
+// Call this between every yield boundary in the evaluator. Returns
+// true iff the budget has expired and the caller should stop.
+// ---------------------------------------------------------------------------
+
+let poll (b : budget) : ML bool =
+  if is_disabled b then false
+  else is_expired b (now_ms ())
+
+// ---------------------------------------------------------------------------
+// Budgeted result type.
+//
+// Wrapper for operations that may bail out under a budget. Lets the
+// evaluator return BudgetedExpired without constructing a partial
+// result; the caller maps that to HTTP 503 / a 408-style envelope.
+// ---------------------------------------------------------------------------
+
+type budgeted (a : Type) =
+  | BudgetedOk      : value:a -> budgeted a
+  | BudgetedExpired : budgeted a
+
+let bind_budgeted (#a #b : Type) (x : budgeted a) (f : a -> budgeted b)
+  : budgeted b =
+  match x with
+  | BudgetedOk v -> f v
+  | BudgetedExpired -> BudgetedExpired
+
+let map_budgeted (#a #b : Type) (f : a -> b) (x : budgeted a) : budgeted b =
+  match x with
+  | BudgetedOk v -> BudgetedOk (f v)
+  | BudgetedExpired -> BudgetedExpired
+
+let is_ok (#a : Type) (x : budgeted a) : bool =
+  match x with
+  | BudgetedOk _ -> true
+  | BudgetedExpired -> false

--- a/formal/fstar/build-ocaml.sh
+++ b/formal/fstar/build-ocaml.sh
@@ -231,6 +231,8 @@ if [[ "$STEP" == "all" || "$STEP" == "extract" ]]; then
              Parser.SRX.fst Parser.CSVResults.fst \
              Parser.JSONResults.fst \
              SPARQL.JSON.Escape.fst \
+             SPARQL.Eval.TimeBudget.fst \
+             SPARQL.Eval.Limits.fst \
              SPARQL.HTTP.Response.fst \
              SPARQL.HTTP.BackendInfo.fst \
              SPARQL.HTTP.QueriesIndex.fst \
@@ -323,6 +325,8 @@ if [[ "$STEP" == "all" || "$STEP" == "compile" ]]; then
     Parser_NQuads.ml Parser_TriG.ml Parser_XML.ml Parser_RDFXML.ml \
     Parser_SRX.ml Parser_CSVResults.ml Parser_JSONResults.ml \
     SPARQL_JSON_Escape.ml \
+    SPARQL_Eval_TimeBudget.ml \
+    SPARQL_Eval_Limits.ml \
     SPARQL_HTTP_Response.ml \
     SPARQL_HTTP_BackendInfo.ml \
     SPARQL_HTTP_QueriesIndex.ml \

--- a/formal/fstar/minimal_regrettable_glue_code_each_with_an_open_issue/202_now_ms.sh
+++ b/formal/fstar/minimal_regrettable_glue_code_each_with_an_open_issue/202_now_ms.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+# Issue #202: realise SPARQL.Eval.TimeBudget.now_ms (rule-#11(a)
+# pure-I/O assume val).
+# https://github.com/danbri/factoidal/issues/202
+#
+# Replaces the F*-extracted `failwith` stub for
+# `SPARQL_Eval_TimeBudget.now_ms` with `Unix.gettimeofday ()`-based
+# millisecond reading. This is the ONLY OCaml realisation needed by
+# the cooperative-cancellation infrastructure that retires Heth3
+# (per-query timeout) and supports Tav5's row-cap policy modules.
+#
+# Recovery plan reference:
+#   docs/designissues/2026-05-07-query-planning-fstar-recovery.md
+#   (Phase 5: Time budget)
+#
+# Trust boundary: a wallclock read is observable I/O. Millisecond
+# precision is sufficient for per-query budget polling. Wallclock
+# jumps cause only early/late expiry (both safer than the previous
+# SIGALRM scheme).
+
+set -euo pipefail
+
+OUTDIR="$1"
+
+# Backward compatibility: if $1 is a .ml file, use its directory
+if [[ -f "$OUTDIR" && "$OUTDIR" == *.ml ]]; then
+  OUTDIR="$(dirname "$OUTDIR")"
+fi
+
+if [[ ! -d "$OUTDIR" ]]; then
+  echo "Error: $OUTDIR is not a directory" >&2
+  exit 1
+fi
+
+FILE="$OUTDIR/SPARQL_Eval_TimeBudget.ml"
+if [[ ! -f "$FILE" ]]; then
+  echo "  WARN: $FILE not found; skipping 202_now_ms patch."
+  echo "         (F* extract may not have produced SPARQL.Eval.TimeBudget yet.)"
+  exit 0
+fi
+
+# Idempotency: marker is the Unix.gettimeofday call that distinguishes
+# the realised version from the failwith stub.
+if grep -q 'Unix.gettimeofday' "$FILE"; then
+  echo "  [202_now_ms] already applied; skipping."
+  exit 0
+fi
+
+echo "  Patching $FILE (now_ms -> Unix.gettimeofday)..."
+
+python3 - "$FILE" <<'PYEOF'
+import sys
+
+path = sys.argv[1]
+with open(path, "r") as f:
+    content = f.read()
+
+# F* extraction emits assume vals as a top-level
+#   let (now_ms : unit -> Prims.int) =
+#     fun uu___ -> failwith "Not yet implemented: SPARQL.Eval.TimeBudget.now_ms"
+# Replace the body, leaving the public type signature alone so the
+# OCaml compiler still sees the same ABI.
+old_patterns = [
+    'let (now_ms : unit -> Prims.int) =\n'
+    '  fun uu___ -> failwith "Not yet implemented: SPARQL.Eval.TimeBudget.now_ms"',
+    'let (now_ms : unit -> Prims.int) =\n'
+    '  fun uu___ ->\n'
+    '    failwith "Not yet implemented: SPARQL.Eval.TimeBudget.now_ms"',
+]
+new_body = (
+    'let (now_ms : unit -> Prims.int) =\n'
+    '  (* Issue #202: rule-#11(a) pure-I/O realisation.\n'
+    '     Unix.gettimeofday returns seconds-as-float; multiply to ms,\n'
+    '     truncate, and lift to Prims.int (Z.t). Wallclock jumps are\n'
+    '     tolerated -- only affects polling cadence, not correctness. *)\n'
+    '  fun uu___ ->\n'
+    '    Z.of_int (int_of_float (Unix.gettimeofday () *. 1000.0))'
+)
+
+replaced = False
+for old in old_patterns:
+    if old in content:
+        content = content.replace(old, new_body, 1)
+        replaced = True
+        break
+
+if not replaced:
+    sys.stderr.write(
+        "  ERROR: 202_now_ms could not find the failwith stub for now_ms in "
+        + path
+        + "\n         Has the extraction shape changed?\n"
+    )
+    sys.exit(1)
+
+with open(path, "w") as f:
+    f.write(content)
+PYEOF
+
+echo "  [202_now_ms] applied: now_ms -> Z.of_int (int_of_float (Unix.gettimeofday () *. 1000.0))"

--- a/formal/fstar/minimal_regrettable_glue_code_each_with_an_open_issue/README.md
+++ b/formal/fstar/minimal_regrettable_glue_code_each_with_an_open_issue/README.md
@@ -21,6 +21,7 @@ tracking when it can be eliminated.**
 | `69_runner_io_glue.sh` | [#69](https://github.com/danbri/factoidal/issues/69) | I/O glue | w3c_runner.ml |
 | `89_fast_string_primitives.sh` | [#89](https://github.com/danbri/factoidal/issues/89) | assume-val stubs (perf) | Parser_FastString.ml |
 | `103_parquet_ascii_string_fast_path.sh` | [#103](https://github.com/danbri/factoidal/issues/103) | OCaml runtime override (perf) | Parquet_Footer.ml |
+| `202_now_ms.sh` | [#202](https://github.com/danbri/factoidal/issues/202) | assume-val stubs (I/O clock) | SPARQL_Eval_TimeBudget.ml |
 
 ## Categories
 

--- a/formal/fstar/ocaml-output/SPARQL_Eval_Limits.ml
+++ b/formal/fstar/ocaml-output/SPARQL_Eval_Limits.ml
@@ -1,0 +1,24 @@
+open Prims
+type row_cap = {
+  max_rows: Prims.nat }
+let (__proj__Mkrow_cap__item__max_rows : row_cap -> Prims.nat) =
+  fun projectee -> match projectee with | { max_rows;_} -> max_rows
+let (no_cap : row_cap) = { max_rows = Prims.int_zero }
+let (mk_cap : Prims.nat -> row_cap) = fun n -> { max_rows = n }
+let (is_enabled : row_cap -> Prims.bool) =
+  fun c -> c.max_rows <> Prims.int_zero
+let (cap_reached : row_cap -> Prims.nat -> Prims.bool) =
+  fun c -> fun n_rows -> (is_enabled c) && (n_rows >= c.max_rows)
+let rec take_capped_aux :
+  'a . row_cap -> 'a Prims.list -> Prims.nat -> 'a Prims.list =
+  fun c ->
+    fun rows ->
+      fun taken_so_far ->
+        match rows with
+        | [] -> []
+        | x::rest ->
+            if (is_enabled c) && (taken_so_far >= c.max_rows)
+            then []
+            else x :: (take_capped_aux c rest (taken_so_far + Prims.int_one))
+let take_capped : 'a . row_cap -> 'a Prims.list -> 'a Prims.list =
+  fun c -> fun rows -> take_capped_aux c rows Prims.int_zero

--- a/formal/fstar/ocaml-output/SPARQL_Eval_TimeBudget.ml
+++ b/formal/fstar/ocaml-output/SPARQL_Eval_TimeBudget.ml
@@ -1,0 +1,59 @@
+open Prims
+let (now_ms : unit -> Prims.int) =
+  (* Issue #202: rule-#11(a) pure-I/O realisation.
+     Unix.gettimeofday returns seconds-as-float; multiply to ms,
+     truncate, and lift to Prims.int (Z.t). Wallclock jumps are
+     tolerated -- only affects polling cadence, not correctness. *)
+  fun uu___ ->
+    Z.of_int (int_of_float (Unix.gettimeofday () *. 1000.0))
+type budget = {
+  deadline_ms: Prims.int }
+let (__proj__Mkbudget__item__deadline_ms : budget -> Prims.int) =
+  fun projectee -> match projectee with | { deadline_ms;_} -> deadline_ms
+let (no_budget : budget) = { deadline_ms = Prims.int_zero }
+let (mk_budget_secs : Prims.nat -> budget) =
+  fun secs ->
+    if secs = Prims.int_zero
+    then no_budget
+    else
+      (let now = now_ms () in
+       { deadline_ms = (now + (secs * (Prims.of_int (1000)))) })
+let (mk_budget_ms : Prims.nat -> budget) =
+  fun ms ->
+    if ms = Prims.int_zero
+    then no_budget
+    else (let now = now_ms () in { deadline_ms = (now + ms) })
+let (is_expired : budget -> Prims.int -> Prims.bool) =
+  fun b ->
+    fun now -> (b.deadline_ms <> Prims.int_zero) && (now >= b.deadline_ms)
+let (is_disabled : budget -> Prims.bool) =
+  fun b -> b.deadline_ms = Prims.int_zero
+let (poll : budget -> Prims.bool) =
+  fun b ->
+    if is_disabled b
+    then false
+    else (let uu___1 = now_ms () in is_expired b uu___1)
+type 'a budgeted =
+  | BudgetedOk of 'a 
+  | BudgetedExpired 
+let uu___is_BudgetedOk : 'a . 'a budgeted -> Prims.bool =
+  fun projectee ->
+    match projectee with | BudgetedOk value -> true | uu___ -> false
+let __proj__BudgetedOk__item__value : 'a . 'a budgeted -> 'a =
+  fun projectee -> match projectee with | BudgetedOk value -> value
+let uu___is_BudgetedExpired : 'a . 'a budgeted -> Prims.bool =
+  fun projectee ->
+    match projectee with | BudgetedExpired -> true | uu___ -> false
+let bind_budgeted : 'a 'b . 'a budgeted -> ('a -> 'b budgeted) -> 'b budgeted
+  =
+  fun x ->
+    fun f ->
+      match x with | BudgetedOk v -> f v | BudgetedExpired -> BudgetedExpired
+let map_budgeted : 'a 'b . ('a -> 'b) -> 'a budgeted -> 'b budgeted =
+  fun f ->
+    fun x ->
+      match x with
+      | BudgetedOk v -> BudgetedOk (f v)
+      | BudgetedExpired -> BudgetedExpired
+let is_ok : 'a . 'a budgeted -> Prims.bool =
+  fun x -> match x with | BudgetedOk uu___ -> true | BudgetedExpired -> false

--- a/formal/fstar/ocaml-output/factoidal_http.ml
+++ b/formal/fstar/ocaml-output/factoidal_http.ml
@@ -955,14 +955,48 @@ let result_cap_response ~cap ~actual_size =
     rb_content_type = "application/json; charset=utf-8";
     rb_body = SPARQL_HTTP_Response.result_cap_response_body (Z.of_int cap) }
 
-(* True iff the cap is enabled and [List.length rows > cap].
+(* Row-cap circuit breaker (recovery plan Phase 5 — codename Tav5
+   retired). The policy "stop after N rows" is defined in F* —
+   see formal/fstar/SPARQL.Eval.Limits.fst — and instantiated here
+   per request via [SPARQL_Eval_Limits.mk_cap]. The OCaml side is
+   now thin glue: build the cap record, ask F* whether the row list
+   reaches the cap, render the HTTP-413 response on overflow.
+
+   The long-standing OCaml [exceeds_cap] semantics are strictly-greater
+   (a result of exactly [cap] rows is allowed through; only
+   [length > cap] triggers HTTP 413). The F* predicate [cap_reached]
+   uses [n_rows >= max_rows] — i.e. it answers "is the cap reached?"
+   given a row count. To encode strict overflow we pass [cap + 1] as
+   the cap argument: [n >= cap + 1] iff [n > cap]. Wrapping it through
+   F* keeps the policy under [SPARQL.Eval.Limits] and lets a future
+   PR change the strict-vs-inclusive convention in one F* line.
+
    List.length is tail-rec in the OCaml stdlib, so this is safe to call
-   on a 3 M-element list. *)
+   on a 3 M-element list.
+
+   Heth3 (per-query timeout) is a separate F* module
+   ([SPARQL.Eval.TimeBudget]) and is migrated in a follow-up PR. *)
+let row_cap_of_int (cap : int) : SPARQL_Eval_Limits.row_cap =
+  SPARQL_Eval_Limits.mk_cap (Z.of_int (max 0 cap))
+
 let exceeds_cap ~cap rows =
   if cap <= 0 then None
   else
+    (* mk_cap (cap + 1) so [n >= cap + 1] iff [n > cap] (strict). *)
+    let strict_overflow_cap = row_cap_of_int (cap + 1) in
     let n = List.length rows in
-    if n > cap then Some n else None
+    if SPARQL_Eval_Limits.cap_reached strict_overflow_cap (Z.of_int n)
+    then Some n
+    else None
+
+(* F*-defined truncation combinator, exposed for future call sites
+   (streaming serialisers, paginated CONSTRUCT/DESCRIBE). The 413
+   path above doesn't use it because we want to detect overflow
+   rather than silently truncate; both behaviours sit under
+   [SPARQL.Eval.Limits]. The [_] prefix suppresses OCaml's
+   "unused let" warning until the first consumer lands. *)
+let _take_capped_rows ~cap rows =
+  SPARQL_Eval_Limits.take_capped (row_cap_of_int cap) rows
 
 let run_query ~backend ~accept ~max_rows query =
   let bkind = qof3_backend_kind backend in


### PR DESCRIPTION
## Summary

Phase 5 of the F\* migration recovery plan. Two new F\* modules + a glue patch + the Tav5 site delegation in factoidal_http.ml.

This **retires Tav5** in the codename-violator list and **unblocks Heth3** + the Track-1.2 query-timeout work in epic #200.

### What lands

- `formal/fstar/SPARQL.Eval.TimeBudget.fst` — cooperative cancellation. Single new `assume val now_ms : unit -> ML int` (tracked in #202). Pure F\* `is_expired` predicate; `poll` reads the clock; `mk_budget_*` helpers.
- `formal/fstar/SPARQL.Eval.Limits.fst` — pure F\* row-cap circuit breaker. `take_capped` + `cap_reached` + two proved lemmas (`take_capped_length_le_cap`, `take_capped_unlimited_id`).
- `formal/fstar/minimal_regrettable_glue_code_each_with_an_open_issue/202_now_ms.sh` — realisation patch (`Z.of_int (int_of_float (Unix.gettimeofday () *. 1000.0))`).
- `formal/fstar/ocaml-output/factoidal_http.ml` (Tav5 site) — `exceeds_cap` routes through `SPARQL_Eval_Limits.cap_reached`. Existing `[tav5-trace]` log line + HTTP-413 response shape preserved verbatim so log signatures don't break.

Both F\* modules verify under z3 4.13.3 with no `--lax` / `--admit_smt_queries` / `assume val` (modulo `now_ms`).

Runtime behaviour confirmed via ad-hoc OCaml drivers: cap-predicate matches existing strict-greater semantics on boundary cases; `now_ms` + `mk_budget_ms 100` + `poll` + sleep flips poll-result correctly across the deadline.

## Pre-existing regressions surfaced (NOT this PR's fault — but you should know)

The agent's full `./build-ocaml.sh extract && compile` exposed two real bugs on `origin/claude/main` independent of this work:

1. **`Parser.NQuads.fst` Error 19** at lines 204–254 (`parse_nquads_acc` refinement assertion). Reproducible on a clean `claude/main` checkout. Blocks fresh extract loops; the committed `Parser_NQuads.ml` is current so OCaml builds aren't affected. **Worth its own small fix-it PR.** (Independently surfaced by the RIF Phase 1 agent — see #204's "Notable side-finding".)

2. **`factoidal_http.ml:1139` `timing_log_line` int-vs-Z.t mismatch** on `qt.qt_form qt.qt_status qt.qt_rows qt.qt_body_bytes`. Same shape as #172 fixed at line 859. The `tp_explain` migration in #170 + subsequent timing-helper migrations missed this call site. Blocks the `factoidal` + `factoidal-http` native binaries. **Trivial fix-it PR (one or more `Z.of_int` casts).**

I can dispatch tiny fix-it agents for both as soon as you give the nod.

## Test plan

- [x] `fstar.exe --z3version 4.13.3 SPARQL.Eval.TimeBudget.fst` — verifies clean.
- [x] `fstar.exe --z3version 4.13.3 SPARQL.Eval.Limits.fst` — verifies clean.
- [x] Both extract cleanly.
- [x] `w3c_runner` builds and links the new modules.
- [x] Existing `--max-rows N` + HTTP-413 + `[tav5-trace]` log line behaviour preserved.
- [ ] Heth3 migration (separate follow-up PR) consumes `TimeBudget`.
- [ ] Track-1.2 `with_query_timeout` migration (separate) consumes `TimeBudget`.

## Migration epic ticks

- [x] **Tav5** — `SPARQL.Eval.Limits.fst` retires the `--max-rows` circuit-breaker logic from factoidal_http.ml.
- [x] Phase 5 unblocked: TimeBudget infra ready for Heth3 migration + Track-1.2 query-timeout.

Tracker: #200.

## Sister-track issue

#202 — `now_ms : unit -> ML int` tracking.