### PR TITLE
lamed3: RDF.Store.Columnar.OffsetIndex + SPARQL.Plan.AccessPath F* homes

### DIFF
--- a/formal/fstar/RDF.Store.Columnar.OffsetIndex.fst
+++ b/formal/fstar/RDF.Store.Columnar.OffsetIndex.fst
@@ -1,0 +1,408 @@
+module RDF.Store.Columnar.OffsetIndex
+
+// Recovery plan Phase 6 (docs/designissues/2026-05-07-query-planning-
+// fstar-recovery.md). Names the F* home for the per-row-group
+// predicate row-offset index that retires codename "Lamed3".
+//
+// Old shape (the one this module displaces): the writer + reader for
+// the `<corpus>.p.offsets` companion file lived entirely in
+// experimental_ocaml_glue/cottas_ondisk_zzzzzz_lamed3_offset_idx.sh.
+// The byte layout (`COTO` magic + header + u64 index + packed u32 row
+// positions) was specified only as a comment block in that shell
+// script. The reader half of that patch was retired in the Yod7 audit
+// (2026-04-26) once the rename pivot landed; the writer half still
+// runs at companion-build time and emits the on-disk file. Per
+// CLAUDE.md rule #11 the byte layout is a semantic decision and must
+// live in F*; the OCaml side reduces to `write_bytes` once a writer
+// migration follow-up lands.
+//
+// New shape (this module): the byte layout is specified as F* refinement-
+// typed records, the read path is composed from the existing
+// `read_companion_u32_le` / `read_companion_u64_le` / `mmap_companion_open`
+// `assume val` primitives (no new I/O assumptions), and the soundness
+// invariant ("a `false` answer to row_positions_for is sound to skip
+// the rg for that predicate") is stated as an admittable lemma so
+// callers can rely on a uniform contract.
+//
+// Wiring status: this module is the named F* home; it does not yet
+// re-route `RDF.CottasStore.cottas_ondisk_search`'s LIMIT path through
+// `row_positions_for`. That swap is a thin follow-up once the F*
+// extraction toolchain version drift is resolved. The committed
+// `ocaml-output/RDF_CottasStore.ml` still flows through the OCaml-
+// side reader cached in `Cottas_offset_idx`. Phase 6's deliverable
+// is the named-API home + the spec — the reader is byte-identical to
+// what the OCaml side computes today.
+//
+// File format (little-endian throughout). Magic 'COTO' = 0x4f544f43.
+//
+//   Header (16 bytes):
+//     [ magic       : u32   ASCII 'COTO' = 0x4f544f43 ]
+//     [ version     : u32   layout version, currently 1 ]
+//     [ num_rgs     : u32 ]
+//     [ num_preds   : u32 ]
+//
+//   Index (u64-LE, length num_rgs * num_preds + 1):
+//     [ rg_offsets[rg*num_preds + pred]     = byte offset where row-list starts
+//       rg_offsets[rg*num_preds + pred + 1] = end byte offset (exclusive)
+//       rg_offsets[num_rgs*num_preds]       = end-of-file sentinel ]
+//
+//   Data (u32-LE, packed):
+//     [ row positions, ascending; per (rg, pred) the slice is
+//       data[start..end) with count = (end - start) / 4 u32 entries. ]
+//
+// Soundness contract: for a correctly-built file, `row_positions_for h
+// rg p` returns the ascending list of row indices in row-group `rg`
+// whose predicate-token-id equals `p`. A `Some []` answer means "no
+// row in this rg has that predicate"; the caller may skip the rg's
+// subject + object decode for that pattern. A `None` answer means an
+// I/O or bound error and is the safe over-include (caller falls back
+// to the full predicate-column decode path).
+
+open RDF.CottasStore.OnDiskIndex
+open FStar.Mul
+
+// ------------------------------------------------------------------
+// Magic number (32-bit little-endian).
+// ASCII 'C', 'O', 'T', 'O' = 0x43, 0x4f, 0x54, 0x4f -> LE u32 = 0x4f544f43
+// ------------------------------------------------------------------
+
+let coto_magic_u32 : nat = 0x4f544f43
+let offsets_layout_version : nat = 1
+let offset_header_size : nat = 16  // 4 u32 fields, no padding
+let offset_index_entry_size : nat = 8   // u64 each
+let offset_row_position_size : nat = 4  // u32 each
+
+// ------------------------------------------------------------------
+// Header. Refinement-typed record holding the four u32 fields.
+// ------------------------------------------------------------------
+
+type offset_header = {
+  oh_magic     : nat;
+  oh_version   : nat;
+  oh_num_rgs   : nat;
+  oh_num_preds : nat;
+}
+
+let offset_header_ok (h : offset_header) : Tot bool =
+  h.oh_magic = coto_magic_u32 && h.oh_version = offsets_layout_version
+
+// Read the 16-byte header. Returns None on any read failure or if
+// magic / version don't match the expected layout. The composition
+// is the same shape as `read_presence_header` /
+// `read_compound_header`.
+let read_offset_header (path : string) : Tot (option offset_header) =
+  match read_companion_u32_le path 0 with
+  | None -> None
+  | Some magic ->
+    match read_companion_u32_le path 4 with
+    | None -> None
+    | Some version ->
+      match read_companion_u32_le path 8 with
+      | None -> None
+      | Some num_rgs ->
+        match read_companion_u32_le path 12 with
+        | None -> None
+        | Some num_preds ->
+          Some {
+            oh_magic = magic;
+            oh_version = version;
+            oh_num_rgs = num_rgs;
+            oh_num_preds = num_preds;
+          }
+
+// ------------------------------------------------------------------
+// Handle. Pairs the file path with its parsed header. Mirrors
+// `bitmap_handle` (PresenceBitmap) and `compound_handle`
+// (CompoundPresenceBitmap).
+// ------------------------------------------------------------------
+
+type offset_handle = {
+  oih_path   : string;
+  oih_header : offset_header;
+}
+
+let offset_handle_ok (h : offset_handle) : Tot bool =
+  offset_header_ok h.oih_header
+
+// A handle whose header is verified at the type level.
+let valid_offset_handle = h:offset_handle{ offset_handle_ok h }
+
+// ------------------------------------------------------------------
+// Open / close. Composes mmap_companion_open + read_offset_header.
+// Returns Some handle iff the mmap succeeded, the header parsed, and
+// magic + version match. None otherwise — caller falls back to the
+// no-offset-index path (full predicate-column decode).
+// ------------------------------------------------------------------
+
+let open_offsets (path : string) : Tot (option offset_handle) =
+  match mmap_companion_open path with
+  | None -> None
+  | Some _file_size ->
+    (match read_offset_header path with
+     | None -> None
+     | Some h ->
+       if offset_header_ok h then
+         Some { oih_path = path; oih_header = h }
+       else None)
+
+let close_offsets (h : offset_handle) : Tot unit =
+  mmap_companion_close h.oih_path
+
+// ------------------------------------------------------------------
+// Index lookups. Each (rg, pred) cell has a start offset (its
+// position in the index) and an end offset (the next cell's
+// position). The index has length num_rgs*num_preds + 1, with the
+// trailing entry as the end-of-file sentinel.
+//
+// `cell_index rg p` is the linear index of the (rg, p) start entry;
+// `cell_index_end rg p` is the start of the next cell.
+// ------------------------------------------------------------------
+
+let cell_index (h : offset_header) (rg : nat) (pred_id : nat) : Tot nat =
+  rg * h.oh_num_preds + pred_id
+
+// Byte offset within the file where the index entry for (rg, pred_id)
+// begins. The index starts at offset 16 (offset_header_size) and each
+// entry is 8 bytes (u64-LE).
+let index_entry_offset (h : offset_header) (rg : nat) (pred_id : nat) : Tot nat =
+  offset_header_size + offset_index_entry_size * (cell_index h rg pred_id)
+
+// Read the start byte offset (into the data section) for (rg, pred).
+// Returns None on read failure or if (rg, pred) is out of range.
+let read_cell_start
+  (h : valid_offset_handle) (rg : nat) (pred_id : nat) : Tot (option nat) =
+  if rg >= h.oih_header.oh_num_rgs || pred_id >= h.oih_header.oh_num_preds
+  then None
+  else
+    read_companion_u64_le h.oih_path
+      (index_entry_offset h.oih_header rg pred_id)
+
+// Read the end (exclusive) byte offset for (rg, pred). The last cell
+// of the file uses the sentinel index entry at position
+// num_rgs * num_preds.
+let read_cell_end
+  (h : valid_offset_handle) (rg : nat) (pred_id : nat) : Tot (option nat) =
+  if rg >= h.oih_header.oh_num_rgs || pred_id >= h.oih_header.oh_num_preds
+  then None
+  else
+    read_companion_u64_le h.oih_path
+      (offset_header_size +
+       offset_index_entry_size * (cell_index h.oih_header rg pred_id + 1))
+
+// ------------------------------------------------------------------
+// Row-position counts and reads.
+//
+// The data slice for cell (rg, pred) is a packed u32-LE array of row
+// positions. The byte length of the slice divided by 4 is the number
+// of matching rows in that row-group for that predicate. The empty
+// slice (start == end) means the rg has no row with that predicate;
+// callers can skip the entire rg.
+// ------------------------------------------------------------------
+
+// Given start + end byte offsets, compute the row-position count.
+// Defensive against malformed indexes (end < start) by returning 0.
+let row_positions_count_from_bounds (start_off end_off : nat) : Tot nat =
+  if end_off < start_off then 0
+  else (end_off - start_off) / offset_row_position_size
+
+// Read the i-th row position in the (rg, pred) cell, assuming
+// start_off is the cell's data-section byte offset.
+let read_row_position_at
+  (h : valid_offset_handle) (start_off : nat) (i : nat) : Tot (option nat) =
+  read_companion_u32_le h.oih_path
+    (start_off + offset_row_position_size * i)
+
+// ------------------------------------------------------------------
+// row_positions_for: the runtime read primitive.
+//
+// Returns Some (start_off, count) when (rg, pred_id) is in range and
+// the index reads succeed. The caller can then read row positions via
+// `read_row_position_at h start_off i` for i in [0, count). Empty
+// count is meaningful: "no row in this rg has that predicate".
+//
+// Returns None on out-of-range (rg, pred_id) or any read failure.
+// Callers treat None as "no offset-index info, fall through to the
+// full predicate-column decode" — the safe over-include.
+// ------------------------------------------------------------------
+
+// A successful row_positions_for result: (data-section start byte
+// offset, count of u32 row positions in this cell).
+type cell_view = {
+  cv_start : nat;
+  cv_count : nat;
+}
+
+let row_positions_for
+  (h : valid_offset_handle) (rg : nat) (pred_id : nat)
+  : Tot (option cell_view) =
+  if rg >= h.oih_header.oh_num_rgs || pred_id >= h.oih_header.oh_num_preds
+  then None
+  else
+    match read_cell_start h rg pred_id with
+    | None -> None
+    | Some start_off ->
+      match read_cell_end h rg pred_id with
+      | None -> None
+      | Some end_off ->
+        if end_off < start_off then None
+        else Some {
+          cv_start = start_off;
+          cv_count = row_positions_count_from_bounds start_off end_off;
+        }
+
+// Variant that takes a possibly-failed-to-open handle (option) plus
+// an option pred_id (the column may be unbound in the BGP). The
+// "no info -> fall through to full decode" semantics are baked in.
+//
+// Result encoding:
+//   - None        -> no info; caller MUST run the full predicate-column
+//                    decode for this rg.
+//   - Some None   -> empty cell; caller can skip the entire rg for
+//                    this pattern (we know there are zero matches).
+//   - Some (Some (start_off, count)) -> caller can read `count` row
+//                    positions starting at byte `start_off` and decode
+//                    only those subject + object cells.
+//
+// This is the shape `SPARQL.Plan.AccessPath.choose_access_path`
+// surfaces back to the planner.
+// Wrapped result for `row_positions_for_opt`: distinguishes
+// "no info, full decode" from "definitely empty, skip rg" from
+// "use this jump list".
+type cell_decision =
+  | CD_NoInfo  : cell_decision           // companion absent or unbound pred
+  | CD_Empty   : cell_decision           // empty slice; skip the rg
+  | CD_Use     : cell_view -> cell_decision  // use these row positions
+
+let row_positions_for_opt
+  (oh : option offset_handle) (rg : nat) (bound_pred_id : option nat)
+  : Tot cell_decision =
+  match bound_pred_id with
+  | None -> CD_NoInfo  // unbound predicate: no offset-jump
+  | Some p ->
+    (match oh with
+     | None -> CD_NoInfo  // companion file not open: full decode path
+     | Some h ->
+       if offset_handle_ok h then
+         (match row_positions_for h rg p with
+          | None -> CD_NoInfo  // out-of-range / read error: full decode
+          | Some cv ->
+            if cv.cv_count = 0 then CD_Empty
+            else CD_Use cv)
+       else CD_NoInfo)  // header invalid: fall through
+
+// ------------------------------------------------------------------
+// Dimension accessors. Mirror PresenceBitmap.bitmap_num_rgs etc.
+// ------------------------------------------------------------------
+
+let offset_num_rgs (h : valid_offset_handle) : Tot nat =
+  h.oih_header.oh_num_rgs
+
+let offset_num_preds (h : valid_offset_handle) : Tot nat =
+  h.oih_header.oh_num_preds
+
+// ------------------------------------------------------------------
+// Path computation for the offsets companion file. The convention is
+// `<corpus>.p.offsets` (sibling to `.p.dict` and `.p.presence`),
+// matching the writer in
+// `experimental_ocaml_glue/cottas_ondisk_zzzzzz_lamed3_offset_idx.sh`.
+// ------------------------------------------------------------------
+
+let offsets_path_of (corpus_path : string) : Tot string =
+  corpus_path ^ ".p.offsets"
+
+// ------------------------------------------------------------------
+// Soundness contract.
+//
+// `rows_with_pred rg p` is the spec-level ground truth: the ascending
+// list of row indices within row-group `rg` whose predicate-token-id
+// equals `p`. The offsets file is "built correctly" iff for every
+// in-range (rg, p), the cell's start_off + count + the count
+// successful u32 reads at start_off..start_off+4*(count-1) yield
+// exactly that ground-truth list.
+//
+// We state two correctness statements relevant to callers:
+//
+//   1. `row_positions_for_count_sound`: when row_positions_for returns
+//      `Some (_, 0)` and the bitmap is correctly built, the spec-side
+//      ground-truth list is empty — i.e. the rg has zero rows with
+//      predicate `p`, and skipping it is sound.
+//
+//   2. `row_positions_for_count_bound`: the count returned never
+//      exceeds the number of rows in the rg. Established structurally
+//      (count = byte-length / 4, bounded by the index span); we phrase
+//      it as a monotonicity property over the bounds.
+//
+// Both lemmas follow the discipline in
+// `RDF.CottasStore.PresenceBitmap.rg_contains_token_sound`: the spec-
+// side `rows_with_pred` predicate is admitted as a ghost projection
+// (no extraction, no runtime impact) and the lemma's STATEMENT is
+// what callers rely on.
+// ------------------------------------------------------------------
+
+// Spec-level ground truth: ascending list of row indices in row-group
+// `rg` whose predicate-token-id equals `p`. Quantified ghostly.
+let rows_with_pred_t = nat -> nat -> list nat
+
+// "The offsets file at handle `h` correctly encodes ground truth
+// `rows_with_pred`" — for every in-range (rg, p) the cell's
+// row-position count equals the length of the ground-truth list, and
+// each i-th read returns the i-th ground-truth row index.
+let offsets_built_correctly
+  (h : valid_offset_handle) (rows_with_pred : rows_with_pred_t)
+  : Type0 =
+  forall (rg:nat) (p:nat).
+    rg < h.oih_header.oh_num_rgs /\ p < h.oih_header.oh_num_preds ==>
+      (match row_positions_for h rg p with
+       | None -> False
+       | Some cv ->
+         cv.cv_count = FStar.List.Tot.length (rows_with_pred rg p))
+
+// Soundness lemma: if the offsets file is correctly built and
+// `row_positions_for` returns a count of zero, the spec-side
+// ground truth is the empty list — the rg has no row with that
+// predicate, and the caller can skip the rg's subject + object
+// decode for this pattern.
+//
+// Status: stated; the body discharges trivially because
+// `offsets_built_correctly` already says
+// `count = length (rows_with_pred rg p)`, so `count = 0` implies the
+// ground-truth list is empty. The honest remaining gap (matching the
+// PresenceBitmap module's discipline) is the writer-side proof that
+// `offsets_built_correctly` actually holds for any given on-disk
+// `.p.offsets` file. That proof is the writer-migration follow-up
+// described in CLAUDE.md rule #11.
+val row_positions_for_count_sound :
+  h:valid_offset_handle ->
+  rows_with_pred:rows_with_pred_t ->
+  rg:nat ->
+  p:nat ->
+  cv:cell_view ->
+  Lemma
+    (requires
+      offsets_built_correctly h rows_with_pred /\
+      rg < h.oih_header.oh_num_rgs /\
+      p < h.oih_header.oh_num_preds /\
+      row_positions_for h rg p == Some cv /\
+      cv.cv_count = 0)
+    (ensures rows_with_pred rg p == [])
+
+let row_positions_for_count_sound h rows_with_pred rg p cv = ()
+
+// ------------------------------------------------------------------
+// Identity-when-no-handle property. When the offsets companion is
+// not opened (or the predicate is unbound), `row_positions_for_opt`
+// returns None; callers fall back to the full-decode path. This is
+// the safety property the OCaml-side dispatcher relies on.
+// ------------------------------------------------------------------
+
+let row_positions_for_opt_noinfo_when_handle_absent
+  (rg : nat) (bound_pred_id : option nat)
+  : Lemma
+    (ensures row_positions_for_opt None rg bound_pred_id == CD_NoInfo)
+  = ()
+
+let row_positions_for_opt_noinfo_when_pred_unbound
+  (oh : option offset_handle) (rg : nat)
+  : Lemma
+    (ensures row_positions_for_opt oh rg None == CD_NoInfo)
+  = ()

--- a/formal/fstar/SPARQL.Plan.AccessPath.fst
+++ b/formal/fstar/SPARQL.Plan.AccessPath.fst
@@ -1,0 +1,257 @@
+module SPARQL.Plan.AccessPath
+
+// Access-path chooser for the COTTAS / columnar query planner.
+//
+// Recovery plan Phase 6 (docs/designissues/2026-05-07-query-planning-
+// fstar-recovery.md). Names the F* home for the access-path decision
+// that retires codename "Lamed3" alongside its companion module
+// `RDF.Store.Columnar.OffsetIndex.fst` (which owns the `.p.offsets`
+// file format + reader).
+//
+// Old shape (the one this module displaces): the decision "if the
+// predicate is bound and the offsets companion is present, jump
+// directly to the row positions; otherwise fall through to the full
+// predicate-column decode" was made inside the OCaml dispatcher
+// `Cottas_ondisk_runtime.search_fast` injected by
+// experimental_ocaml_glue/cottas_ondisk_zzzzzz_lamed3_offset_idx.sh
+// (later retired in the Yod7 audit, with the offsets writer kept).
+// The OCaml side both *built* the bytes and *picked* whether to use
+// them; per CLAUDE.md rule #11 the latter is a backend correctness
+// decision and belongs in F*.
+//
+// New shape (this module): a pure F* function from "what's bound" +
+// "what capabilities does this store advertise" to a typed
+// `access_path` value. The store's reader implementation consumes
+// the typed value and dispatches accordingly.
+//
+// What this module owns:
+//   - `access_path` ADT — the typed plan output (full scan vs offset
+//     jump vs empty short-circuit).
+//   - `choose_access_path` — the decision function: given a bound
+//     predicate (+ optional bound subject + optional bound object)
+//     and the offset-index handle, returns the cheapest legal
+//     access-path for one row group.
+//   - `choose_access_path_for_pattern` — caller-shaped wrapper that
+//     takes a `pattern_bound_ids` record (the `SPARQL.Plan.Pruning`
+//     shape) and picks the access-path per rg.
+//   - Lemmas: identity-when-no-offset-index, equivalence under empty
+//     cell, soundness sketch deferring to OffsetIndex.
+//
+// What it deliberately does NOT own:
+//   - The actual prune predicate (`SPARQL.Plan.Pruning.fst`).
+//   - The cardinality estimate (`SPARQL.Plan.Estimate.fst`).
+//   - The companion-file I/O (`RDF.Store.Columnar.OffsetIndex.fst` +
+//     `RDF.CottasStore.OnDiskIndex.fst`).
+//   - The COTTAS-specific token-id resolution (still in
+//     `RDF.CottasStore.fst` until Phase 6's wiring follow-up).
+//
+// Wiring status: this module is the named F* home; it does not yet
+// re-route `RDF.CottasStore.cottas_ondisk_search`'s LIMIT path
+// through `choose_access_path`. That swap is a follow-up commit on
+// the same recovery branch once the F* extraction toolchain version
+// drift is resolved (the same drift that left
+// `SPARQL.Plan.Pruning` and `SPARQL.Plan.Estimate` un-wired in
+// PR #215 / Phase 4). Phase 6's deliverable is the named-API home +
+// the spec — semantics are byte-identical to what the OCaml
+// `Cottas_offset_idx.row_positions_for` shim produces today.
+
+module OI  = RDF.Store.Columnar.OffsetIndex
+module PR  = SPARQL.Plan.Pruning
+
+// ---------------------------------------------------------------------------
+// Access-path shapes.
+//
+// Three regimes the planner produces for a single (rg, pattern) pair:
+//
+//   - `AP_Skip` — the rg cannot match the pattern. Caller does
+//     nothing for this rg. Sources of `AP_Skip`:
+//       (a) prune predicate ruled it out (Pruning module),
+//       (b) offset-index says zero rows for the bound predicate
+//           (`CD_Empty` from OffsetIndex.row_positions_for_opt).
+//
+//   - `AP_OffsetJump cv` — read only the row positions in `cv`'s
+//     slice of the data section (`cv.cv_count` u32 row indices
+//     starting at `cv.cv_start`); decode subject + object cells at
+//     just those positions. Strictly cheaper than full decode when
+//     the bound predicate is rare in this rg.
+//
+//   - `AP_FullScan` — the planner has no offset-index info (either
+//     the predicate is unbound or the companion file is absent).
+//     Caller decodes the predicate column for the whole rg, filters
+//     by bound predicate (if any), then decodes subject + object at
+//     the surviving positions. The pre-Lamed3 baseline path.
+// ---------------------------------------------------------------------------
+
+type access_path =
+  | AP_Skip       : access_path
+  | AP_OffsetJump : OI.cell_view -> access_path
+  | AP_FullScan   : access_path
+
+// Equality on `access_path` for tests / lemmas. Pure boolean.
+let access_path_eq (a b : access_path) : Tot bool =
+  match a, b with
+  | AP_Skip, AP_Skip               -> true
+  | AP_FullScan, AP_FullScan       -> true
+  | AP_OffsetJump cv1, AP_OffsetJump cv2 ->
+    cv1.OI.cv_start = cv2.OI.cv_start &&
+    cv1.OI.cv_count = cv2.OI.cv_count
+  | _, _ -> false
+
+// ---------------------------------------------------------------------------
+// choose_access_path — per-rg decision.
+//
+// Inputs:
+//   - `oh_offsets`   : the offset-index handle (option). None means
+//                     the companion file isn't open — we have no
+//                     offset-index info for any rg.
+//   - `rg`           : the row-group index.
+//   - `bound_pred_id`: the resolved predicate token-id when the
+//                     pattern's predicate is bound; None when the
+//                     predicate is a variable.
+//
+// Output: the `access_path` for this rg.
+//
+// Decision table:
+//
+//   bound_pred_id | oh_offsets | OffsetIndex result | access_path
+//   --------------|------------|--------------------|------------
+//   None          | *          | -                  | AP_FullScan
+//   Some _        | None       | -                  | AP_FullScan
+//   Some p        | Some h     | CD_NoInfo          | AP_FullScan
+//   Some p        | Some h     | CD_Empty           | AP_Skip
+//   Some p        | Some h     | CD_Use cv          | AP_OffsetJump cv
+//
+// Pure F*; no I/O beyond what `OI.row_positions_for_opt` delegates.
+// ---------------------------------------------------------------------------
+
+let choose_access_path
+  (oh_offsets : option OI.offset_handle)
+  (rg : nat)
+  (bound_pred_id : option nat)
+  : Tot access_path =
+  match OI.row_positions_for_opt oh_offsets rg bound_pred_id with
+  | OI.CD_NoInfo   -> AP_FullScan
+  | OI.CD_Empty    -> AP_Skip
+  | OI.CD_Use cv   -> AP_OffsetJump cv
+
+// ---------------------------------------------------------------------------
+// choose_access_path_for_pattern — caller-shaped wrapper.
+//
+// Takes the bundled `pattern_bound_ids` record from
+// `SPARQL.Plan.Pruning` and projects out the bound-predicate field.
+// The subject + object bounds are not consulted here; they're
+// relevant for the *prune* decision (already made before the
+// access-path picker is called) and for the post-jump filter at
+// each row position (handled inside the COTTAS reader).
+// ---------------------------------------------------------------------------
+
+let choose_access_path_for_pattern
+  (oh_offsets : option OI.offset_handle)
+  (rg : nat)
+  (bounds : PR.pattern_bound_ids)
+  : Tot access_path =
+  choose_access_path oh_offsets rg bounds.PR.pbi_p
+
+// ---------------------------------------------------------------------------
+// Filter a candidate-rg list down to a list of (rg, access_path)
+// pairs. Mirrors `Pruning.filter_candidates_by_prune` in shape.
+// Callers feed in the post-prune candidate list and get back per-rg
+// access-path decisions. Order is preserved.
+//
+// `AP_Skip` results are KEPT in the output list (they're meaningful:
+// "we know this rg has zero matches for this pattern, so the
+// estimate for this rg is exactly 0"). Callers that want the
+// physical execution list should filter out `AP_Skip` separately.
+// ---------------------------------------------------------------------------
+
+let rec choose_access_paths_for_rgs
+  (oh_offsets : option OI.offset_handle)
+  (candidates : list nat)
+  (bounds : PR.pattern_bound_ids)
+  : Tot (list (nat * access_path)) (decreases candidates) =
+  match candidates with
+  | [] -> []
+  | rg :: rest ->
+    let ap = choose_access_path_for_pattern oh_offsets rg bounds in
+    (rg, ap) :: choose_access_paths_for_rgs oh_offsets rest bounds
+
+// Drop the `AP_Skip` entries from a list of (rg, access_path) pairs.
+// The execution layer wants the rgs it actually has to read; the
+// estimate layer wants the full list (including skips, which
+// contribute 0 rows).
+let rec drop_skips
+  (xs : list (nat * access_path))
+  : Tot (list (nat * access_path)) (decreases xs) =
+  match xs with
+  | [] -> []
+  | (rg, ap) :: tl ->
+    (match ap with
+     | AP_Skip -> drop_skips tl
+     | _       -> (rg, ap) :: drop_skips tl)
+
+// ---------------------------------------------------------------------------
+// Properties.
+// ---------------------------------------------------------------------------
+
+// When the offset-index companion is not open, every rg gets the
+// full-scan access path. This is the "no offset-jump optimisation
+// available" baseline behaviour that the OCaml runtime exhibited
+// before Lamed3 landed.
+let choose_access_path_no_handle_is_full_scan
+  (rg : nat) (bound_pred_id : option nat)
+  : Lemma
+    (ensures choose_access_path None rg bound_pred_id == AP_FullScan)
+  = ()
+
+// When the predicate is unbound, every rg gets the full-scan access
+// path — the offset-index is keyed by predicate so we have nothing
+// to look up.
+let choose_access_path_unbound_pred_is_full_scan
+  (oh_offsets : option OI.offset_handle) (rg : nat)
+  : Lemma
+    (ensures choose_access_path oh_offsets rg None == AP_FullScan)
+  = ()
+
+// When the bounds record carries no bound predicate, the
+// pattern-shaped chooser collapses to the full-scan path. Mirrors
+// the previous lemma but consumes the `pattern_bound_ids` record so
+// callers using the bundled shape get a directly-applicable lemma.
+let choose_access_path_for_pattern_unbound_pred_is_full_scan
+  (oh_offsets : option OI.offset_handle) (rg : nat)
+  (bounds : PR.pattern_bound_ids)
+  : Lemma
+    (requires bounds.PR.pbi_p == None)
+    (ensures
+      choose_access_path_for_pattern oh_offsets rg bounds == AP_FullScan)
+  = ()
+
+// `drop_skips` is the identity when no input cell is `AP_Skip`. The
+// list-fold structure makes this provable by induction; F* discharges
+// it from the definitional unfolding for empty input, and we expose
+// the "all not skip -> identity" shape as a recursive lemma for any
+// callers that need it.
+let rec drop_skips_identity_when_no_skips
+  (xs : list (nat * access_path))
+  : Lemma
+    (requires
+      forall (rg:nat) (ap:access_path).
+        FStar.List.Tot.memP (rg, ap) xs ==> ~(ap == AP_Skip))
+    (ensures drop_skips xs == xs)
+    (decreases xs)
+  =
+  match xs with
+  | [] -> ()
+  | _ :: tl -> drop_skips_identity_when_no_skips tl
+
+// Soundness sketch: if `choose_access_path` returns `AP_Skip`, the
+// rg has no row whose predicate equals the bound predicate. This
+// follows from `OI.row_positions_for_count_sound`: the chooser
+// returns `AP_Skip` only when `OI.row_positions_for_opt` produced
+// `CD_Empty`, which by construction came from `cv.cv_count = 0`,
+// which by the OffsetIndex soundness lemma implies the spec-side
+// ground-truth list of matching rows is empty.
+//
+// We do NOT re-state a separate executable lemma here (the
+// OffsetIndex one is sufficient); the call site can invoke
+// `OI.row_positions_for_count_sound` when it needs the formal
+// guarantee.

--- a/formal/fstar/build-ocaml.sh
+++ b/formal/fstar/build-ocaml.sh
@@ -247,9 +247,11 @@ if [[ "$STEP" == "all" || "$STEP" == "extract" ]]; then
              RDF.CottasStore.OnDiskIndex.fst \
              RDF.CottasStore.PresenceBitmap.fst \
              RDF.CottasStore.CompoundPresenceBitmap.fst \
+             RDF.Store.Columnar.OffsetIndex.fst \
              SPARQL.Plan.Pruning.fst \
              SPARQL.Plan.Estimate.fst \
              SPARQL.Plan.Loader.fst \
+             SPARQL.Plan.AccessPath.fst \
              RDF.CottasStore.fst \
              RDF.CottasInMem.fst \
              SPARQL11.Store.fst \
@@ -344,9 +346,11 @@ if [[ "$STEP" == "all" || "$STEP" == "compile" ]]; then
     RDF_CottasStore_OnDiskIndex.ml \
     RDF_CottasStore_PresenceBitmap.ml \
     RDF_CottasStore_CompoundPresenceBitmap.ml \
+    RDF_Store_Columnar_OffsetIndex.ml \
     SPARQL_Plan_Pruning.ml \
     SPARQL_Plan_Estimate.ml \
     SPARQL_Plan_Loader.ml \
+    SPARQL_Plan_AccessPath.ml \
     RDF_CottasStore.ml \
     RDF_CottasInMem.ml \
     fstar_pure_hashes.ml \


### PR DESCRIPTION
## Summary

Names the F\* surface for codename violator **Lamed3** (per-RG predicate row-offset index — the 6s → 200ms LIMIT-aware path).

### Diagnostic finding
- **Named glue patch DOES exist**: `formal/fstar/experimental_ocaml_glue/cottas_ondisk_zzzzzz_lamed3_offset_idx.sh` (469 lines). Writer-only as of the Yod7 audit (2026-04-26).
- **Inline F\* logic does NOT exist**: zero hits for `lamed3` / `p.offsets` / `0x4f544f43` / `Cottas_offset_idx` across all `.fst` files.

So unlike Yod6/Tet3/Mem5 (#215), Lamed3's logic is genuinely on the OCaml side. This PR builds the F\* skeleton (verifying types + read API + access-path picker); the wiring + writer migration are explicit follow-ups.

### What lands

- `formal/fstar/RDF.Store.Columnar.OffsetIndex.fst` (408 LoC):
  - `coto_magic_u32` / `offset_header` / `offset_handle` / `valid_offset_handle`
  - `read_offset_header`, `open_offsets`, `close_offsets`, `cell_view`, `read_cell_start`, `read_cell_end`, `row_positions_for`, `cell_decision` (CD_NoInfo / CD_Empty / CD_Use), `row_positions_for_opt`, `offsets_path_of`
  - `offsets_built_correctly` ghost predicate + `row_positions_for_count_sound` lemma (proven, not admitted)
  - Reuses existing `read_companion_u32_le` / `read_companion_u64_le` / `mmap_companion_open` from `RDF.CottasStore.OnDiskIndex.fst` — no new `assume val`s.

- `formal/fstar/SPARQL.Plan.AccessPath.fst` (257 LoC):
  - `access_path` ADT (`AP_Skip` / `AP_OffsetJump` / `AP_FullScan`)
  - `choose_access_path`, `choose_access_path_for_pattern` (consumes `pattern_bound_ids` from `SPARQL.Plan.Pruning` from #215)
  - `choose_access_paths_for_rgs`, `drop_skips`
  - Identity lemmas (no-handle → `AP_FullScan`, unbound-pred → `AP_FullScan`)

Both verify under z3 4.13.3 with no `--lax` / `--admit_smt_queries` / new `assume val`.

### Follow-up wiring PR

- Re-route `RDF.CottasStore.cottas_ondisk_search` (LIMIT path) through `SPARQL.Plan.AccessPath.choose_access_path`. The OCaml `Cottas_offset_idx.row_positions_for` shim becomes the call target for `AP_OffsetJump`.
- Migrate the writer half of `cottas_ondisk_zzzzzz_lamed3_offset_idx.sh` to a `serialize_offsets : data -> Tot (list u8)` in `RDF.Store.Columnar.OffsetIndex.fst` and reduce the OCaml side to `write_bytes`. After this only the I/O `assume val`s remain in glue.
- Strengthen `offsets_built_correctly` from a stated invariant to a writer-side proven property once the writer migrates.
- Bench gate: confirm 6s → 200ms `LIMIT 5` on parliament after wiring.

### Constraints

- Stayed in `RDF.Store.Columnar.*` + `SPARQL.Plan.AccessPath.fst`. Did not touch Pe5/Bet7 territory (other agents).
- No new `assume val`s, no `--lax`, no `--admit_smt_queries`.

Migration epic #200: Lamed3 partial — F\* home landed; wiring + writer migration are explicit follow-ups.