### PR TITLE
fix: bump Parser.NQuads.fst Z3 rlimit so parse_nquads_acc verifies

### DIFF
--- a/formal/fstar/Parser.NQuads.fst
+++ b/formal/fstar/Parser.NQuads.fst
@@ -199,6 +199,14 @@ let dataset_add_quad (ds : rdf_dataset) (t : triple) (graph_name : option iri) :
     - If '#', skip comment to end of line
     - If end of line or end of input, skip
     - Otherwise, parse a quad *)
+
+// parse_nquads_acc nests an inner let-rec (skip_line) plus four
+// outer recursive calls; F*'s default --z3rlimit 5 isn't enough to
+// discharge the Tot postcondition. Bump locally. Verified at rlimit
+// 30; sibling Parser.Turtle.fst:1820 uses the same pragma for
+// similar reasons.
+#push-options "--z3rlimit 30"
+
 let rec parse_nquads_acc (input:string) (pos:nat) (ds:rdf_dataset) (fuel:nat)
   : Tot rdf_dataset (decreases fuel) =
   if fuel = 0 then ds
@@ -252,6 +260,8 @@ let rec parse_nquads_acc (input:string) (pos:nat) (ds:rdf_dataset) (fuel:nat)
             let pos2 = skip_line pos1 (len - pos1) in
             if pos2 = pos1 then ds  (* no progress *)
             else parse_nquads_acc input pos2 ds (fuel - 1)
+
+#pop-options
 
 (** Parse a complete N-Quads document string into an rdf_dataset.
     Triples without a graph label go into the default graph.


### PR DESCRIPTION
## Summary

Two-line F\* pragma fix. Every agent in this session running `./build-ocaml.sh extract` from a fresh worktree hit `Error 19 "Assertion failed" at Parser.NQuads.fst(204,2-254,58)`. Root cause: F\*'s default `--z3rlimit 5` wasn't enough to discharge `parse_nquads_acc`'s Tot postcondition (the function nests an inner let-rec `skip_line` plus four outer recursive calls — the WP gets large).

Verified locally: **`--z3rlimit 30`** OR `--max_fuel 8 --max_ifuel 8` both discharge cleanly. Picked `z3rlimit 30` because sibling [Parser.Turtle.fst:1820-1873](https://github.com/danbri/factoidal/blob/claude/main/formal/fstar/Parser.Turtle.fst#L1820) already uses that exact pragma for a similarly-shaped nested-recursion function.

```fstar
#push-options "--z3rlimit 30"

let rec parse_nquads_acc (input:string) (pos:nat) (ds:rdf_dataset) (fuel:nat)
  : Tot rdf_dataset (decreases fuel) =
  ...
  // body unchanged
  ...

#pop-options
```

## Why this didn't show up in the public dashboard staleness

CI uses mtime-based skip on the committed `Parser_NQuads.ml` — when the .fst hasn't been touched, the extract loop sees the .ml is up-to-date and skips re-running F\* on it. So normal CI runs never hit this error.

The 6-day dashboard staleness was a **separate** issue:
- Days 1-5 (May 1 → May 6): `factoidal_http.ml` int/Z.t cascade (`render_response_head`, `render_timing_log_line`, `truncate_for_log`, `render_recent_query_json`, `render_recent_queries_envelope`, `count_dataset_triples`). Fixed in #172 + #206.
- Day 6+ (May 7): the 5-min debounce in #176 vs. our merge cadence. Every push's debounce sees the next merge during its 5-min sleep, exits cleanly, native-shadow + browser-artifacts skip. The workflow shows "success" but the suite never runs. Fired a `workflow_dispatch` (bypasses debounce) just before opening this PR — that's the run that should refresh `latest.json`.

## Who this PR helps

- **Every agent** running a fresh-worktree extract.
- **Anyone editing `Parser.NQuads.fst`** (forces re-extract → trips the error).
- **Fresh-clone workflows** (CI on a new runner, dev onboarding).

## Test plan

- [x] `fstar.exe --z3version 4.13.3 Parser.NQuads.fst` — verifies clean.
- [x] `fstar.exe --z3version 4.13.3 --codegen OCaml --odir /tmp/x Parser.NQuads.fst` — extracts clean.
- [ ] Merge → next fresh-extract scenario succeeds.

## Related

- Sibling pragma in `Parser.Turtle.fst:1820`.
- Parser.NQuads.fst already had `#push-options "--split_queries always"` at line 452 (after the failing function) — this PR adds an earlier pragma block covering 202-263.

No semantic change. Just an SMT budget knob.