### PR TITLE
docs: cross-link XML API-style note to Phase 0 audit

### DIFF
--- a/docs/designissues/2026-05-07-xml-fstar-phase0-audit.md
+++ b/docs/designissues/2026-05-07-xml-fstar-phase0-audit.md
@@ -147,6 +147,17 @@ same four functions and the same C14N-ish serialiser.
 **Recommendation: (B) build alongside, then migrate Parser.RDFXML in a
 follow-up PR.**
 
+**API style: DOM tree, namespace-aware AST, no streaming in Phase 1.**
+A separate API-style survey (DOM vs SAX vs StAX vs reader-monad vs
+EverParse format-spec) is recorded in
+[issue #185 comment](https://github.com/danbri/factoidal/issues/185#issuecomment-4398862203).
+Summary: the only in-tree consumer (`Parser.RDFXML.fst`) is DOM-shaped,
+the planned consumers (RSS / Atom / Sitemap / RIF-XML) all parse small
+documents and want a tree, and shipping streaming costs verifier
+complexity for zero current consumer. If a streaming consumer surfaces
+later, a pull-style `next_event` shim layers on the same tokeniser
+without breaking DOM consumers.
+
 Concrete shape:
 
 - `formal/fstar/XML.Core.fst` — refined AST: namespace-aware


### PR DESCRIPTION
## Summary

Small follow-up to the XML F\* API-style research posted on issue #185 ([comment](https://github.com/danbri/factoidal/issues/185#issuecomment-4398862203)).

Adds a short API-style note to `docs/designissues/2026-05-07-xml-fstar-phase0-audit.md` cross-linking the comment so the Phase 0 audit reflects the (now-confirmed) recommendation: DOM-style core with namespace-aware AST.

### Three findings from the research worth recording

- **RIF-XML is XML-feature-trivial** (~12 closed elements, no exotic features). The "XML core defangs RIF-XML" argument is real but the actual surface RIF needs is much smaller than RDF/XML.
- **EverParse has zero text-format coverage in 2026.** Phase 0's "roll our own" recommendation is reaffirmed.
- **`Parser.RDFXML.fst` doesn't need streaming anywhere.** Both consumers (rdf:parseType Literal/Collection + c14n serialiser) materialise the full tree. DOM is the right shape.

## Test plan

Doc-only.