### PR TITLE
workflow: skills + build lock for dev-loop hazards we hit 2026-05-07

### DIFF
--- a/.claude/skills/build-and-test/SKILL.md
+++ b/.claude/skills/build-and-test/SKILL.md
@@ -197,6 +197,27 @@ the runner reports zero tests.
 | `bin/linux-x86_64/w3c_runner` shows 0 tests | Stale binary; built before submodule paths added | Rebuild: `./build-ocaml.sh` |
 | Ext fails with `MLP_Const` translate error | Module has string-pattern match arms unsupported by KaRaMeL | Refactor to `if/else if`; or omit from karamel allowlist |
 | Compile fails on `Prims.int` mismatch | OCaml int passed where Z.t expected | Add `Z.of_int` at the call site |
+| `FATAL: another build-ocaml.sh is already running in this worktree` | Stale or concurrent invocation holds the per-worktree flock | Wait for the running build, or `pkill -f 'build-ocaml.sh'` if stuck |
+| Fresh build fails with `Unbound module FooBar` | Source-without-build-wiring (workflow-gotchas-debugging §3) | Add the new module to all three lists in `build-ocaml.sh` (extract loop, `COMMON_MODULES`, `FSTAR_MODULES`) |
+| Modules being re-extracted that should be cached | Concurrent fstar.exe runs from parallel agents corrupting the .checked.lax cache | Lock should prevent same-worktree races; check `ps aux \| grep fstar.exe` for cross-worktree contention |
+
+## Single-runner lock and build-running marker
+
+`build-ocaml.sh` opens a `flock` on `.build.lock` at entry. Concurrent
+invocations in the same worktree exit immediately with exit code 75
+and a `FATAL: another build-ocaml.sh is already running` message.
+
+The lock is per-worktree — two worktrees can build concurrently and
+won't block each other (their locks are at different paths). Only
+same-worktree concurrency is refused, which is enough to prevent the
+.cmi/.cmx/.checked-cache races we hit in 2026-05-07.
+
+The marker file `.build-running` is written on entry and removed via
+`trap` on exit (success or failure or signal). Stop hooks should
+suppress "uncommitted changes" warnings while this file exists, since
+the build is actively rewriting `.ml` and binary files.
+
+Both files are gitignored (`formal/fstar/.gitignore`).
 
 ## What this skill does NOT do
 

--- a/.claude/skills/subagent-prompting/SKILL.md
+++ b/.claude/skills/subagent-prompting/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: subagent-prompting
+description: How to write subagent prompts for the Factoidal repo so the agent's work actually lands cleanly. Use whenever you dispatch a subagent with the Agent tool, especially with `isolation: "worktree"`. Two load-bearing rules. (1) Path discipline — agents must use only paths under their worktree, not absolute paths from your prompt context. (2) Post-condition checks — agent must verify its main-worktree footprint is zero before reporting back. Pairs with workflow-gotchas-debugging (which catalogues recovery steps when these rules are violated).
+---
+
+# Subagent prompting for Factoidal
+
+This repo runs many parallel subagents, each in its own git worktree
+under `.claude/worktrees/agent-<id>/`. The Agent tool's `isolation:
+"worktree"` setting is supposed to keep their work isolated — but the
+isolation can be silently bypassed if the agent uses absolute paths
+from your prompt instead of paths under its own worktree.
+
+When that happens, the agent's edits land in your **main** worktree,
+not in its isolated copy. Your `git status` shows uncommitted changes
+you didn't make. The agent's branch has nothing to push. Recovery
+takes 10-30 minutes per incident.
+
+This skill exists because we hit this hazard 3+ times in one session
+(2026-05-07; see `.claude/skills/workflow-gotchas-debugging/SKILL.md`
+for the full incident report).
+
+## The two rules every agent prompt must include
+
+### Rule 1 — path discipline preamble
+
+Every agent prompt MUST start with this block (copy-paste, then fill in
+the worktree path placeholder if you know it; the agent figures it out
+from `pwd` if you don't):
+
+```
+## Path discipline (MANDATORY)
+
+Your worktree is at $WORKTREE_PATH (run `pwd` to confirm). All file
+operations — Read, Edit, Write, Bash commands — MUST use paths under
+that root.
+
+If this prompt mentions paths like `/home/user/factoidal/formal/...`,
+those refer to the MAIN worktree. Translate them to your worktree by
+substituting the prefix:
+
+  /home/user/factoidal/<rest>
+  → $WORKTREE_PATH/<rest>
+
+Do NOT edit files under /home/user/factoidal/ directly. That is a
+different working tree; your edits will not appear on your branch and
+will pollute the main tree's git status.
+
+Verify before each Edit/Write:
+  - `pwd` returns a path under $WORKTREE_PATH
+  - The file path you're about to edit also starts with $WORKTREE_PATH
+
+If you find yourself about to use an absolute path that doesn't start
+with $WORKTREE_PATH, STOP and translate it.
+```
+
+### Rule 2 — post-condition self-check before pushing
+
+Every agent prompt MUST end with this block:
+
+```
+## Before you push (MANDATORY post-condition check)
+
+After your final commit but BEFORE running `git push`, run this check:
+
+  cd $WORKTREE_PATH && git status -s
+  # Expected: empty. Anything here means a commit was missed.
+
+  cd /home/user/factoidal && git status -s
+  # Expected: empty (or unchanged from your start). Anything here that
+  # you don't recognise from the parent session means you leaked into
+  # the main worktree.
+
+If the second check shows files YOU edited, you have leaked. Recovery:
+  1. Stash them in MAIN (not your worktree):
+     cd /home/user/factoidal && git stash push -m "agent-<your-id>-leakage" <files>
+  2. In your worktree, copy the stashed content via:
+     git -C /home/user/factoidal stash show -p stash@{0} | git apply
+  3. Re-commit in your worktree.
+  4. Then push.
+
+Report both `git status` outputs in your final response so the parent
+can verify.
+```
+
+## Other patterns
+
+### Forbid hand-written .ml in `formal/fstar/ocaml-output/`
+
+Any agent task that involves "make this OCaml side faster / fix this
+behavior" should explicitly forbid editing extracted `.ml` files
+directly:
+
+```
+## Iron rule #11 (MANDATORY)
+
+Inside the verified library boundary, OCaml is `assume val`
+realisations only. Do NOT hand-edit any extracted file under
+$WORKTREE_PATH/formal/fstar/ocaml-output/*.ml — fix the .fst source
+or add a patch script under
+$WORKTREE_PATH/formal/fstar/experimental_ocaml_glue/ or
+$WORKTREE_PATH/formal/fstar/minimal_regrettable_glue_code_each_with_an_open_issue/
+
+Consumer-side .ml (w3c_runner.ml, owl_runner.ml, factoidal_*.ml,
+rdfc10_runner.ml, cottas_ondisk_smoketest.ml) are hand-written
+runners, NOT extracted. They are exempt from rule #13 but still
+subject to rule #15 ("no semantic logic in test runners"). If you
+find yourself adding logic to a runner, ask whether that logic
+belongs in the F* spec instead.
+```
+
+### One agent = one commit-sized goal
+
+Per anti-pattern #23 in CLAUDE.md. Don't dispatch "fix all of OWL DL";
+dispatch "land prp-key (Cluster B) + report numerical impact". An
+agent that doesn't know when to stop ships sprawl.
+
+### Ship code sketches, not narrow instructions
+
+Per anti-pattern #24. The prompt should include:
+- Concrete file paths with line numbers
+- The function names and signatures involved
+- A code sketch of the proposed change
+- The specific test or score that should move
+
+Not just "make Tableau better."
+
+## When to forgo `isolation: "worktree"`
+
+For read-only research tasks, use the `Explore` subagent instead — no
+worktree, no leakage hazard, no merge to coordinate.
+
+For tasks that must commit + push code, always use `isolation:
+"worktree"`. The leakage hazard is real but Rule 1 + Rule 2 manage it.
+
+## Skill cross-refs
+
+- `workflow-gotchas-debugging` — what to do when the rules above
+  weren't followed and leakage already happened.
+- `github-and-prs` — how the agent should branch + push.
+- `build-and-test` — how the agent should run `build-ocaml.sh` (and
+  the new `flock` lock that prevents extract races).
+- `markdown-style` — agent commit messages and PR bodies.

--- a/.claude/skills/workflow-gotchas-debugging/SKILL.md
+++ b/.claude/skills/workflow-gotchas-debugging/SKILL.md
@@ -1,0 +1,299 @@
+---
+name: workflow-gotchas-debugging
+description: Diagnostic playbook for the dev-loop hazards that recur in this repo. Use when a build mysteriously fails, a fresh clone breaks where local works, an agent's work doesn't appear on its branch, the same uncommitted file keeps coming back after `git checkout`, or "stop hook fires every turn but I'm not done." These are the seven hazards we've actually hit (see "Lessons from 2026-05-07" below) plus their detection + recovery steps.
+---
+
+# Workflow gotchas + debugging
+
+This skill catalogues the seven hazards that have actually bitten this
+project in production. Each section lists symptoms, root cause, the
+recovery procedure, and (where applicable) the prevention now in place.
+
+## 1. Subagent worktree-leakage
+
+### Symptom
+
+You spawn a subagent with `isolation: "worktree"`. Later you see
+uncommitted changes in your **main** worktree (`/home/user/factoidal/`)
+that you didn't make. Or your branch silently switches to one the agent
+created. Or the same file (`Parser.RIFXML.fst`, `w3c_runner.ml`) keeps
+coming back after you `git checkout` it.
+
+### Root cause
+
+Subagents have their own working directory (`$WORKTREE_PATH`), but if
+the prompt context contains absolute paths to the main worktree
+(`/home/user/factoidal/formal/fstar/...`), the agent uses those paths
+directly with the `Edit`/`Write` tools and writes to the **main
+worktree**, bypassing isolation entirely.
+
+The agent's own worktree stays clean; nothing pushes from there. The
+edits live in your main worktree, and `git status` shows them as
+yours.
+
+### Detection
+
+```bash
+# In main worktree:
+git status -s | head
+# Files you didn't touch will appear modified.
+
+# Compare to agent worktree:
+diff -q /home/user/factoidal/formal/fstar/<file> \
+        /home/user/factoidal/.claude/worktrees/agent-<id>/formal/fstar/<file>
+# If they differ AND the agent's copy matches origin, the agent edited
+# your main, not its own.
+
+# Spot the branch swap:
+git branch --show-current
+# If it's not the branch you started on, an agent ran `git checkout` here.
+```
+
+### Recovery
+
+```bash
+# Stash the leaked changes with a clear label so you can recover them later
+git stash push -m "agent-leakage-<topic>" path/to/affected/files
+
+# If branch was swapped, checkout the right one:
+git checkout claude/<your-branch>
+
+# Recover the agent's intended work later:
+git stash list                    # find the stash
+git stash show -p stash@{N}        # inspect
+# Then either: cherry-pick onto the agent's branch, or git apply
+# inside the agent's worktree.
+```
+
+### Prevention
+
+The `subagent-prompting` skill mandates a path-discipline preamble.
+Every agent prompt now includes:
+
+> Your worktree is at `$WORKTREE_PATH`. Use ONLY paths under that root.
+> Before any `Edit`/`Write`, verify `pwd` matches your worktree. If you
+> see paths like `/home/user/factoidal/...` in this prompt, translate
+> them to `$WORKTREE_PATH/...` first.
+
+Plus a post-condition check the agent runs before pushing.
+
+## 2. Concurrent F\* extracts racing the cache
+
+### Symptom
+
+`./build-ocaml.sh extract` hangs / dies midway. fstar.exe processes show
+up in `ps` from multiple worktrees. Modules that should be `(up to date)`
+get re-extracted in a fresh order. Compile fails with "Unbound module"
+errors that don't make sense.
+
+### Root cause
+
+Different worktrees have separate `.ml` outputs but **share** the F\*
+opam switch's `.checked.lax` hint cache. Concurrent fstar.exe runs
+invalidate each other's cache entries; one process's `.checked` is
+written while another reads it; downstream cache misses cascade.
+
+### Detection
+
+```bash
+ps aux | grep "fstar.exe" | grep -v grep
+# More than one fstar.exe = hazard.
+
+ps aux | grep "build-ocaml.sh extract" | grep -v grep
+# More than one extract loop = race.
+```
+
+### Recovery
+
+```bash
+# Pick the right one to keep, kill the others:
+pkill -f "build-ocaml.sh extract"
+# Wait, then run the extract serially.
+```
+
+### Prevention
+
+`build-ocaml.sh` opens a `flock` on `.build.lock` at entry. Concurrent
+invocations exit immediately with "another build in flight." See the
+`build-and-test` skill for the lock semantics.
+
+## 3. Source-without-build-wiring
+
+### Symptom
+
+A PR adds a new `.fst` module. F\* verifies it. The PR merges. Days
+later, on a fresh clone, `./build-ocaml.sh compile` fails with
+"Unbound module FooBar". Local builds were green only because the
+`.cmx` was cached from before.
+
+### Root cause
+
+`build-ocaml.sh` has the F\* module list in **three** places:
+
+- The `for fst in ... ; do` extract loop (around line 226)
+- `COMMON_MODULES="..."` for native compile (around line 331)
+- `FSTAR_MODULES=( ... )` for js_of_ocaml (around line 635)
+
+It's easy to add a module to one and forget the others. PR #224 added
+`RDF.List.Helpers.fst` source without updating any of the three;
+SPARQL11_Algebra references `RDF_List_Helpers.assoc_tr` and the build
+breaks. Same pattern hit `RIF.Core.Eval.fst` earlier.
+
+### Detection
+
+```bash
+# After landing a new .fst, verify it appears in all three places:
+grep -c "<NewModule>.fst" formal/fstar/build-ocaml.sh   # should be >= 1
+grep -c "<NewModule>.ml"  formal/fstar/build-ocaml.sh   # should be >= 2
+```
+
+CI gate: build-ocaml.sh `compile` runs on every PR head, not just
+post-merge on `claude/main`.
+
+### Recovery
+
+Add the module to all three lists. Re-extract + recompile.
+
+### Prevention (planned)
+
+Single source of truth: `formal/fstar/modules.txt`, sourced into
+build-ocaml.sh. Each section reads from the same file. No more
+3-place divergence.
+
+## 4. Stale documentation numbers
+
+### Symptom
+
+`docs/designissues/2026-05-07-tableau-audit.md` cites
+"51 pass / 70 total" for the entailment suite. Actual current score
+is 69/70 — but the audit doc says 51/70 and triages "this is the
+queue."
+
+### Root cause
+
+Test scores in design docs are written once and never refreshed. PRs
+that improve scores don't update every doc that mentions the old
+number.
+
+### Detection
+
+CI lint planned: scrape `\d+ pass / \d+ total` patterns from
+`docs/designissues/*` and `docs/claude-rules/*`. Compare to
+`docs/test-results/latest.json`. Flag mismatches in PR diff.
+
+### Recovery
+
+Update the affected docs with current numbers. Do this when you
+notice a stale number — don't defer.
+
+## 5. Build-aware stop-hook needed
+
+### Symptom
+
+A long-running build is in flight (extract takes 10-15 minutes).
+Every turn-end the stop hook complains "uncommitted changes" because
+the build is rewriting `.ml` files. User sees noise; assistant feels
+pressure to commit partial state.
+
+### Root cause
+
+`~/.claude/stop-hook-git-check.sh` doesn't know about builds.
+
+### Recovery
+
+Don't commit partial extracted state. Wait for the build to finish.
+
+### Prevention (planned)
+
+`build-ocaml.sh` writes `.build-running` on entry, removes on exit /
+trap. Stop hook checks for the marker and skips the warning when
+present.
+
+## 6. The `(* *)` F\* comment trap
+
+### Symptom
+
+F\* reports a syntax error hundreds of lines after the actual offender.
+The reported line looks fine.
+
+### Root cause
+
+F\* block comments `(* ... *)` **nest**. Any `*)` inside a comment
+prematurely closes it; any `(*` opens a new level. Common offenders:
+ARQ-style notation containing `construct(*)`, COUNT(*) snippets in
+explanatory comments.
+
+### Detection
+
+```bash
+# After a syntax error, scan for problem patterns:
+grep -nE '(\(\*|\*\))' <file>.fst | head -50
+# Look for `*)` inside a comment, or unbalanced `(*`.
+```
+
+### Recovery
+
+Reword to avoid `(*` / `*)` inside comments, or switch to `//` line
+comments.
+
+### Prevention
+
+CLAUDE.md DANGER section. The `fstar-env` skill repeats the warning.
+
+## 7. Worktree garbage accumulation
+
+### Symptom
+
+`.claude/worktrees/` has 33+ entries, most locked, some pointing at
+branches that were merged weeks ago. `git worktree list` is enormous.
+Disk usage drifts upward.
+
+### Detection
+
+```bash
+git worktree list | wc -l    # Should be << 10 normally.
+ls .claude/worktrees | wc -l  # Same expectation.
+```
+
+### Recovery
+
+```bash
+# Audit which worktrees are still relevant:
+git worktree list
+# For each agent-* worktree where the agent is finished:
+git worktree remove --force <path>
+git branch -D <branch>   # only if pushed + merged
+git worktree prune
+```
+
+### Prevention (planned)
+
+Daily `git worktree prune --expire 1.day.ago` plus a CI sweep that
+deletes worktrees whose agent-id appears in the completed-agents
+ledger.
+
+## Lessons from 2026-05-07
+
+This skill is the durable form of a single bad session:
+
+- A 10-minute extract turned into 90 minutes because of #1 + #2
+  (worktree leakage + concurrent races) compounding.
+- PR #228 had to be force-pushed multiple times because the source
+  files I committed kept getting reverted by leaked agent edits.
+- "Stop hook fires every turn" pushed me toward partial commits;
+  resisting that pressure was correct.
+- The actual drift fix turned out to be just a build-script wiring
+  issue + a patch script issue — the .ml drift wasn't real because
+  main's .ml files compiled fine under the new F\* version. Title
+  / scope creep in the PR was a leftover from an incorrect initial
+  diagnosis.
+
+## Quick checklist when something feels wrong
+
+1. `git status -s` in main worktree — uncommitted files you didn't
+   touch? → suspect agent leakage (#1).
+2. `ps aux | grep fstar.exe | grep -v grep` — multiple? → race (#2).
+3. `git branch --show-current` — wrong branch? → agent swap (#1).
+4. New `.fst` in recent merges? → grep build-ocaml.sh for it (#3).
+5. Build-running flag set? → wait, don't commit partial.
+6. Doc number that "doesn't match what I just measured"? → stale (#4).

--- a/formal/fstar/.gitignore
+++ b/formal/fstar/.gitignore
@@ -15,3 +15,7 @@ z3-4.13.3
 # KaRaMeL pilot — see docs/designissues/2026-05-07-c-build-and-roaring-plan.md
 krml-output/
 c-output/
+
+# build-ocaml.sh runtime state
+.build.lock
+.build-running

--- a/formal/fstar/build-ocaml.sh
+++ b/formal/fstar/build-ocaml.sh
@@ -55,6 +55,39 @@ OUTDIR=ocaml-output
 JSDIR=../../docs/fstar-extracted
 STEP="${1:-all}"
 
+# ---------------------------------------------------------------------------
+# Single-runner lock + build-running marker.
+#
+# Concurrent extract/compile invocations in the same worktree are a recurring
+# hazard — multiple fstar.exe processes corrupt each other's .checked.lax cache
+# entries; concurrent ocamlopt runs race on .cmi/.cmx files. This lock makes
+# build-ocaml.sh refuse to run if another instance is already in flight in the
+# same worktree.
+#
+# The build-running marker (.build-running) is consumed by the stop hook to
+# silence "uncommitted changes" warnings while a build is rewriting .ml or
+# binary files. See .claude/skills/workflow-gotchas-debugging/SKILL.md
+# sections 2 and 5.
+#
+# The lock is per-worktree: each worktree has its own .build.lock, so parallel
+# agent worktrees don't block each other. Only same-worktree concurrency is
+# refused.
+# ---------------------------------------------------------------------------
+LOCK_FILE=".build.lock"
+exec 200>"$LOCK_FILE"
+if ! flock -n 200; then
+  echo "FATAL: another build-ocaml.sh is already running in this worktree." >&2
+  echo "       (lock file: $(pwd)/$LOCK_FILE)" >&2
+  echo "       Wait for it to finish, or kill it:" >&2
+  echo "         pkill -f 'build-ocaml.sh'" >&2
+  exit 75
+fi
+
+# Build-running marker, removed on any exit (success, failure, signal).
+MARKER_FILE=".build-running"
+echo "$$:$STEP:$(date -u +%Y-%m-%dT%H:%M:%SZ)" > "$MARKER_FILE"
+trap 'rm -f "$MARKER_FILE"' EXIT
+
 case "$STEP" in
   compile|js|wasm|patches)
     # These steps don't invoke fstar.exe; skip the preflight check so


### PR DESCRIPTION
## Summary

Two new skills + one build-script change addressing the recurring hazards from the F\* drift / OWL cluster session today.

### `workflow-gotchas-debugging` skill (new)

Diagnostic playbook for the seven hazards we actually hit. Each section: symptoms + detection + recovery + prevention.

1. Subagent worktree-leakage (agents writing to main worktree paths)
2. Concurrent F\* extracts racing the .checked.lax cache
3. Source-without-build-wiring (PR #224's `RDF.List.Helpers.fst` source landed without updating any of the three build-script lists; #228 caught it)
4. Stale documentation numbers (Tableau audit cited 51/70; actual is 69/70)
5. Build-aware stop-hook needed (`.build-running` marker)
6. The F\* nested-comment trap
7. Worktree garbage accumulation (33 stale worktrees on disk)

### `subagent-prompting` skill (new)

Two MANDATORY rules every Agent prompt must include:

- **Path discipline preamble** — agents must use only paths under `$WORKTREE_PATH`, not absolute paths from the parent's prompt context.
- **Post-condition self-check** — agent runs `git status` in both its worktree and the main worktree before pushing; reports both. Anything in main = leakage that needs recovery.

Plus guidance on iron-rule #11 enforcement and one-agent-one-commit scoping (anti-pattern #23).

### `build-ocaml.sh` flock + `.build-running` marker

- Per-worktree `flock` on `.build.lock` refuses concurrent invocations in the same worktree. Different worktrees still build concurrently (they have different lock paths).
- `.build-running` marker written on entry, removed via `trap` on exit. Stop hooks should suppress "uncommitted changes" warnings while this exists.
- Both files gitignored under `formal/fstar/.gitignore`.

Verified the lock works cross-process: a second `./build-ocaml.sh compile` while a first runs gets `FATAL: another build-ocaml.sh is already running in this worktree` and exits 75.

### `build-and-test` skill update

- Three new entries in the Common build/test failures table (lock contention, source-without-wiring `Unbound module`, cross-worktree fstar.exe contention).
- "Single-runner lock and build-running marker" subsection.

## Pending follow-ups (not in this PR)

Listed in the `workflow-gotchas-debugging` skill. Each is its own PR:

- **Build-aware stop hook** — wire `~/.claude/stop-hook-git-check.sh` to skip warnings when `.build-running` exists.
- **`modules.txt` single-source-of-truth** — eliminates the 3-place divergence in `build-ocaml.sh` that bit #224.
- **CI gate for source-without-wiring** — run `./build-ocaml.sh compile` on every PR head.
- **CI lint for stale doc numbers** — scrape `\d+ pass / \d+ total` against `latest.json`.
- **Daily worktree GC** — `git worktree prune --expire 1.day.ago`.

## Test plan

- [x] Lock denies concurrent same-worktree invocations (verified)
- [x] Lock allows cross-worktree builds (per-worktree path, default behavior)
- [x] `.build-running` marker created on entry, removed on exit (trap)
- [x] `.build.lock` and `.build-running` gitignored
- [x] All three skill files render cleanly in GitHub markdown
- [ ] Stop hook integration (separate PR — needs hook script edit)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Gid59KLYfGtaXLNfFWnPt1)_