### PR TITLE
dep-graph: mobile responsiveness + types & terms view + fullscreen

### DIFF
--- a/docs/.eleventy.js
+++ b/docs/.eleventy.js
@@ -21,6 +21,7 @@ module.exports = function(eleventyConfig) {
   // design docs and offline viewing.
   eleventyConfig.addPassthroughCopy("web/demos/dep-graph/modules.json");
   eleventyConfig.addPassthroughCopy("web/demos/dep-graph/namespaces.json");
+  eleventyConfig.addPassthroughCopy("web/demos/dep-graph/terms.json");
   eleventyConfig.addPassthroughCopy("web/demos/dep-graph/modules.dot");
   eleventyConfig.addPassthroughCopy("web/demos/dep-graph/modules.mmd");
   eleventyConfig.addPassthroughCopy("web/demos/dep-graph/modules.png");

--- a/docs/web/demos/dep-graph/index.html
+++ b/docs/web/demos/dep-graph/index.html
@@ -38,7 +38,8 @@
   input[type=text]::placeholder { color: var(--muted); }
   label { display: block; margin: 8px 0 4px; color: var(--muted); font-size: 11px;
           text-transform: uppercase; letter-spacing: 0.06em; }
-  #graph { position: relative; overflow: hidden; touch-action: none; }
+  #graph { position: relative; overflow: hidden; touch-action: none; background: var(--bg); }
+  #graph:fullscreen, #graph:-webkit-full-screen { width: 100vw; height: 100vh; }
   svg { width: 100%; height: 100%; display: block; cursor: grab; touch-action: none; }
   svg:active { cursor: grabbing; }
   .node circle { stroke: #0c0e13; stroke-width: 1.5px; cursor: pointer; }
@@ -60,6 +61,9 @@
   .meta { color: var(--muted); font-size: 12px; }
   .pill { display: inline-block; padding: 1px 6px; border-radius: 8px; background: #1f2530;
           color: var(--muted); font-size: 11px; font-variant-numeric: tabular-nums; }
+  .members { margin: 4px 0 8px; display: flex; flex-wrap: wrap; gap: 4px; }
+  .members .pill { background: #1c2533; color: var(--fg); font-family: ui-monospace,
+                   "SFMono-Regular", Menlo, monospace; font-size: 11px; }
   .dep-list { margin: 4px 0 0; padding: 0; list-style: none; }
   .dep-list li { padding: 6px 0; border-bottom: 1px dashed var(--border); cursor: pointer;
                  display: flex; align-items: center; gap: 6px; }
@@ -118,6 +122,7 @@
     <select id="view">
       <option value="modules">Per-module (every .fst/.fsti)</option>
       <option value="namespaces">By namespace (Parser, RDF, SPARQL, …)</option>
+      <option value="terms">Types &amp; terms (triple, graph, rdf_term, …)</option>
     </select>
 
     <h2>Namespaces</h2>
@@ -132,6 +137,7 @@
       <button id="btn-freeze">Freeze</button>
       <button id="btn-labels" class="on">Labels</button>
       <button id="btn-leaves" class="on">Leaves</button>
+      <button id="btn-fullscreen" title="Fullscreen graph (Esc to exit)">⛶</button>
     </div>
     <svg></svg>
     <div id="footer">drag to pan · wheel/pinch to zoom · click a node for details</div>
@@ -146,9 +152,10 @@
         <span class="pill" id="detail-ns"></span>
         <span class="pill" id="detail-deg"></span>
       </div>
-      <h2>Imports (<span id="dep-count">0</span>)</h2>
+      <div id="detail-members" style="display:none"></div>
+      <h2><span id="dep-heading">Imports</span> (<span id="dep-count">0</span>)</h2>
       <ul class="dep-list" id="dep-list"></ul>
-      <h2>Imported by (<span id="rdep-count">0</span>)</h2>
+      <h2><span id="rdep-heading">Imported by</span> (<span id="rdep-count">0</span>)</h2>
       <ul class="dep-list" id="rdep-list"></ul>
     </div>
   </aside>
@@ -170,34 +177,48 @@ const NS_COLOR = {
 };
 const COLOR = ns => NS_COLOR[ns] || "#cccccc";
 
-const state = { data: { modules: null, namespaces: null }, view: "modules",
+const state = { data: { modules: null, namespaces: null, terms: null }, view: "modules",
                 graph: null, sim: null, selected: null, hoverNs: null,
                 showLabels: true, showLeaves: true, frozen: false };
 
 async function load() {
-  const [m, n] = await Promise.all([
+  const [m, n, t] = await Promise.all([
     fetch("modules.json").then(r => r.json()),
     fetch("namespaces.json").then(r => r.json()),
+    fetch("terms.json").then(r => r.json()).catch(() => null),
   ]);
   state.data.modules = m;
   state.data.namespaces = n;
+  state.data.terms = t;
   document.getElementById("stats").textContent =
-    `${m.nodes.length} modules · ${m.links.length} edges · ${n.nodes.length} namespaces`;
+    `${m.nodes.length} modules · ${m.links.length} edges · ${n.nodes.length} namespaces`
+    + (t ? ` · ${t.nodes.length} types` : "");
   buildNsList();
   render();
 }
 
 function buildNsList() {
   const list = d3.select("#ns-list");
-  const by = d3.rollups(state.data.modules.nodes, v => v.length, d => d.namespace)
+  list.selectAll("*").remove();
+  const src = state.view === "terms" && state.data.terms
+    ? state.data.terms.nodes : state.data.modules.nodes;
+  const by = d3.rollups(src, v => v.length, d => d.namespace)
               .sort((a,b) => d3.descending(a[1], b[1]));
   list.selectAll("div.row").data(by).enter().append("div")
     .attr("class", "row")
     .on("mouseover", (e, [ns]) => { state.hoverNs = ns; refreshHighlight(); })
     .on("mouseout", () => { state.hoverNs = null; refreshHighlight(); })
     .on("click", (e, [ns]) => {
-      document.getElementById("search").value = ns + ".";
-      onSearch();
+      // In modules/namespaces views, prefix-search by namespace name. In
+      // terms view, term names don't carry the namespace, so we instead
+      // pin the namespace as a persistent dim filter.
+      if (state.view === "terms") {
+        state.pinnedNs = state.pinnedNs === ns ? null : ns;
+        refreshHighlight();
+      } else {
+        document.getElementById("search").value = ns + ".";
+        onSearch();
+      }
       if (matchMedia("(max-width: 900px)").matches) closeDrawers();
     })
     .call(div => {
@@ -233,15 +254,17 @@ function render() {
     weight: l.weight || 1,
   })).filter(l => l.source && l.target);
 
-  const isModuleView = state.view === "modules";
-  const radius = d => isModuleView
-    ? 4 + Math.sqrt((d.deps || 0) + (d.rdeps || 0)) * 1.6
-    : 8 + Math.sqrt(d.modules || 1) * 3;
+  const view = state.view;
+  const isNs = view === "namespaces";
+  const radius = d => isNs
+    ? 8 + Math.sqrt(d.modules || 1) * 3
+    : 4 + Math.sqrt((d.deps || 0) + (d.rdeps || 0)) * 1.6;
 
+  const linkDist = isNs ? 130 : (view === "terms" ? 50 : 55);
+  const charge = isNs ? -600 : (view === "terms" ? -120 : -90);
   const sim = d3.forceSimulation(nodes)
-    .force("link", d3.forceLink(links).id(d => d.id)
-      .distance(isModuleView ? 55 : 130).strength(0.6))
-    .force("charge", d3.forceManyBody().strength(isModuleView ? -90 : -600))
+    .force("link", d3.forceLink(links).id(d => d.id).distance(linkDist).strength(0.6))
+    .force("charge", d3.forceManyBody().strength(charge))
     .force("center", d3.forceCenter(w/2, h/2))
     .force("collide", d3.forceCollide().radius(d => radius(d) + 4))
     .alpha(1).alphaDecay(0.03);
@@ -266,14 +289,42 @@ function render() {
         .on("start", (e, d) => { if (!e.active) sim.alphaTarget(0.3).restart(); d.fx = d.x; d.fy = d.y; })
         .on("drag",  (e, d) => { d.fx = e.x; d.fy = e.y; })
         .on("end",   (e, d) => { if (!e.active) sim.alphaTarget(0); if (!state.frozen) { d.fx = null; d.fy = null; } }));
-  node.append("circle")
-    .attr("r", radius).attr("fill", d => COLOR(d.namespace))
+  const nodeShape = view === "terms"
+    ? d => d.kind === "variant" ? "diamond" : (d.kind === "alias" ? "circle" : "square")
+    : () => "circle";
+  node.each(function(d) {
+    const sel = d3.select(this);
+    const r = radius(d);
+    const shape = nodeShape(d);
+    if (shape === "diamond") {
+      sel.append("polygon")
+        .attr("points", `0,${-r} ${r},0 0,${r} ${-r},0`)
+        .attr("fill", COLOR(d.namespace))
+        .attr("stroke", "#0c0e13").attr("stroke-width", 1.5).attr("class", "shape");
+    } else if (shape === "square") {
+      const s = r * 1.5;
+      sel.append("rect")
+        .attr("x", -s/2).attr("y", -s/2).attr("width", s).attr("height", s)
+        .attr("rx", 2)
+        .attr("fill", COLOR(d.namespace))
+        .attr("stroke", "#0c0e13").attr("stroke-width", 1.5).attr("class", "shape");
+    } else {
+      sel.append("circle")
+        .attr("r", r).attr("fill", COLOR(d.namespace))
+        .attr("stroke", "#0c0e13").attr("stroke-width", 1.5).attr("class", "shape");
+    }
+  });
+  node.select(".shape")
+    .style("cursor", "pointer")
     .on("click", (e, d) => { e.stopPropagation(); selectNode(d); })
     .on("mouseover", (e, d) => { state.hover = d; refreshHighlight(); })
     .on("mouseout",  ()      => { state.hover = null; refreshHighlight(); });
-  node.append("title").text(d => `${d.id}\nimports ${d.deps || 0}\nimported by ${d.rdeps || 0}`);
+  node.append("title").text(d =>
+    view === "terms"
+      ? `${d.id}  (${d.kind})\nin ${d.module}\nuses ${d.deps || 0}\nused by ${d.rdeps || 0}`
+      : `${d.id}\nimports ${d.deps || 0}\nimported by ${d.rdeps || 0}`);
   node.append("text").attr("x", d => radius(d) + 4).attr("y", 3)
-      .text(d => isModuleView ? d.id.split(".").slice(-1)[0] : d.id);
+      .text(d => view === "modules" ? d.id.split(".").slice(-1)[0] : d.id);
 
   state.graph = { nodes, links, link, node };
   toggleLabels(state.showLabels);
@@ -300,10 +351,27 @@ function updateDetails() {
   if (!state.selected) { empty.style.display = "block"; panel.style.display = "none"; return; }
   empty.style.display = "none"; panel.style.display = "block";
   const d = state.selected;
+  const isTerm = state.view === "terms";
   document.getElementById("detail-name").textContent = d.id;
-  document.getElementById("detail-ns").textContent = d.namespace;
-  document.getElementById("detail-deg").textContent =
-    `${d.deps || 0} imports · ${d.rdeps || 0} importers`;
+  document.getElementById("detail-ns").textContent =
+    isTerm ? `${d.kind} in ${d.module}` : d.namespace;
+  document.getElementById("detail-deg").textContent = isTerm
+    ? `uses ${d.deps || 0} · used by ${d.rdeps || 0}`
+    : `${d.deps || 0} imports · ${d.rdeps || 0} importers`;
+  document.getElementById("dep-heading").textContent = isTerm ? "Uses" : "Imports";
+  document.getElementById("rdep-heading").textContent = isTerm ? "Used by" : "Imported by";
+
+  const memBlock = document.getElementById("detail-members");
+  if (isTerm && d.members && d.members.length) {
+    const label = d.kind === "variant" ? "Constructors" : "Fields";
+    memBlock.innerHTML = `<h2>${label} (${d.members.length})</h2>`
+      + `<div class="members">` + d.members.map(m =>
+        `<span class="pill">${m}</span>`).join(" ") + `</div>`;
+    memBlock.style.display = "block";
+  } else {
+    memBlock.style.display = "none";
+  }
+
   const data = currentData();
   const incoming = data.links.filter(l => (l.target.id || l.target) === d.id).map(l => l.source.id || l.source);
   const outgoing = data.links.filter(l => (l.source.id || l.source) === d.id).map(l => l.target.id || l.target);
@@ -330,9 +398,9 @@ function fillList(id, ids) {
 
 function refreshHighlight() {
   if (!state.graph) return;
-  const sel = state.selected, hover = state.hover, hoverNs = state.hoverNs;
+  const sel = state.selected, hover = state.hover;
   const focus = hover || sel;
-  const focusNs = hoverNs;
+  const focusNs = state.hoverNs || state.pinnedNs;
   const focusId = focus ? focus.id : null;
   const neighbours = new Set();
   if (focusId) {
@@ -405,7 +473,10 @@ function freeze() {
 document.getElementById("search").addEventListener("input", onSearch);
 document.getElementById("view").addEventListener("change", e => {
   state.view = e.target.value;
-  state.selected = null; updateDetails(); render();
+  state.selected = null;
+  updateDetails();
+  buildNsList();
+  render();
 });
 document.getElementById("btn-fit").addEventListener("click", fit);
 document.getElementById("btn-freeze").addEventListener("click", freeze);
@@ -413,6 +484,34 @@ document.getElementById("btn-labels").addEventListener("click",
   () => toggleLabels(!state.showLabels));
 document.getElementById("btn-leaves").addEventListener("click",
   () => toggleLeaves(!state.showLeaves));
+document.getElementById("btn-fullscreen").addEventListener("click", toggleFullscreen);
+
+function toggleFullscreen() {
+  const el = document.getElementById("graph");
+  const fs = document.fullscreenElement || document.webkitFullscreenElement;
+  if (fs) {
+    (document.exitFullscreen || document.webkitExitFullscreen).call(document);
+  } else {
+    (el.requestFullscreen || el.webkitRequestFullscreen).call(el);
+  }
+}
+function onFsChange() {
+  const fs = document.fullscreenElement || document.webkitFullscreenElement;
+  document.getElementById("btn-fullscreen").classList.toggle("on", !!fs);
+  if (state.sim) {
+    state.sim.alpha(0.3).restart();
+    state.sim.force("center", d3.forceCenter(
+      d3.select("svg").node().clientWidth / 2,
+      d3.select("svg").node().clientHeight / 2));
+  }
+}
+document.addEventListener("fullscreenchange", onFsChange);
+document.addEventListener("webkitfullscreenchange", onFsChange);
+addEventListener("keydown", e => {
+  if (e.key === "f" && !["INPUT","TEXTAREA","SELECT"].includes(document.activeElement.tagName)) {
+    toggleFullscreen();
+  }
+});
 
 const isMobile = () => matchMedia("(max-width: 900px)").matches;
 const sidebarEl = document.getElementById("sidebar");

--- a/docs/web/demos/dep-graph/index.html
+++ b/docs/web/demos/dep-graph/index.html
@@ -17,10 +17,11 @@
   }
   html, body { margin: 0; padding: 0; height: 100%; background: var(--bg); color: var(--fg);
                font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
-               font-size: 13px; }
-  #app { display: grid; grid-template-columns: 280px 1fr 320px; height: 100vh; }
+               font-size: 13px; -webkit-text-size-adjust: 100%; }
+  #app { display: grid; grid-template-columns: 280px 1fr 320px; height: 100vh; height: 100dvh; }
   #sidebar, #details { background: var(--panel); border-right: 1px solid var(--border);
-                       padding: 12px 14px; overflow-y: auto; }
+                       padding: 12px 14px; overflow-y: auto;
+                       -webkit-overflow-scrolling: touch; }
   #details { border-right: none; border-left: 1px solid var(--border); }
   h1 { font-size: 14px; margin: 0 0 8px; font-weight: 600; }
   h2 { font-size: 12px; margin: 18px 0 6px; color: var(--muted); text-transform: uppercase;
@@ -37,8 +38,8 @@
   input[type=text]::placeholder { color: var(--muted); }
   label { display: block; margin: 8px 0 4px; color: var(--muted); font-size: 11px;
           text-transform: uppercase; letter-spacing: 0.06em; }
-  #graph { position: relative; overflow: hidden; }
-  svg { width: 100%; height: 100%; display: block; cursor: grab; }
+  #graph { position: relative; overflow: hidden; touch-action: none; }
+  svg { width: 100%; height: 100%; display: block; cursor: grab; touch-action: none; }
   svg:active { cursor: grabbing; }
   .node circle { stroke: #0c0e13; stroke-width: 1.5px; cursor: pointer; }
   .node text { font-size: 10px; fill: var(--fg); pointer-events: none;
@@ -50,7 +51,7 @@
   line.link.hi { stroke: var(--link-hi); stroke-opacity: 0.95; stroke-width: 1.6px; }
   #toolbar { position: absolute; top: 10px; left: 10px; display: flex; gap: 6px; flex-wrap: wrap;
              background: rgba(15,17,21,0.85); padding: 6px 8px; border-radius: 6px;
-             border: 1px solid var(--border); }
+             border: 1px solid var(--border); z-index: 4; }
   #toolbar button { background: #1c222d; color: var(--fg); border: 1px solid var(--border);
                     padding: 4px 10px; border-radius: 4px; cursor: pointer; font-size: 12px; }
   #toolbar button.on { background: var(--accent); color: #0c0e13; border-color: var(--accent); }
@@ -60,13 +61,48 @@
   .pill { display: inline-block; padding: 1px 6px; border-radius: 8px; background: #1f2530;
           color: var(--muted); font-size: 11px; font-variant-numeric: tabular-nums; }
   .dep-list { margin: 4px 0 0; padding: 0; list-style: none; }
-  .dep-list li { padding: 2px 0; border-bottom: 1px dashed var(--border); cursor: pointer;
+  .dep-list li { padding: 6px 0; border-bottom: 1px dashed var(--border); cursor: pointer;
                  display: flex; align-items: center; gap: 6px; }
   .dep-list li:hover { color: var(--accent); }
   #empty { color: var(--muted); margin-top: 30vh; text-align: center; }
   #stats { font-variant-numeric: tabular-nums; margin-top: 4px; color: var(--muted); }
-  #footer { position: absolute; bottom: 8px; right: 12px; color: var(--muted); font-size: 11px; }
+  #footer { position: absolute; bottom: 8px; right: 12px; color: var(--muted); font-size: 11px;
+            pointer-events: none; }
   #footer code { background: #1c222d; padding: 1px 5px; border-radius: 3px; }
+
+  /* Mobile drawer toggles — hidden on wide screens */
+  .drawer-toggle { display: none; position: absolute; top: 10px; z-index: 6;
+                   width: 38px; height: 38px; border-radius: 8px;
+                   background: rgba(15,17,21,0.9); color: var(--fg);
+                   border: 1px solid var(--border); font-size: 18px; line-height: 1;
+                   cursor: pointer; padding: 0; align-items: center; justify-content: center; }
+  .drawer-toggle:active { background: #252c39; }
+  #toggle-left  { right: 58px; }
+  #toggle-right { right: 10px; }
+  #scrim { display: none; position: fixed; inset: 0; background: rgba(0,0,0,0.55);
+           z-index: 5; }
+
+  @media (max-width: 900px) {
+    #app { grid-template-columns: 1fr; grid-template-rows: 1fr; }
+    #sidebar, #details {
+      position: fixed; top: 0; bottom: 0; width: min(82vw, 340px); z-index: 10;
+      transition: transform 0.22s ease;
+      box-shadow: 0 0 30px rgba(0,0,0,0.6);
+      padding: 14px 16px 24px;
+    }
+    #sidebar { left: 0; transform: translateX(-100%); border-right: 1px solid var(--border); }
+    #details { right: 0; transform: translateX(100%); border-left: 1px solid var(--border); }
+    #sidebar.open, #details.open { transform: translateX(0); }
+    .drawer-toggle { display: flex; }
+    #scrim.show { display: block; }
+    #toolbar { top: 56px; left: 8px; padding: 4px 6px; gap: 4px; max-width: calc(100vw - 16px); }
+    #toolbar button { padding: 4px 8px; font-size: 11px; }
+    #footer { display: none; }
+    /* Slightly tighter dep list, larger tap targets */
+    .dep-list li { padding: 8px 0; }
+    h1 { font-size: 15px; }
+    #empty { margin-top: 20vh; padding: 0 14px; }
+  }
 </style>
 </head>
 <body>
@@ -89,6 +125,8 @@
   </aside>
 
   <main id="graph">
+    <button class="drawer-toggle" id="toggle-left"  aria-label="Open sidebar">☰</button>
+    <button class="drawer-toggle" id="toggle-right" aria-label="Open details">ⓘ</button>
     <div id="toolbar">
       <button id="btn-fit">Fit</button>
       <button id="btn-freeze">Freeze</button>
@@ -96,8 +134,9 @@
       <button id="btn-leaves" class="on">Leaves</button>
     </div>
     <svg></svg>
-    <div id="footer">drag to pan · wheel to zoom · click a node for details</div>
+    <div id="footer">drag to pan · wheel/pinch to zoom · click a node for details</div>
   </main>
+  <div id="scrim"></div>
 
   <aside id="details">
     <div id="empty">Click a node to inspect its dependencies and reverse-dependencies.</div>
@@ -159,6 +198,7 @@ function buildNsList() {
     .on("click", (e, [ns]) => {
       document.getElementById("search").value = ns + ".";
       onSearch();
+      if (matchMedia("(max-width: 900px)").matches) closeDrawers();
     })
     .call(div => {
       div.append("span").attr("class", "swatch")
@@ -373,6 +413,32 @@ document.getElementById("btn-labels").addEventListener("click",
   () => toggleLabels(!state.showLabels));
 document.getElementById("btn-leaves").addEventListener("click",
   () => toggleLeaves(!state.showLeaves));
+
+const isMobile = () => matchMedia("(max-width: 900px)").matches;
+const sidebarEl = document.getElementById("sidebar");
+const detailsEl = document.getElementById("details");
+const scrimEl   = document.getElementById("scrim");
+function openDrawer(side) {
+  closeDrawers();
+  (side === "left" ? sidebarEl : detailsEl).classList.add("open");
+  scrimEl.classList.add("show");
+}
+function closeDrawers() {
+  sidebarEl.classList.remove("open");
+  detailsEl.classList.remove("open");
+  scrimEl.classList.remove("show");
+}
+document.getElementById("toggle-left").addEventListener("click",
+  () => sidebarEl.classList.contains("open") ? closeDrawers() : openDrawer("left"));
+document.getElementById("toggle-right").addEventListener("click",
+  () => detailsEl.classList.contains("open") ? closeDrawers() : openDrawer("right"));
+scrimEl.addEventListener("click", closeDrawers);
+
+const _origSelectNode = selectNode;
+selectNode = function(d) {
+  _origSelectNode(d);
+  if (isMobile() && d) openDrawer("right");
+};
 
 load().catch(err => {
   document.getElementById("stats").textContent = "Load failed: " + err.message;

--- a/docs/web/demos/dep-graph/terms.json
+++ b/docs/web/demos/dep-graph/terms.json
@@ -1,0 +1,4091 @@
+{
+  "nodes": [
+    {
+      "id": "accept_entry",
+      "namespace": "SPARQL",
+      "module": "SPARQL.Protocol",
+      "kind": "alias",
+      "members": [],
+      "deps": 2,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "access_path",
+      "namespace": "SPARQL",
+      "module": "SPARQL.Plan.AccessPath",
+      "kind": "variant",
+      "members": [
+        "AP_Skip",
+        "AP_OffsetJump",
+        "AP_FullScan"
+      ],
+      "deps": 1,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "aggregate_fn",
+      "namespace": "SPARQL11",
+      "module": "SPARQL11.Algebra",
+      "kind": "variant",
+      "members": [
+        "Agg_Count",
+        "Agg_Sum",
+        "Agg_Min",
+        "Agg_Max",
+        "Agg_Avg",
+        "Agg_GroupConcat",
+        "Agg_Sample"
+      ],
+      "deps": 0,
+      "rdeps": 1,
+      "inProject": true
+    },
+    {
+      "id": "algebra_op",
+      "namespace": "RDF",
+      "module": "RDF.Graph.Executable",
+      "kind": "variant",
+      "members": [
+        "BGP_Op",
+        "Filter_Op",
+        "Optional_Op",
+        "Union_Op"
+      ],
+      "deps": 1,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "arith_op",
+      "namespace": "SPARQL11",
+      "module": "SPARQL11.Algebra",
+      "kind": "alias",
+      "members": [],
+      "deps": 0,
+      "rdeps": 1,
+      "inProject": true
+    },
+    {
+      "id": "backend_info",
+      "namespace": "SPARQL",
+      "module": "SPARQL.HTTP.BackendInfo",
+      "kind": "record",
+      "members": [
+        "bi_kind",
+        "bi_source",
+        "bi_in_memory_triples",
+        "bi_in_memory_default_graph_triples",
+        "bi_in_memory_named_graphs",
+        "bi_in_memory_named_graph_triples",
+        "bi_cottas"
+      ],
+      "deps": 2,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "backend_kind",
+      "namespace": "SPARQL",
+      "module": "SPARQL.HTTP.BackendInfo",
+      "kind": "variant",
+      "members": [
+        "BK_InMem",
+        "BK_CottasOnDisk",
+        "BK_Hybrid",
+        "BK_Empty"
+      ],
+      "deps": 0,
+      "rdeps": 1,
+      "inProject": true
+    },
+    {
+      "id": "ballyhoo_error",
+      "namespace": "Parser",
+      "module": "Parser.Ballyhoo",
+      "kind": "record",
+      "members": [
+        "be_line",
+        "be_message"
+      ],
+      "deps": 0,
+      "rdeps": 1,
+      "inProject": true
+    },
+    {
+      "id": "ballyhoo_event",
+      "namespace": "Parser",
+      "module": "Parser.Ballyhoo",
+      "kind": "variant",
+      "members": [
+        "BE_DefaultTriple",
+        "BE_NamedTriple"
+      ],
+      "deps": 2,
+      "rdeps": 1,
+      "inProject": true
+    },
+    {
+      "id": "ballyhoo_mode",
+      "namespace": "Parser",
+      "module": "Parser.Ballyhoo",
+      "kind": "variant",
+      "members": [
+        "BM_NQuads"
+      ],
+      "deps": 0,
+      "rdeps": 1,
+      "inProject": true
+    },
+    {
+      "id": "ballyhoo_order",
+      "namespace": "Parser",
+      "module": "Parser.BallyhooHDT",
+      "kind": "variant",
+      "members": [
+        "BO_SPO",
+        "BO_SOP",
+        "BO_PSO",
+        "BO_POS",
+        "BO_OSP",
+        "BO_OPS"
+      ],
+      "deps": 0,
+      "rdeps": 1,
+      "inProject": true
+    },
+    {
+      "id": "ballyhoo_state",
+      "namespace": "Parser",
+      "module": "Parser.Ballyhoo",
+      "kind": "record",
+      "members": [
+        "bs_mode",
+        "bs_carry",
+        "bs_line_no",
+        "bs_events_rev",
+        "bs_errors_rev",
+        "bs_lines_ok",
+        "bs_lines_failed"
+      ],
+      "deps": 3,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "bgp",
+      "namespace": "RDF",
+      "module": "RDF.Graph.Executable",
+      "kind": "alias",
+      "members": [],
+      "deps": 1,
+      "rdeps": 2,
+      "inProject": true
+    },
+    {
+      "id": "binding_row",
+      "namespace": "SPARQL",
+      "module": "SPARQL.Protocol",
+      "kind": "alias",
+      "members": [],
+      "deps": 1,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "bitmap_handle",
+      "namespace": "RDF",
+      "module": "RDF.CottasStore.PresenceBitmap",
+      "kind": "record",
+      "members": [
+        "bh_path",
+        "bh_header"
+      ],
+      "deps": 1,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "bloom_bits",
+      "namespace": "Parser",
+      "module": "Parser.BallyhooBloom",
+      "kind": "alias",
+      "members": [],
+      "deps": 0,
+      "rdeps": 1,
+      "inProject": true
+    },
+    {
+      "id": "bn_full_key",
+      "namespace": "RDF",
+      "module": "RDF.Canonical",
+      "kind": "record",
+      "members": [
+        "bk_orig",
+        "bk_hfdq",
+        "bk_nbr1",
+        "bk_nbr2",
+        "bk_nbr3"
+      ],
+      "deps": 1,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "bn_hfdq_pair",
+      "namespace": "RDF",
+      "module": "RDF.Canonical",
+      "kind": "alias",
+      "members": [],
+      "deps": 1,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "bnode_id",
+      "namespace": "RDF",
+      "module": "RDF.Graph.Executable",
+      "kind": "alias",
+      "members": [],
+      "deps": 0,
+      "rdeps": 8,
+      "inProject": true
+    },
+    {
+      "id": "bound_status",
+      "namespace": "SPARQL",
+      "module": "SPARQL.Explain",
+      "kind": "variant",
+      "members": [
+        "BS_Var",
+        "BS_Hit",
+        "BS_Miss",
+        "BS_Other"
+      ],
+      "deps": 0,
+      "rdeps": 1,
+      "inProject": true
+    },
+    {
+      "id": "bucket",
+      "namespace": "RDF",
+      "module": "RDF.Canonical",
+      "kind": "alias",
+      "members": [],
+      "deps": 1,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "bucket_map",
+      "namespace": "RDF",
+      "module": "RDF.Graph.Executable",
+      "kind": "alias",
+      "members": [],
+      "deps": 1,
+      "rdeps": 1,
+      "inProject": true
+    },
+    {
+      "id": "budget",
+      "namespace": "SPARQL",
+      "module": "SPARQL.Eval.TimeBudget",
+      "kind": "record",
+      "members": [],
+      "deps": 0,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "budgeted",
+      "namespace": "SPARQL",
+      "module": "SPARQL.Eval.TimeBudget",
+      "kind": "variant",
+      "members": [
+        "BudgetedOk",
+        "BudgetedExpired"
+      ],
+      "deps": 0,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "cast_target",
+      "namespace": "SPARQL11",
+      "module": "SPARQL11.Algebra",
+      "kind": "variant",
+      "members": [
+        "Cast_Integer",
+        "Cast_Decimal",
+        "Cast_Float",
+        "Cast_Double",
+        "Cast_String",
+        "Cast_Boolean",
+        "Cast_DateTime"
+      ],
+      "deps": 0,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "ce_combinator",
+      "namespace": "OWL",
+      "module": "OWL.QueryRewrite",
+      "kind": "variant",
+      "members": [
+        "CE_Intersect",
+        "CE_MinCardinality",
+        "CE_ComplementOf"
+      ],
+      "deps": 0,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "cell_decision",
+      "namespace": "RDF",
+      "module": "RDF.Store.Columnar.OffsetIndex",
+      "kind": "variant",
+      "members": [
+        "CD_NoInfo",
+        "CD_Empty",
+        "CD_Use"
+      ],
+      "deps": 1,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "cell_view",
+      "namespace": "RDF",
+      "module": "RDF.Store.Columnar.OffsetIndex",
+      "kind": "record",
+      "members": [
+        "cv_start",
+        "cv_count"
+      ],
+      "deps": 0,
+      "rdeps": 2,
+      "inProject": true
+    },
+    {
+      "id": "class_expr",
+      "namespace": "Tableau",
+      "module": "Tableau",
+      "kind": "variant",
+      "members": [
+        "CE_Named",
+        "CE_SomeValuesFrom",
+        "CE_AllValuesFrom",
+        "CE_HasValue",
+        "CE_IntersectionOf",
+        "CE_UnionOf",
+        "CE_ComplementOf",
+        "CE_MinCard",
+        "CE_MaxCard",
+        "CE_ExactCard",
+        "CE_MinQualCard",
+        "CE_MaxQualCard",
+        "CE_ExactQualCard",
+        "CE_Unknown"
+      ],
+      "deps": 2,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "comp_op",
+      "namespace": "RDF",
+      "module": "RDF.Graph.Executable",
+      "kind": "variant",
+      "members": [
+        "Eq",
+        "Ne",
+        "Lt",
+        "Gt",
+        "Le",
+        "Ge"
+      ],
+      "deps": 0,
+      "rdeps": 1,
+      "inProject": true
+    },
+    {
+      "id": "compact_field",
+      "namespace": "Parquet",
+      "module": "Parquet.Footer",
+      "kind": "record",
+      "members": [
+        "cf_id",
+        "cf_type",
+        "cf_value_start",
+        "cf_next"
+      ],
+      "deps": 0,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "compact_list_info",
+      "namespace": "Parquet",
+      "module": "Parquet.Footer",
+      "kind": "record",
+      "members": [
+        "cli_count",
+        "cli_etype",
+        "cli_payload_start"
+      ],
+      "deps": 0,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "companion_file_status",
+      "namespace": "SPARQL",
+      "module": "SPARQL.Plan.Loader",
+      "kind": "variant",
+      "members": [
+        "CFS_Present",
+        "CFS_Missing",
+        "CFS_Corrupt",
+        "CFS_StaleSchema"
+      ],
+      "deps": 0,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "companion_status",
+      "namespace": "RDF",
+      "module": "RDF.CottasStore.OnDiskIndex",
+      "kind": "record",
+      "members": [
+        "cs_dict_path",
+        "cs_presence_path",
+        "cs_dict_header",
+        "cs_presence_header"
+      ],
+      "deps": 2,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "compound_handle",
+      "namespace": "RDF",
+      "module": "RDF.CottasStore.CompoundPresenceBitmap",
+      "kind": "record",
+      "members": [
+        "ph_path",
+        "ph_header"
+      ],
+      "deps": 1,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "compound_header",
+      "namespace": "RDF",
+      "module": "RDF.CottasStore.CompoundPresenceBitmap",
+      "kind": "record",
+      "members": [
+        "ch_magic",
+        "ch_version",
+        "ch_num_rgs",
+        "ch_pred_dict_size",
+        "ch_obj_dict_size"
+      ],
+      "deps": 0,
+      "rdeps": 1,
+      "inProject": true
+    },
+    {
+      "id": "constraint_component",
+      "namespace": "SHACL",
+      "module": "SHACL.Validation",
+      "kind": "variant",
+      "members": [
+        "CC_MinCount",
+        "CC_MaxCount",
+        "CC_Datatype",
+        "CC_NodeKind",
+        "CC_Class",
+        "CC_In",
+        "CC_HasValue",
+        "CC_Pattern",
+        "CC_MinLength",
+        "CC_MaxLength",
+        "CC_LanguageIn",
+        "CC_UniqueLang",
+        "CC_MinInclusive",
+        "CC_MaxInclusive",
+        "CC_MinExclusive",
+        "CC_MaxExclusive",
+        "CC_Not",
+        "CC_And",
+        "CC_Or",
+        "CC_Xone",
+        "CC_Equals",
+        "CC_Disjoint",
+        "CC_LessThan",
+        "CC_LessThanOrEq",
+        "CC_Closed",
+        "CC_Sparql"
+      ],
+      "deps": 4,
+      "rdeps": 2,
+      "inProject": true
+    },
+    {
+      "id": "corpus_graph_binding",
+      "namespace": "Parser",
+      "module": "Parser.BallyhooHDT",
+      "kind": "record",
+      "members": [
+        "cgb_graph_name",
+        "cgb_artifact_path",
+        "cgb_summary"
+      ],
+      "deps": 2,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "cors_policy",
+      "namespace": "SPARQL",
+      "module": "SPARQL.HTTP.Response",
+      "kind": "variant",
+      "members": [
+        "CORS_Off",
+        "CORS_Any",
+        "CORS_List"
+      ],
+      "deps": 0,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "cottas_artifact_summary",
+      "namespace": "Parser",
+      "module": "Parser.BallyhooCOTTAS",
+      "kind": "record",
+      "members": [
+        "cas_path",
+        "cas_num_quads",
+        "cas_num_row_groups",
+        "cas_dictionary",
+        "cas_row_groups"
+      ],
+      "deps": 2,
+      "rdeps": 3,
+      "inProject": true
+    },
+    {
+      "id": "cottas_bound_qp",
+      "namespace": "Parser",
+      "module": "Parser.BallyhooCOTTAS",
+      "kind": "record",
+      "members": [
+        "cbqp_s",
+        "cbqp_p",
+        "cbqp_o",
+        "cbqp_g"
+      ],
+      "deps": 2,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "cottas_column_kind",
+      "namespace": "Parser",
+      "module": "Parser.BallyhooCOTTAS",
+      "kind": "variant",
+      "members": [
+        "CC_Subject",
+        "CC_Predicate",
+        "CC_Object",
+        "CC_Graph"
+      ],
+      "deps": 0,
+      "rdeps": 1,
+      "inProject": true
+    },
+    {
+      "id": "cottas_column_summary",
+      "namespace": "Parser",
+      "module": "Parser.BallyhooCOTTAS",
+      "kind": "record",
+      "members": [
+        "ccs_kind",
+        "ccs_num_values",
+        "ccs_null_count",
+        "ccs_encoding"
+      ],
+      "deps": 2,
+      "rdeps": 1,
+      "inProject": true
+    },
+    {
+      "id": "cottas_dataset_store",
+      "namespace": "Parser",
+      "module": "Parser.BallyhooCOTTAS",
+      "kind": "record",
+      "members": [
+        "cds_artifact_path",
+        "cds_summary",
+        "cds_handle"
+      ],
+      "deps": 1,
+      "rdeps": 2,
+      "inProject": true
+    },
+    {
+      "id": "cottas_dictionary_summary",
+      "namespace": "Parser",
+      "module": "Parser.BallyhooCOTTAS",
+      "kind": "record",
+      "members": [
+        "cds_num_terms",
+        "cds_num_graphs",
+        "cds_bytes_strings"
+      ],
+      "deps": 0,
+      "rdeps": 1,
+      "inProject": true
+    },
+    {
+      "id": "cottas_encoding",
+      "namespace": "Parser",
+      "module": "Parser.BallyhooCOTTAS",
+      "kind": "variant",
+      "members": [
+        "CE_Plain",
+        "CE_Dictionary",
+        "CE_RLE",
+        "CE_Delta"
+      ],
+      "deps": 0,
+      "rdeps": 1,
+      "inProject": true
+    },
+    {
+      "id": "cottas_graph_ref",
+      "namespace": "Parser",
+      "module": "Parser.BallyhooCOTTAS",
+      "kind": "alias",
+      "members": [],
+      "deps": 0,
+      "rdeps": 3,
+      "inProject": true
+    },
+    {
+      "id": "cottas_named_graph_store",
+      "namespace": "Parser",
+      "module": "Parser.BallyhooCOTTAS",
+      "kind": "record",
+      "members": [
+        "cngs_name",
+        "cngs_ref",
+        "cngs_dataset"
+      ],
+      "deps": 3,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "cottas_ondisk_handle",
+      "namespace": "RDF",
+      "module": "RDF.CottasStore",
+      "kind": "record",
+      "members": [
+        "coh_path",
+        "coh_summary",
+        "coh_subjects",
+        "coh_predicates",
+        "coh_objects",
+        "coh_graphs",
+        "coh_subj_revmap",
+        "coh_pred_revmap",
+        "coh_obj_revmap",
+        "coh_graph_revmap",
+        "coh_subjects_raw",
+        "coh_predicates_raw",
+        "coh_objects_raw",
+        "coh_graphs_raw",
+        "coh_subj_raw_revmap",
+        "coh_pred_raw_revmap",
+        "coh_obj_raw_revmap",
+        "coh_graph_raw_revmap"
+      ],
+      "deps": 5,
+      "rdeps": 1,
+      "inProject": true
+    },
+    {
+      "id": "cottas_ondisk_store",
+      "namespace": "RDF",
+      "module": "RDF.CottasStore",
+      "kind": "record",
+      "members": [
+        "cods_artifact_path",
+        "cods_summary",
+        "cods_handle"
+      ],
+      "deps": 2,
+      "rdeps": 1,
+      "inProject": true
+    },
+    {
+      "id": "cottas_qp_row",
+      "namespace": "Parser",
+      "module": "Parser.BallyhooCOTTAS",
+      "kind": "record",
+      "members": [
+        "cqpr_s",
+        "cqpr_p",
+        "cqpr_o",
+        "cqpr_g"
+      ],
+      "deps": 2,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "cottas_row_group_summary",
+      "namespace": "Parser",
+      "module": "Parser.BallyhooCOTTAS",
+      "kind": "record",
+      "members": [
+        "crgs_index",
+        "crgs_num_rows",
+        "crgs_columns"
+      ],
+      "deps": 1,
+      "rdeps": 1,
+      "inProject": true
+    },
+    {
+      "id": "cottas_summary",
+      "namespace": "SPARQL",
+      "module": "SPARQL.HTTP.BackendInfo",
+      "kind": "record",
+      "members": [
+        "cs_path",
+        "cs_quads",
+        "cs_row_groups"
+      ],
+      "deps": 0,
+      "rdeps": 1,
+      "inProject": true
+    },
+    {
+      "id": "cottas_term_ref",
+      "namespace": "Parser",
+      "module": "Parser.BallyhooCOTTAS",
+      "kind": "alias",
+      "members": [],
+      "deps": 0,
+      "rdeps": 2,
+      "inProject": true
+    },
+    {
+      "id": "dataset_backend",
+      "namespace": "SPARQL11",
+      "module": "SPARQL11.Store",
+      "kind": "record",
+      "members": [
+        "dsb_default",
+        "dsb_named"
+      ],
+      "deps": 2,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "dict_cache",
+      "namespace": "RDF",
+      "module": "RDF.CottasStore",
+      "kind": "alias",
+      "members": [],
+      "deps": 0,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "dict_header",
+      "namespace": "RDF",
+      "module": "RDF.CottasStore.OnDiskIndex",
+      "kind": "record",
+      "members": [
+        "dh_magic",
+        "dh_version",
+        "dh_num_tokens",
+        "dh_ids_offset",
+        "dh_tokens_offset"
+      ],
+      "deps": 0,
+      "rdeps": 1,
+      "inProject": true
+    },
+    {
+      "id": "dlba_page_cache",
+      "namespace": "Parquet",
+      "module": "Parquet.Footer",
+      "kind": "record",
+      "members": [
+        "dpc_payload_hex",
+        "dpc_values_offset",
+        "dpc_value_count",
+        "dpc_first_length",
+        "dpc_min_delta",
+        "dpc_bit_width",
+        "dpc_packed_start",
+        "dpc_value_data_offset",
+        "dpc_lengths",
+        "dpc_value_starts"
+      ],
+      "deps": 0,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "estimate_count",
+      "namespace": "SPARQL",
+      "module": "SPARQL.Plan.Estimate",
+      "kind": "variant",
+      "members": [
+        "EC_Exact",
+        "EC_Approx",
+        "EC_Unknown"
+      ],
+      "deps": 0,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "eval_result",
+      "namespace": "SPARQL11",
+      "module": "SPARQL11.Algebra",
+      "kind": "variant",
+      "members": [
+        "ER_Term",
+        "ER_Bool",
+        "ER_Num",
+        "ER_Dec",
+        "ER_Dbl",
+        "ER_Error"
+      ],
+      "deps": 1,
+      "rdeps": 1,
+      "inProject": true
+    },
+    {
+      "id": "expr",
+      "namespace": "SPARQL11",
+      "module": "SPARQL11.Algebra",
+      "kind": "record",
+      "members": [
+        "sm_order_by",
+        "sm_distinct",
+        "sm_reduced",
+        "sm_offset",
+        "sm_limit",
+        "q_base",
+        "q_prefixes",
+        "q_form",
+        "q_dataset",
+        "q_pattern",
+        "q_group_by",
+        "q_having",
+        "q_modifier",
+        "q_values"
+      ],
+      "deps": 11,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "filter_expr_eval",
+      "namespace": "RDF",
+      "module": "RDF.Graph.Executable",
+      "kind": "alias",
+      "members": [],
+      "deps": 2,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "ggp_check_result",
+      "namespace": "SPARQL",
+      "module": "SPARQL.Update.Sandbox",
+      "kind": "variant",
+      "members": [
+        "GCR_Rewrite",
+        "GCR_Reject"
+      ],
+      "deps": 0,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "ggp_target_status",
+      "namespace": "SPARQL",
+      "module": "SPARQL.Update.Sandbox",
+      "kind": "variant",
+      "members": [
+        "GTS_Ok",
+        "GTS_Mismatch",
+        "GTS_NonIri"
+      ],
+      "deps": 1,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "graph_backend",
+      "namespace": "SPARQL11",
+      "module": "SPARQL11.Store",
+      "kind": "variant",
+      "members": [
+        "GB_List",
+        "GB_Indexed",
+        "GB_HDT",
+        "GB_COTTAS",
+        "GB_CottasOnDisk",
+        "GB_Union"
+      ],
+      "deps": 6,
+      "rdeps": 2,
+      "inProject": true
+    },
+    {
+      "id": "graph_key",
+      "namespace": "SPARQL",
+      "module": "SPARQL.GraphStore",
+      "kind": "alias",
+      "members": [],
+      "deps": 0,
+      "rdeps": 2,
+      "inProject": true
+    },
+    {
+      "id": "graph_ref",
+      "namespace": "SPARQL11",
+      "module": "SPARQL11.Algebra",
+      "kind": "variant",
+      "members": [
+        "GR_Default",
+        "GR_Named",
+        "GR_All",
+        "GR_Graph"
+      ],
+      "deps": 1,
+      "rdeps": 1,
+      "inProject": true
+    },
+    {
+      "id": "graph_store",
+      "namespace": "SPARQL",
+      "module": "SPARQL.GraphStore",
+      "kind": "record",
+      "members": [
+        "gs_default",
+        "gs_named"
+      ],
+      "deps": 2,
+      "rdeps": 2,
+      "inProject": true
+    },
+    {
+      "id": "gref_check_result",
+      "namespace": "SPARQL",
+      "module": "SPARQL.Update.Sandbox",
+      "kind": "variant",
+      "members": [
+        "GRCR_Ok",
+        "GRCR_Reject"
+      ],
+      "deps": 0,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "group",
+      "namespace": "SPARQL11",
+      "module": "SPARQL11.Algebra",
+      "kind": "record",
+      "members": [
+        "g_key",
+        "g_solutions"
+      ],
+      "deps": 1,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "gs_named",
+      "namespace": "SPARQL",
+      "module": "SPARQL.GraphStore",
+      "kind": "record",
+      "members": [
+        "gn_iri",
+        "gn_graph"
+      ],
+      "deps": 2,
+      "rdeps": 1,
+      "inProject": true
+    },
+    {
+      "id": "gs_target",
+      "namespace": "SPARQL",
+      "module": "SPARQL.GraphStore",
+      "kind": "variant",
+      "members": [
+        "GT_Default",
+        "GT_Named"
+      ],
+      "deps": 1,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "hdt_artifact_summary",
+      "namespace": "Parser",
+      "module": "Parser.BallyhooHDT",
+      "kind": "record",
+      "members": [
+        "has_source_iri",
+        "has_dictionary",
+        "has_triples",
+        "has_statistics"
+      ],
+      "deps": 4,
+      "rdeps": 3,
+      "inProject": true
+    },
+    {
+      "id": "hdt_bound_tp",
+      "namespace": "Parser",
+      "module": "Parser.BallyhooHDT",
+      "kind": "record",
+      "members": [
+        "hbt_s",
+        "hbt_p",
+        "hbt_o"
+      ],
+      "deps": 1,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "hdt_control_info",
+      "namespace": "Parser",
+      "module": "Parser.BallyhooHDT",
+      "kind": "record",
+      "members": [
+        "hci_format_iri",
+        "hci_length_hint"
+      ],
+      "deps": 0,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "hdt_dictionary_summary",
+      "namespace": "Parser",
+      "module": "Parser.BallyhooHDT",
+      "kind": "record",
+      "members": [
+        "hds_num_shared_subject_object",
+        "hds_num_subjects",
+        "hds_num_predicates",
+        "hds_num_objects",
+        "hds_size_strings"
+      ],
+      "deps": 0,
+      "rdeps": 1,
+      "inProject": true
+    },
+    {
+      "id": "hdt_graph_store",
+      "namespace": "Parser",
+      "module": "Parser.BallyhooHDT",
+      "kind": "record",
+      "members": [
+        "hgs_graph_name",
+        "hgs_artifact_path",
+        "hgs_summary",
+        "hgs_handle"
+      ],
+      "deps": 2,
+      "rdeps": 1,
+      "inProject": true
+    },
+    {
+      "id": "hdt_statistics",
+      "namespace": "Parser",
+      "module": "Parser.BallyhooHDT",
+      "kind": "record",
+      "members": [
+        "hs_hdt_size",
+        "hs_original_size"
+      ],
+      "deps": 0,
+      "rdeps": 1,
+      "inProject": true
+    },
+    {
+      "id": "hdt_term_ref",
+      "namespace": "Parser",
+      "module": "Parser.BallyhooHDT",
+      "kind": "alias",
+      "members": [],
+      "deps": 0,
+      "rdeps": 4,
+      "inProject": true
+    },
+    {
+      "id": "hdt_tp_row",
+      "namespace": "Parser",
+      "module": "Parser.BallyhooHDT",
+      "kind": "record",
+      "members": [
+        "hrow_s",
+        "hrow_p",
+        "hrow_o"
+      ],
+      "deps": 1,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "hdt_triples_summary",
+      "namespace": "Parser",
+      "module": "Parser.BallyhooHDT",
+      "kind": "record",
+      "members": [
+        "hts_num_triples",
+        "hts_order"
+      ],
+      "deps": 1,
+      "rdeps": 1,
+      "inProject": true
+    },
+    {
+      "id": "hdtq_annotation_mode",
+      "namespace": "Parser",
+      "module": "Parser.BallyhooHDTQ",
+      "kind": "variant",
+      "members": [
+        "HQ_AnnotatedGraphs",
+        "HQ_AnnotatedTriples"
+      ],
+      "deps": 0,
+      "rdeps": 1,
+      "inProject": true
+    },
+    {
+      "id": "hdtq_artifact_summary",
+      "namespace": "Parser",
+      "module": "Parser.BallyhooHDTQ",
+      "kind": "record",
+      "members": [
+        "hqas_hdt",
+        "hqas_graph_dictionary",
+        "hqas_quad_info"
+      ],
+      "deps": 3,
+      "rdeps": 1,
+      "inProject": true
+    },
+    {
+      "id": "hdtq_bound_qp",
+      "namespace": "Parser",
+      "module": "Parser.BallyhooHDTQ",
+      "kind": "record",
+      "members": [
+        "hqbp_s",
+        "hqbp_p",
+        "hqbp_o",
+        "hqbp_g"
+      ],
+      "deps": 2,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "hdtq_dataset_store",
+      "namespace": "Parser",
+      "module": "Parser.BallyhooHDTQ",
+      "kind": "record",
+      "members": [
+        "hqds_artifact_path",
+        "hqds_summary",
+        "hqds_handle"
+      ],
+      "deps": 1,
+      "rdeps": 1,
+      "inProject": true
+    },
+    {
+      "id": "hdtq_graph_dictionary_summary",
+      "namespace": "Parser",
+      "module": "Parser.BallyhooHDTQ",
+      "kind": "record",
+      "members": [
+        "hgds_num_graphs",
+        "hgds_size_strings"
+      ],
+      "deps": 0,
+      "rdeps": 1,
+      "inProject": true
+    },
+    {
+      "id": "hdtq_graph_ref",
+      "namespace": "Parser",
+      "module": "Parser.BallyhooHDTQ",
+      "kind": "alias",
+      "members": [],
+      "deps": 0,
+      "rdeps": 3,
+      "inProject": true
+    },
+    {
+      "id": "hdtq_named_graph_store",
+      "namespace": "Parser",
+      "module": "Parser.BallyhooHDTQ",
+      "kind": "record",
+      "members": [
+        "hqng_name",
+        "hqng_ref",
+        "hqng_dataset"
+      ],
+      "deps": 3,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "hdtq_qp_row",
+      "namespace": "Parser",
+      "module": "Parser.BallyhooHDTQ",
+      "kind": "record",
+      "members": [
+        "hqrow_s",
+        "hqrow_p",
+        "hqrow_o",
+        "hqrow_g"
+      ],
+      "deps": 2,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "hdtq_quad_info_summary",
+      "namespace": "Parser",
+      "module": "Parser.BallyhooHDTQ",
+      "kind": "record",
+      "members": [
+        "hqis_num_quads",
+        "hqis_annotation_mode"
+      ],
+      "deps": 1,
+      "rdeps": 1,
+      "inProject": true
+    },
+    {
+      "id": "http_client_error",
+      "namespace": "SPARQL",
+      "module": "SPARQL.HTTP.Client",
+      "kind": "variant",
+      "members": [
+        "HCE_MalformedStatusLine",
+        "HCE_MalformedHeader",
+        "HCE_BadStatusCode",
+        "HCE_HeadersTooLarge",
+        "HCE_BodyTooLarge",
+        "HCE_MissingCRLF",
+        "HCE_BadResponse"
+      ],
+      "deps": 0,
+      "rdeps": 1,
+      "inProject": true
+    },
+    {
+      "id": "http_client_result",
+      "namespace": "SPARQL",
+      "module": "SPARQL.HTTP.Client",
+      "kind": "alias",
+      "members": [],
+      "deps": 1,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "http_error",
+      "namespace": "SPARQL",
+      "module": "SPARQL.HTTP",
+      "kind": "variant",
+      "members": [
+        "HE_MalformedRequestLine",
+        "HE_MalformedHeader",
+        "HE_BadRequest",
+        "HE_BodyTooLarge",
+        "HE_HeadersTooLarge",
+        "HE_MissingCRLF"
+      ],
+      "deps": 0,
+      "rdeps": 1,
+      "inProject": true
+    },
+    {
+      "id": "http_request",
+      "namespace": "SPARQL",
+      "module": "SPARQL.HTTP",
+      "kind": "record",
+      "members": [
+        "hr_method",
+        "hr_path",
+        "hr_query_str",
+        "hr_version",
+        "hr_headers",
+        "hr_body"
+      ],
+      "deps": 0,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "http_request_msg",
+      "namespace": "SPARQL",
+      "module": "SPARQL.HTTP.Client",
+      "kind": "record",
+      "members": [
+        "rm_method",
+        "rm_path",
+        "rm_query_str",
+        "rm_version",
+        "rm_host",
+        "rm_headers",
+        "rm_body"
+      ],
+      "deps": 0,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "http_response",
+      "namespace": "SPARQL",
+      "module": "SPARQL.HTTP.Client",
+      "kind": "record",
+      "members": [
+        "rsp_version",
+        "rsp_status",
+        "rsp_reason",
+        "rsp_headers",
+        "rsp_body"
+      ],
+      "deps": 0,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "http_result",
+      "namespace": "SPARQL",
+      "module": "SPARQL.HTTP",
+      "kind": "alias",
+      "members": [],
+      "deps": 1,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "indexed_graph",
+      "namespace": "RDF",
+      "module": "RDF.Graph.Executable",
+      "kind": "record",
+      "members": [
+        "ig_triples",
+        "ig_pred",
+        "ig_subj",
+        "ig_obj",
+        "ig_sp",
+        "ig_po",
+        "ig_so"
+      ],
+      "deps": 2,
+      "rdeps": 1,
+      "inProject": true
+    },
+    {
+      "id": "iri",
+      "namespace": "RDF",
+      "module": "RDF.Graph.Executable",
+      "kind": "alias",
+      "members": [],
+      "deps": 0,
+      "rdeps": 15,
+      "inProject": true
+    },
+    {
+      "id": "iri_parts",
+      "namespace": "Parser",
+      "module": "Parser.IRI",
+      "kind": "record",
+      "members": [
+        "ip_scheme",
+        "ip_authority",
+        "ip_path",
+        "ip_query",
+        "ip_fragment"
+      ],
+      "deps": 0,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "iri_ref_span",
+      "namespace": "Parser",
+      "module": "Parser.TurtleScanner",
+      "kind": "record",
+      "members": [
+        "irs_span",
+        "irs_has_colon"
+      ],
+      "deps": 1,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "issuer_state",
+      "namespace": "RDF",
+      "module": "RDF.Canonical",
+      "kind": "record",
+      "members": [
+        "is_counter",
+        "is_issued"
+      ],
+      "deps": 1,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "json_value",
+      "namespace": "Parser",
+      "module": "Parser.JSONResults",
+      "kind": "variant",
+      "members": [
+        "JNull",
+        "JBool",
+        "JString",
+        "JNumber",
+        "JArray",
+        "JObject"
+      ],
+      "deps": 0,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "lex_result",
+      "namespace": "SPARQL11",
+      "module": "SPARQL11.Parser",
+      "kind": "alias",
+      "members": [],
+      "deps": 2,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "literal",
+      "namespace": "RDF",
+      "module": "RDF.Graph.Executable",
+      "kind": "record",
+      "members": [
+        "lexical_form",
+        "datatype",
+        "lang_tag"
+      ],
+      "deps": 1,
+      "rdeps": 1,
+      "inProject": true
+    },
+    {
+      "id": "load_strategy",
+      "namespace": "SPARQL",
+      "module": "SPARQL.Plan.Loader",
+      "kind": "variant",
+      "members": [
+        "LS_Mmap",
+        "LS_InRamFallback",
+        "LS_Refuse"
+      ],
+      "deps": 0,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "meta_column_chunk_locator",
+      "namespace": "Parquet",
+      "module": "Parquet.Footer",
+      "kind": "record",
+      "members": [
+        "mcc_meta_hex",
+        "mcc_meta_hex_len",
+        "mcc_column_chunk_start"
+      ],
+      "deps": 0,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "modifier_result",
+      "namespace": "SPARQL11",
+      "module": "SPARQL11.Parser",
+      "kind": "alias",
+      "members": [],
+      "deps": 0,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "named_graph",
+      "namespace": "RDF",
+      "module": "RDF.Graph.Executable",
+      "kind": "record",
+      "members": [
+        "ng_name",
+        "ng_graph"
+      ],
+      "deps": 2,
+      "rdeps": 1,
+      "inProject": true
+    },
+    {
+      "id": "named_graph_backend",
+      "namespace": "SPARQL11",
+      "module": "SPARQL11.Store",
+      "kind": "record",
+      "members": [
+        "ngb_name",
+        "ngb_graph"
+      ],
+      "deps": 2,
+      "rdeps": 1,
+      "inProject": true
+    },
+    {
+      "id": "named_graph_store",
+      "namespace": "SPARQL11",
+      "module": "SPARQL11.Algebra",
+      "kind": "record",
+      "members": [
+        "ngs_name",
+        "ngs_store"
+      ],
+      "deps": 2,
+      "rdeps": 1,
+      "inProject": true
+    },
+    {
+      "id": "node_kind",
+      "namespace": "SHACL",
+      "module": "SHACL.Validation",
+      "kind": "variant",
+      "members": [
+        "NK_BlankNode",
+        "NK_IRI",
+        "NK_Literal",
+        "NK_BlankNodeOrIRI",
+        "NK_BlankNodeOrLiteral",
+        "NK_IRIOrLiteral"
+      ],
+      "deps": 0,
+      "rdeps": 1,
+      "inProject": true
+    },
+    {
+      "id": "nquad",
+      "namespace": "Parser",
+      "module": "Parser.NQuads",
+      "kind": "record",
+      "members": [
+        "nq_triple",
+        "nq_graph"
+      ],
+      "deps": 2,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "num_kind",
+      "namespace": "SPARQL11",
+      "module": "SPARQL11.Algebra",
+      "kind": "alias",
+      "members": [],
+      "deps": 0,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "numeric_precision",
+      "namespace": "SPARQL11",
+      "module": "SPARQL11.Algebra",
+      "kind": "variant",
+      "members": [
+        "NP_Integer",
+        "NP_Decimal",
+        "NP_Float",
+        "NP_Double"
+      ],
+      "deps": 0,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "numeric_type",
+      "namespace": "RDF",
+      "module": "RDF.Graph.Executable",
+      "kind": "variant",
+      "members": [
+        "NT_Integer",
+        "NT_Decimal",
+        "NT_Double",
+        "NT_Float"
+      ],
+      "deps": 0,
+      "rdeps": 1,
+      "inProject": true
+    },
+    {
+      "id": "object_result",
+      "namespace": "Parser",
+      "module": "Parser.Turtle",
+      "kind": "record",
+      "members": [
+        "or_term",
+        "or_triples",
+        "or_state"
+      ],
+      "deps": 3,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "offset_handle",
+      "namespace": "RDF",
+      "module": "RDF.Store.Columnar.OffsetIndex",
+      "kind": "record",
+      "members": [
+        "oih_path",
+        "oih_header"
+      ],
+      "deps": 1,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "offset_header",
+      "namespace": "RDF",
+      "module": "RDF.Store.Columnar.OffsetIndex",
+      "kind": "record",
+      "members": [
+        "oh_magic",
+        "oh_version",
+        "oh_num_rgs",
+        "oh_num_preds"
+      ],
+      "deps": 0,
+      "rdeps": 1,
+      "inProject": true
+    },
+    {
+      "id": "page_cache",
+      "namespace": "RDF",
+      "module": "RDF.CottasStore.PageCache",
+      "kind": "record",
+      "members": [
+        "pc_entries",
+        "pc_clock",
+        "pc_capacity"
+      ],
+      "deps": 1,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "parquet_footer",
+      "namespace": "Parquet",
+      "module": "Parquet.Footer",
+      "kind": "record",
+      "members": [
+        "pf_metadata_len",
+        "pf_footer_len",
+        "pf_magic"
+      ],
+      "deps": 0,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "parse_result",
+      "namespace": "Parser",
+      "module": "Parser.Combinators",
+      "kind": "variant",
+      "members": [
+        "ParseOk",
+        "ParseFail"
+      ],
+      "deps": 1,
+      "rdeps": 1,
+      "inProject": true
+    },
+    {
+      "id": "parser",
+      "namespace": "Parser",
+      "module": "Parser.Combinators",
+      "kind": "alias",
+      "members": [],
+      "deps": 1,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "path",
+      "namespace": "SHACL",
+      "module": "SHACL.Validation",
+      "kind": "variant",
+      "members": [
+        "P_Predicate",
+        "P_Inverse",
+        "P_Sequence",
+        "P_Alternative",
+        "P_ZeroOrMore",
+        "P_OneOrMore",
+        "P_ZeroOrOne"
+      ],
+      "deps": 1,
+      "rdeps": 2,
+      "inProject": true
+    },
+    {
+      "id": "path_result",
+      "namespace": "SPARQL11",
+      "module": "SPARQL11.Algebra",
+      "kind": "alias",
+      "members": [],
+      "deps": 1,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "path_result_fwd",
+      "namespace": "SPARQL11",
+      "module": "SPARQL11.Algebra",
+      "kind": "alias",
+      "members": [],
+      "deps": 1,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "pattern_bound_ids",
+      "namespace": "SPARQL",
+      "module": "SPARQL.Plan.Pruning",
+      "kind": "record",
+      "members": [
+        "pbi_s",
+        "pbi_p",
+        "pbi_o"
+      ],
+      "deps": 0,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "pattern_subject",
+      "namespace": "RDF",
+      "module": "RDF.Graph.Executable",
+      "kind": "variant",
+      "members": [
+        "PS_Concrete",
+        "PS_Var"
+      ],
+      "deps": 2,
+      "rdeps": 2,
+      "inProject": true
+    },
+    {
+      "id": "pattern_term",
+      "namespace": "RDF",
+      "module": "RDF.Graph.Executable",
+      "kind": "variant",
+      "members": [
+        "PT_Concrete",
+        "PT_Var"
+      ],
+      "deps": 2,
+      "rdeps": 3,
+      "inProject": true
+    },
+    {
+      "id": "pcache_entry",
+      "namespace": "RDF",
+      "module": "RDF.CottasStore.PageCache",
+      "kind": "record",
+      "members": [
+        "pce_key",
+        "pce_value",
+        "pce_age"
+      ],
+      "deps": 1,
+      "rdeps": 1,
+      "inProject": true
+    },
+    {
+      "id": "pcache_key",
+      "namespace": "RDF",
+      "module": "RDF.CottasStore.PageCache",
+      "kind": "alias",
+      "members": [],
+      "deps": 0,
+      "rdeps": 1,
+      "inProject": true
+    },
+    {
+      "id": "plan_form",
+      "namespace": "SPARQL",
+      "module": "SPARQL.Plan.Explain",
+      "kind": "variant",
+      "members": [
+        "PF_Select_Vars",
+        "PF_Select_All",
+        "PF_Construct",
+        "PF_Ask",
+        "PF_Describe"
+      ],
+      "deps": 1,
+      "rdeps": 1,
+      "inProject": true
+    },
+    {
+      "id": "plan_node",
+      "namespace": "SPARQL",
+      "module": "SPARQL.Plan.Explain",
+      "kind": "variant",
+      "members": [
+        "Plan_Bgp",
+        "Plan_Join",
+        "Plan_LeftJoin",
+        "Plan_Filter",
+        "Plan_Union",
+        "Plan_Graph",
+        "Plan_Minus",
+        "Plan_Bind",
+        "Plan_Values",
+        "Plan_Service",
+        "Plan_ServiceVar",
+        "Plan_SubSelect",
+        "Plan_PropertyPath",
+        "Plan_Empty"
+      ],
+      "deps": 2,
+      "rdeps": 1,
+      "inProject": true
+    },
+    {
+      "id": "pos",
+      "namespace": "SPARQL11",
+      "module": "SPARQL11.Parser",
+      "kind": "alias",
+      "members": [],
+      "deps": 0,
+      "rdeps": 2,
+      "inProject": true
+    },
+    {
+      "id": "predicate_bloom",
+      "namespace": "Parser",
+      "module": "Parser.BallyhooBloom",
+      "kind": "record",
+      "members": [
+        "pb_bit_count",
+        "pb_hash_count",
+        "pb_bits"
+      ],
+      "deps": 1,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "prefix_map",
+      "namespace": "SPARQL11",
+      "module": "SPARQL11.Parser",
+      "kind": "alias",
+      "members": [],
+      "deps": 0,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "prefix_table",
+      "namespace": "RDF",
+      "module": "RDF.Pretty",
+      "kind": "alias",
+      "members": [],
+      "deps": 0,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "prefixed_name_span",
+      "namespace": "Parser",
+      "module": "Parser.TurtleScanner",
+      "kind": "record",
+      "members": [
+        "pns_prefix",
+        "pns_local"
+      ],
+      "deps": 1,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "presence_header",
+      "namespace": "RDF",
+      "module": "RDF.CottasStore.OnDiskIndex",
+      "kind": "record",
+      "members": [
+        "ph_magic",
+        "ph_version",
+        "ph_num_rgs",
+        "ph_num_tokens"
+      ],
+      "deps": 0,
+      "rdeps": 2,
+      "inProject": true
+    },
+    {
+      "id": "process_result",
+      "namespace": "Parser",
+      "module": "Parser.RDFXML",
+      "kind": "record",
+      "members": [
+        "pr_triples",
+        "pr_state"
+      ],
+      "deps": 2,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "q_priority",
+      "namespace": "SPARQL",
+      "module": "SPARQL.Protocol",
+      "kind": "record",
+      "members": [],
+      "deps": 0,
+      "rdeps": 1,
+      "inProject": true
+    },
+    {
+      "id": "qquad",
+      "namespace": "RDF",
+      "module": "RDF.Canonical",
+      "kind": "alias",
+      "members": [],
+      "deps": 2,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "query_entry",
+      "namespace": "SPARQL",
+      "module": "SPARQL.HTTP.QueriesIndex",
+      "kind": "record",
+      "members": [
+        "qe_group",
+        "qe_key",
+        "qe_label",
+        "qe_body"
+      ],
+      "deps": 0,
+      "rdeps": 1,
+      "inProject": true
+    },
+    {
+      "id": "query_group",
+      "namespace": "SPARQL",
+      "module": "SPARQL.HTTP.QueriesIndex",
+      "kind": "record",
+      "members": [
+        "qg_name",
+        "qg_entries"
+      ],
+      "deps": 1,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "query_plan",
+      "namespace": "SPARQL",
+      "module": "SPARQL.Plan.Explain",
+      "kind": "record",
+      "members": [
+        "qp_form",
+        "qp_distinct",
+        "qp_offset",
+        "qp_limit",
+        "qp_order_by",
+        "qp_root"
+      ],
+      "deps": 2,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "rdf_dataset",
+      "namespace": "RDF",
+      "module": "RDF.Graph.Executable",
+      "kind": "record",
+      "members": [
+        "ds_default",
+        "ds_named"
+      ],
+      "deps": 2,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "rdf_dataset_store",
+      "namespace": "SPARQL11",
+      "module": "SPARQL11.Algebra",
+      "kind": "record",
+      "members": [
+        "dss_default",
+        "dss_named"
+      ],
+      "deps": 2,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "rdf_format",
+      "namespace": "RDF",
+      "module": "RDF.Format",
+      "kind": "variant",
+      "members": [
+        "NT",
+        "Turtle",
+        "NQuads",
+        "TriG",
+        "RDFXML"
+      ],
+      "deps": 0,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "rdf_graph",
+      "namespace": "RDF",
+      "module": "RDF.Graph.Executable",
+      "kind": "alias",
+      "members": [],
+      "deps": 1,
+      "rdeps": 5,
+      "inProject": true
+    },
+    {
+      "id": "rdf_term",
+      "namespace": "RDF",
+      "module": "RDF.Graph.Executable",
+      "kind": "variant",
+      "members": [
+        "T_IRI",
+        "T_BNode",
+        "T_Literal"
+      ],
+      "deps": 3,
+      "rdeps": 18,
+      "inProject": true
+    },
+    {
+      "id": "rdfxml_state",
+      "namespace": "Parser",
+      "module": "Parser.RDFXML",
+      "kind": "record",
+      "members": [
+        "base_iri",
+        "namespaces",
+        "lang",
+        "bnode_counter",
+        "li_counter",
+        "seen_ids",
+        "has_error"
+      ],
+      "deps": 0,
+      "rdeps": 1,
+      "inProject": true
+    },
+    {
+      "id": "resolved_quad",
+      "namespace": "RDF",
+      "module": "RDF.Store.Loader",
+      "kind": "record",
+      "members": [
+        "rq_triple",
+        "rq_graph"
+      ],
+      "deps": 1,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "response_format",
+      "namespace": "SPARQL",
+      "module": "SPARQL.Protocol",
+      "kind": "variant",
+      "members": [
+        "RF_Json",
+        "RF_Xml",
+        "RF_Csv",
+        "RF_Tsv",
+        "RF_Turtle",
+        "RF_NTriples",
+        "RF_Text"
+      ],
+      "deps": 0,
+      "rdeps": 1,
+      "inProject": true
+    },
+    {
+      "id": "rif_atom",
+      "namespace": "RIF",
+      "module": "RIF.Core.Syntax",
+      "kind": "variant",
+      "members": [
+        "RIF_Triple",
+        "RIF_Frame",
+        "RIF_Member",
+        "RIF_Sub"
+      ],
+      "deps": 1,
+      "rdeps": 2,
+      "inProject": true
+    },
+    {
+      "id": "rif_body",
+      "namespace": "RIF",
+      "module": "RIF.Core.Syntax",
+      "kind": "variant",
+      "members": [
+        "RIF_BodyAtom",
+        "RIF_BodyAnd"
+      ],
+      "deps": 1,
+      "rdeps": 1,
+      "inProject": true
+    },
+    {
+      "id": "rif_program",
+      "namespace": "RIF",
+      "module": "RIF.Core.Syntax",
+      "kind": "record",
+      "members": [
+        "rules"
+      ],
+      "deps": 1,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "rif_rule",
+      "namespace": "RIF",
+      "module": "RIF.Core.Syntax",
+      "kind": "record",
+      "members": [
+        "rule_name",
+        "head",
+        "body"
+      ],
+      "deps": 2,
+      "rdeps": 1,
+      "inProject": true
+    },
+    {
+      "id": "rif_term",
+      "namespace": "RIF",
+      "module": "RIF.Core.Syntax",
+      "kind": "variant",
+      "members": [
+        "RIF_Var",
+        "RIF_Const"
+      ],
+      "deps": 2,
+      "rdeps": 1,
+      "inProject": true
+    },
+    {
+      "id": "rif_var",
+      "namespace": "RIF",
+      "module": "RIF.Core.Syntax",
+      "kind": "record",
+      "members": [
+        "var_name"
+      ],
+      "deps": 1,
+      "rdeps": 1,
+      "inProject": true
+    },
+    {
+      "id": "row_cap",
+      "namespace": "SPARQL",
+      "module": "SPARQL.Eval.Limits",
+      "kind": "record",
+      "members": [],
+      "deps": 0,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "sandbox_result",
+      "namespace": "SPARQL",
+      "module": "SPARQL.Update.Sandbox",
+      "kind": "variant",
+      "members": [
+        "SB_Ok",
+        "SB_Reject"
+      ],
+      "deps": 1,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "scan_mode",
+      "namespace": "Parser",
+      "module": "Parser.TurtleScanner",
+      "kind": "variant",
+      "members": [
+        "SM_Normal",
+        "SM_Comment",
+        "SM_IriRef",
+        "SM_String"
+      ],
+      "deps": 0,
+      "rdeps": 1,
+      "inProject": true
+    },
+    {
+      "id": "scanned_token",
+      "namespace": "Parser",
+      "module": "Parser.TurtleScanner",
+      "kind": "record",
+      "members": [
+        "st_kind",
+        "st_span"
+      ],
+      "deps": 2,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "scanner_state",
+      "namespace": "Parser",
+      "module": "Parser.TurtleScanner",
+      "kind": "record",
+      "members": [
+        "ss_mode",
+        "ss_carry"
+      ],
+      "deps": 1,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "severity",
+      "namespace": "SHACL",
+      "module": "SHACL.Validation",
+      "kind": "variant",
+      "members": [
+        "Sev_Info",
+        "Sev_Warning",
+        "Sev_Violation"
+      ],
+      "deps": 0,
+      "rdeps": 2,
+      "inProject": true
+    },
+    {
+      "id": "shape",
+      "namespace": "SHACL",
+      "module": "SHACL.Validation",
+      "kind": "record",
+      "members": [
+        "shape_id",
+        "is_property",
+        "shape_path",
+        "targets",
+        "shape_sev",
+        "message",
+        "constraints",
+        "property_refs"
+      ],
+      "deps": 5,
+      "rdeps": 1,
+      "inProject": true
+    },
+    {
+      "id": "shape_ref",
+      "namespace": "SHACL",
+      "module": "SHACL.Validation",
+      "kind": "alias",
+      "members": [],
+      "deps": 0,
+      "rdeps": 3,
+      "inProject": true
+    },
+    {
+      "id": "shapes_graph",
+      "namespace": "SHACL",
+      "module": "SHACL.Validation",
+      "kind": "record",
+      "members": [
+        "shapes"
+      ],
+      "deps": 1,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "short_string_span",
+      "namespace": "Parser",
+      "module": "Parser.TurtleScanner",
+      "kind": "record",
+      "members": [
+        "sss_quote",
+        "sss_content"
+      ],
+      "deps": 1,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "solution_mapping",
+      "namespace": "RDF",
+      "module": "RDF.Graph.Executable",
+      "kind": "alias",
+      "members": [],
+      "deps": 2,
+      "rdeps": 2,
+      "inProject": true
+    },
+    {
+      "id": "solution_multiset",
+      "namespace": "RDF",
+      "module": "RDF.Graph.Executable",
+      "kind": "alias",
+      "members": [],
+      "deps": 1,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "span",
+      "namespace": "Parser",
+      "module": "Parser.TurtleScanner",
+      "kind": "record",
+      "members": [
+        "sp_start",
+        "sp_end"
+      ],
+      "deps": 0,
+      "rdeps": 4,
+      "inProject": true
+    },
+    {
+      "id": "sparql_request",
+      "namespace": "SPARQL",
+      "module": "SPARQL.Protocol",
+      "kind": "variant",
+      "members": [
+        "PR_Query",
+        "PR_Update",
+        "PR_Bad"
+      ],
+      "deps": 0,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "sparql_update",
+      "namespace": "SPARQL11",
+      "module": "SPARQL11.Algebra",
+      "kind": "record",
+      "members": [
+        "u_base",
+        "u_prefixes",
+        "u_ops"
+      ],
+      "deps": 2,
+      "rdeps": 1,
+      "inProject": true
+    },
+    {
+      "id": "sparql_value",
+      "namespace": "RDF",
+      "module": "RDF.Graph.Executable",
+      "kind": "variant",
+      "members": [
+        "SV_Numeric",
+        "SV_PlainLiteral",
+        "SV_LangLiteral",
+        "SV_Iri",
+        "SV_BNode",
+        "SV_TypedLiteral",
+        "SV_Boolean"
+      ],
+      "deps": 3,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "subject",
+      "namespace": "RDF",
+      "module": "RDF.Graph.Executable",
+      "kind": "variant",
+      "members": [
+        "S_IRI",
+        "S_BNode"
+      ],
+      "deps": 2,
+      "rdeps": 5,
+      "inProject": true
+    },
+    {
+      "id": "subject_result",
+      "namespace": "Parser",
+      "module": "Parser.Turtle",
+      "kind": "record",
+      "members": [
+        "sr_subject",
+        "sr_triples",
+        "sr_state",
+        "sr_is_bnode_proplist"
+      ],
+      "deps": 3,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "tab_branch",
+      "namespace": "Tableau",
+      "module": "Tableau",
+      "kind": "record",
+      "members": [
+        "tb_nodes",
+        "tb_status"
+      ],
+      "deps": 2,
+      "rdeps": 1,
+      "inProject": true
+    },
+    {
+      "id": "tab_individual",
+      "namespace": "Tableau",
+      "module": "Tableau",
+      "kind": "variant",
+      "members": [
+        "TI_IRI",
+        "TI_BNode",
+        "TI_Skolem"
+      ],
+      "deps": 2,
+      "rdeps": 2,
+      "inProject": true
+    },
+    {
+      "id": "tab_link",
+      "namespace": "Tableau",
+      "module": "Tableau",
+      "kind": "record",
+      "members": [
+        "tl_pred",
+        "tl_obj"
+      ],
+      "deps": 2,
+      "rdeps": 1,
+      "inProject": true
+    },
+    {
+      "id": "tab_node",
+      "namespace": "Tableau",
+      "module": "Tableau",
+      "kind": "record",
+      "members": [
+        "tn_indiv",
+        "tn_classes",
+        "tn_links",
+        "tn_same_as"
+      ],
+      "deps": 3,
+      "rdeps": 1,
+      "inProject": true
+    },
+    {
+      "id": "tab_obligation",
+      "namespace": "Tableau",
+      "module": "Tableau",
+      "kind": "record",
+      "members": [
+        "tob_owner",
+        "tob_desc"
+      ],
+      "deps": 1,
+      "rdeps": 1,
+      "inProject": true
+    },
+    {
+      "id": "tab_status",
+      "namespace": "Tableau",
+      "module": "Tableau",
+      "kind": "variant",
+      "members": [
+        "Open",
+        "Closed",
+        "Unknown"
+      ],
+      "deps": 0,
+      "rdeps": 1,
+      "inProject": true
+    },
+    {
+      "id": "tableau_state",
+      "namespace": "Tableau",
+      "module": "Tableau",
+      "kind": "record",
+      "members": [
+        "ts_branches",
+        "ts_obligations",
+        "ts_una",
+        "ts_fuel_used"
+      ],
+      "deps": 2,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "target",
+      "namespace": "SHACL",
+      "module": "SHACL.Validation",
+      "kind": "variant",
+      "members": [
+        "T_Class",
+        "T_Node",
+        "T_SubjectsOf",
+        "T_ObjectsOf",
+        "T_ImplicitClass",
+        "T_Sparql"
+      ],
+      "deps": 2,
+      "rdeps": 1,
+      "inProject": true
+    },
+    {
+      "id": "test_kind",
+      "namespace": "RDF",
+      "module": "RDF.Canonical.Manifest",
+      "kind": "variant",
+      "members": [
+        "TK_Eval",
+        "TK_NegEval",
+        "TK_Map",
+        "TK_Unknown"
+      ],
+      "deps": 0,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "token",
+      "namespace": "SPARQL11",
+      "module": "SPARQL11.Parser",
+      "kind": "variant",
+      "members": [
+        "Tok_SELECT",
+        "Tok_WHERE",
+        "Tok_OPTIONAL",
+        "Tok_GRAPH",
+        "Tok_EXISTS",
+        "Tok_AS",
+        "Tok_ORDER",
+        "Tok_GROUP",
+        "Tok_LIMIT",
+        "Tok_FROM",
+        "Tok_IN",
+        "Tok_A",
+        "Tok_LBRACE",
+        "Tok_LBRACKET",
+        "Tok_DOT",
+        "Tok_STAR",
+        "Tok_PLUS",
+        "Tok_EQ",
+        "Tok_AND",
+        "Tok_HATHAT",
+        "Tok_IRI",
+        "Tok_PNAME",
+        "Tok_VAR",
+        "Tok_STRING",
+        "Tok_LANGTAG",
+        "Tok_INTEGER",
+        "Tok_DECIMAL",
+        "Tok_DOUBLE",
+        "Tok_BNODE",
+        "Tok_ANON",
+        "Tok_STR",
+        "Tok_IRI_KW",
+        "Tok_ABS",
+        "Tok_CONCAT",
+        "Tok_ENCODE_FOR_URI",
+        "Tok_STRBEFORE",
+        "Tok_SUBSTR",
+        "Tok_ISIRI",
+        "Tok_SAMETERM",
+        "Tok_COUNT",
+        "Tok_GROUP_CONCAT",
+        "Tok_COALESCE",
+        "Tok_YEAR",
+        "Tok_TIMEZONE",
+        "Tok_MD5",
+        "Tok_LOAD",
+        "Tok_ADD",
+        "Tok_INSERT",
+        "Tok_INTO",
+        "Tok_DEFAULT",
+        "Tok_EOF"
+      ],
+      "deps": 0,
+      "rdeps": 2,
+      "inProject": true
+    },
+    {
+      "id": "token_kind",
+      "namespace": "Parser",
+      "module": "Parser.TurtleScanner",
+      "kind": "variant",
+      "members": [
+        "TK_Dot",
+        "TK_Semicolon",
+        "TK_Comma",
+        "TK_LBracket",
+        "TK_RBracket",
+        "TK_LParen",
+        "TK_RParen",
+        "TK_IriRef",
+        "TK_PrefixedName"
+      ],
+      "deps": 0,
+      "rdeps": 1,
+      "inProject": true
+    },
+    {
+      "id": "token_stream",
+      "namespace": "SPARQL11",
+      "module": "SPARQL11.Parser",
+      "kind": "alias",
+      "members": [],
+      "deps": 1,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "tp_explain",
+      "namespace": "SPARQL",
+      "module": "SPARQL.Explain",
+      "kind": "record",
+      "members": [
+        "tpx_label",
+        "tpx_tp",
+        "tpx_s_status",
+        "tpx_p_status",
+        "tpx_o_status",
+        "tpx_bound_built",
+        "tpx_pred_present",
+        "tpx_estimate"
+      ],
+      "deps": 2,
+      "rdeps": 1,
+      "inProject": true
+    },
+    {
+      "id": "tpl_opt_result",
+      "namespace": "SPARQL",
+      "module": "SPARQL.Update.Sandbox",
+      "kind": "variant",
+      "members": [
+        "TOR_Rewrite",
+        "TOR_Reject"
+      ],
+      "deps": 0,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "trig_parse_state",
+      "namespace": "Parser",
+      "module": "Parser.TriG",
+      "kind": "record",
+      "members": [
+        "ts",
+        "has_error"
+      ],
+      "deps": 1,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "triple",
+      "namespace": "RDF",
+      "module": "RDF.Graph.Executable",
+      "kind": "record",
+      "members": [
+        "s",
+        "p",
+        "o"
+      ],
+      "deps": 3,
+      "rdeps": 11,
+      "inProject": true
+    },
+    {
+      "id": "triple_pattern",
+      "namespace": "RDF",
+      "module": "RDF.Graph.Executable",
+      "kind": "record",
+      "members": [
+        "tp_s",
+        "tp_p",
+        "tp_o"
+      ],
+      "deps": 3,
+      "rdeps": 3,
+      "inProject": true
+    },
+    {
+      "id": "triple_pattern_bound",
+      "namespace": "SPARQL11",
+      "module": "SPARQL11.Algebra",
+      "kind": "record",
+      "members": [
+        "bs",
+        "bp",
+        "bo"
+      ],
+      "deps": 3,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "turtle_doc_result",
+      "namespace": "Parser",
+      "module": "Parser.Turtle",
+      "kind": "record",
+      "members": [
+        "tdr_triples",
+        "tdr_state",
+        "tdr_has_error"
+      ],
+      "deps": 2,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "turtle_state",
+      "namespace": "Parser",
+      "module": "Parser.Turtle",
+      "kind": "record",
+      "members": [
+        "prefixes",
+        "base_iri",
+        "bnode_counter"
+      ],
+      "deps": 0,
+      "rdeps": 4,
+      "inProject": true
+    },
+    {
+      "id": "update_op",
+      "namespace": "SPARQL11",
+      "module": "SPARQL11.Algebra",
+      "kind": "variant",
+      "members": [
+        "U_Load",
+        "U_Clear",
+        "U_Drop",
+        "U_Create",
+        "U_Add",
+        "U_Move",
+        "U_Copy",
+        "U_InsertData",
+        "U_DeleteData",
+        "U_DeleteWhere",
+        "U_Modify"
+      ],
+      "deps": 2,
+      "rdeps": 2,
+      "inProject": true
+    },
+    {
+      "id": "update_sandbox_result",
+      "namespace": "SPARQL",
+      "module": "SPARQL.Update.Sandbox",
+      "kind": "variant",
+      "members": [
+        "USR_Ok",
+        "USR_Error"
+      ],
+      "deps": 1,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "validation_report",
+      "namespace": "SHACL",
+      "module": "SHACL.Validation",
+      "kind": "record",
+      "members": [
+        "conforms",
+        "results"
+      ],
+      "deps": 1,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "var_name",
+      "namespace": "RDF",
+      "module": "RDF.Graph.Executable",
+      "kind": "alias",
+      "members": [],
+      "deps": 0,
+      "rdeps": 7,
+      "inProject": true
+    },
+    {
+      "id": "verb_or_path",
+      "namespace": "SPARQL11",
+      "module": "SPARQL11.Parser",
+      "kind": "variant",
+      "members": [
+        "VSimple",
+        "VPath"
+      ],
+      "deps": 1,
+      "rdeps": 0,
+      "inProject": true
+    },
+    {
+      "id": "violation",
+      "namespace": "SHACL",
+      "module": "SHACL.Validation",
+      "kind": "record",
+      "members": [
+        "v_focus_node",
+        "v_path",
+        "v_value",
+        "v_source_shape",
+        "v_constraint",
+        "v_severity",
+        "v_message"
+      ],
+      "deps": 5,
+      "rdeps": 1,
+      "inProject": true
+    },
+    {
+      "id": "wf_iri",
+      "namespace": "RDF",
+      "module": "RDF.Graph.Executable",
+      "kind": "record",
+      "members": [],
+      "deps": 1,
+      "rdeps": 19,
+      "inProject": true
+    },
+    {
+      "id": "wf_literal",
+      "namespace": "RDF",
+      "module": "RDF.Graph.Executable",
+      "kind": "record",
+      "members": [],
+      "deps": 1,
+      "rdeps": 2,
+      "inProject": true
+    },
+    {
+      "id": "xml_attribute",
+      "namespace": "Parser",
+      "module": "Parser.XML",
+      "kind": "record",
+      "members": [],
+      "deps": 0,
+      "rdeps": 1,
+      "inProject": true
+    },
+    {
+      "id": "xml_node",
+      "namespace": "Parser",
+      "module": "Parser.XML",
+      "kind": "variant",
+      "members": [
+        "XText",
+        "XElement",
+        "XComment",
+        "XCDATA"
+      ],
+      "deps": 1,
+      "rdeps": 0,
+      "inProject": true
+    }
+  ],
+  "links": [
+    {
+      "source": "accept_entry",
+      "target": "q_priority",
+      "weight": 1
+    },
+    {
+      "source": "accept_entry",
+      "target": "response_format",
+      "weight": 1
+    },
+    {
+      "source": "access_path",
+      "target": "cell_view",
+      "weight": 1
+    },
+    {
+      "source": "algebra_op",
+      "target": "bgp",
+      "weight": 1
+    },
+    {
+      "source": "backend_info",
+      "target": "backend_kind",
+      "weight": 1
+    },
+    {
+      "source": "backend_info",
+      "target": "cottas_summary",
+      "weight": 1
+    },
+    {
+      "source": "ballyhoo_event",
+      "target": "iri",
+      "weight": 1
+    },
+    {
+      "source": "ballyhoo_event",
+      "target": "triple",
+      "weight": 1
+    },
+    {
+      "source": "ballyhoo_state",
+      "target": "ballyhoo_error",
+      "weight": 1
+    },
+    {
+      "source": "ballyhoo_state",
+      "target": "ballyhoo_event",
+      "weight": 1
+    },
+    {
+      "source": "ballyhoo_state",
+      "target": "ballyhoo_mode",
+      "weight": 1
+    },
+    {
+      "source": "bgp",
+      "target": "triple_pattern",
+      "weight": 1
+    },
+    {
+      "source": "binding_row",
+      "target": "rdf_term",
+      "weight": 1
+    },
+    {
+      "source": "bitmap_handle",
+      "target": "presence_header",
+      "weight": 1
+    },
+    {
+      "source": "bn_full_key",
+      "target": "bnode_id",
+      "weight": 1
+    },
+    {
+      "source": "bn_hfdq_pair",
+      "target": "bnode_id",
+      "weight": 1
+    },
+    {
+      "source": "bucket",
+      "target": "bnode_id",
+      "weight": 1
+    },
+    {
+      "source": "bucket_map",
+      "target": "triple",
+      "weight": 1
+    },
+    {
+      "source": "cell_decision",
+      "target": "cell_view",
+      "weight": 1
+    },
+    {
+      "source": "class_expr",
+      "target": "rdf_term",
+      "weight": 1
+    },
+    {
+      "source": "class_expr",
+      "target": "wf_iri",
+      "weight": 1
+    },
+    {
+      "source": "companion_status",
+      "target": "dict_header",
+      "weight": 1
+    },
+    {
+      "source": "companion_status",
+      "target": "presence_header",
+      "weight": 1
+    },
+    {
+      "source": "compound_handle",
+      "target": "compound_header",
+      "weight": 1
+    },
+    {
+      "source": "constraint_component",
+      "target": "node_kind",
+      "weight": 1
+    },
+    {
+      "source": "constraint_component",
+      "target": "rdf_term",
+      "weight": 1
+    },
+    {
+      "source": "constraint_component",
+      "target": "shape_ref",
+      "weight": 1
+    },
+    {
+      "source": "constraint_component",
+      "target": "wf_iri",
+      "weight": 1
+    },
+    {
+      "source": "corpus_graph_binding",
+      "target": "hdt_artifact_summary",
+      "weight": 1
+    },
+    {
+      "source": "corpus_graph_binding",
+      "target": "iri",
+      "weight": 1
+    },
+    {
+      "source": "cottas_artifact_summary",
+      "target": "cottas_dictionary_summary",
+      "weight": 1
+    },
+    {
+      "source": "cottas_artifact_summary",
+      "target": "cottas_row_group_summary",
+      "weight": 1
+    },
+    {
+      "source": "cottas_bound_qp",
+      "target": "cottas_graph_ref",
+      "weight": 1
+    },
+    {
+      "source": "cottas_bound_qp",
+      "target": "cottas_term_ref",
+      "weight": 1
+    },
+    {
+      "source": "cottas_column_summary",
+      "target": "cottas_column_kind",
+      "weight": 1
+    },
+    {
+      "source": "cottas_column_summary",
+      "target": "cottas_encoding",
+      "weight": 1
+    },
+    {
+      "source": "cottas_dataset_store",
+      "target": "cottas_artifact_summary",
+      "weight": 1
+    },
+    {
+      "source": "cottas_named_graph_store",
+      "target": "cottas_dataset_store",
+      "weight": 1
+    },
+    {
+      "source": "cottas_named_graph_store",
+      "target": "cottas_graph_ref",
+      "weight": 1
+    },
+    {
+      "source": "cottas_named_graph_store",
+      "target": "iri",
+      "weight": 1
+    },
+    {
+      "source": "cottas_ondisk_handle",
+      "target": "cottas_artifact_summary",
+      "weight": 1
+    },
+    {
+      "source": "cottas_ondisk_handle",
+      "target": "iri",
+      "weight": 1
+    },
+    {
+      "source": "cottas_ondisk_handle",
+      "target": "rdf_term",
+      "weight": 1
+    },
+    {
+      "source": "cottas_ondisk_handle",
+      "target": "subject",
+      "weight": 1
+    },
+    {
+      "source": "cottas_ondisk_handle",
+      "target": "wf_iri",
+      "weight": 1
+    },
+    {
+      "source": "cottas_ondisk_store",
+      "target": "cottas_artifact_summary",
+      "weight": 1
+    },
+    {
+      "source": "cottas_ondisk_store",
+      "target": "cottas_ondisk_handle",
+      "weight": 1
+    },
+    {
+      "source": "cottas_qp_row",
+      "target": "cottas_graph_ref",
+      "weight": 1
+    },
+    {
+      "source": "cottas_qp_row",
+      "target": "cottas_term_ref",
+      "weight": 1
+    },
+    {
+      "source": "cottas_row_group_summary",
+      "target": "cottas_column_summary",
+      "weight": 1
+    },
+    {
+      "source": "dataset_backend",
+      "target": "graph_backend",
+      "weight": 1
+    },
+    {
+      "source": "dataset_backend",
+      "target": "named_graph_backend",
+      "weight": 1
+    },
+    {
+      "source": "eval_result",
+      "target": "rdf_term",
+      "weight": 1
+    },
+    {
+      "source": "expr",
+      "target": "aggregate_fn",
+      "weight": 1
+    },
+    {
+      "source": "expr",
+      "target": "arith_op",
+      "weight": 1
+    },
+    {
+      "source": "expr",
+      "target": "bgp",
+      "weight": 1
+    },
+    {
+      "source": "expr",
+      "target": "comp_op",
+      "weight": 1
+    },
+    {
+      "source": "expr",
+      "target": "pattern_subject",
+      "weight": 1
+    },
+    {
+      "source": "expr",
+      "target": "pattern_term",
+      "weight": 1
+    },
+    {
+      "source": "expr",
+      "target": "rdf_term",
+      "weight": 1
+    },
+    {
+      "source": "expr",
+      "target": "triple_pattern",
+      "weight": 1
+    },
+    {
+      "source": "expr",
+      "target": "var_name",
+      "weight": 1
+    },
+    {
+      "source": "expr",
+      "target": "wf_iri",
+      "weight": 1
+    },
+    {
+      "source": "expr",
+      "target": "wf_literal",
+      "weight": 1
+    },
+    {
+      "source": "filter_expr_eval",
+      "target": "rdf_term",
+      "weight": 1
+    },
+    {
+      "source": "filter_expr_eval",
+      "target": "solution_mapping",
+      "weight": 1
+    },
+    {
+      "source": "ggp_target_status",
+      "target": "iri",
+      "weight": 1
+    },
+    {
+      "source": "graph_backend",
+      "target": "cottas_dataset_store",
+      "weight": 1
+    },
+    {
+      "source": "graph_backend",
+      "target": "cottas_ondisk_store",
+      "weight": 1
+    },
+    {
+      "source": "graph_backend",
+      "target": "hdt_graph_store",
+      "weight": 1
+    },
+    {
+      "source": "graph_backend",
+      "target": "indexed_graph",
+      "weight": 1
+    },
+    {
+      "source": "graph_backend",
+      "target": "iri",
+      "weight": 1
+    },
+    {
+      "source": "graph_backend",
+      "target": "rdf_graph",
+      "weight": 1
+    },
+    {
+      "source": "graph_ref",
+      "target": "wf_iri",
+      "weight": 1
+    },
+    {
+      "source": "graph_store",
+      "target": "gs_named",
+      "weight": 1
+    },
+    {
+      "source": "graph_store",
+      "target": "rdf_graph",
+      "weight": 1
+    },
+    {
+      "source": "group",
+      "target": "eval_result",
+      "weight": 1
+    },
+    {
+      "source": "gs_named",
+      "target": "graph_key",
+      "weight": 1
+    },
+    {
+      "source": "gs_named",
+      "target": "rdf_graph",
+      "weight": 1
+    },
+    {
+      "source": "gs_target",
+      "target": "graph_key",
+      "weight": 1
+    },
+    {
+      "source": "hdt_artifact_summary",
+      "target": "hdt_dictionary_summary",
+      "weight": 1
+    },
+    {
+      "source": "hdt_artifact_summary",
+      "target": "hdt_statistics",
+      "weight": 1
+    },
+    {
+      "source": "hdt_artifact_summary",
+      "target": "hdt_triples_summary",
+      "weight": 1
+    },
+    {
+      "source": "hdt_artifact_summary",
+      "target": "iri",
+      "weight": 1
+    },
+    {
+      "source": "hdt_bound_tp",
+      "target": "hdt_term_ref",
+      "weight": 1
+    },
+    {
+      "source": "hdt_graph_store",
+      "target": "hdt_artifact_summary",
+      "weight": 1
+    },
+    {
+      "source": "hdt_graph_store",
+      "target": "iri",
+      "weight": 1
+    },
+    {
+      "source": "hdt_tp_row",
+      "target": "hdt_term_ref",
+      "weight": 1
+    },
+    {
+      "source": "hdt_triples_summary",
+      "target": "ballyhoo_order",
+      "weight": 1
+    },
+    {
+      "source": "hdtq_artifact_summary",
+      "target": "hdt_artifact_summary",
+      "weight": 1
+    },
+    {
+      "source": "hdtq_artifact_summary",
+      "target": "hdtq_graph_dictionary_summary",
+      "weight": 1
+    },
+    {
+      "source": "hdtq_artifact_summary",
+      "target": "hdtq_quad_info_summary",
+      "weight": 1
+    },
+    {
+      "source": "hdtq_bound_qp",
+      "target": "hdt_term_ref",
+      "weight": 1
+    },
+    {
+      "source": "hdtq_bound_qp",
+      "target": "hdtq_graph_ref",
+      "weight": 1
+    },
+    {
+      "source": "hdtq_dataset_store",
+      "target": "hdtq_artifact_summary",
+      "weight": 1
+    },
+    {
+      "source": "hdtq_named_graph_store",
+      "target": "hdtq_dataset_store",
+      "weight": 1
+    },
+    {
+      "source": "hdtq_named_graph_store",
+      "target": "hdtq_graph_ref",
+      "weight": 1
+    },
+    {
+      "source": "hdtq_named_graph_store",
+      "target": "iri",
+      "weight": 1
+    },
+    {
+      "source": "hdtq_qp_row",
+      "target": "hdt_term_ref",
+      "weight": 1
+    },
+    {
+      "source": "hdtq_qp_row",
+      "target": "hdtq_graph_ref",
+      "weight": 1
+    },
+    {
+      "source": "hdtq_quad_info_summary",
+      "target": "hdtq_annotation_mode",
+      "weight": 1
+    },
+    {
+      "source": "http_client_result",
+      "target": "http_client_error",
+      "weight": 1
+    },
+    {
+      "source": "http_result",
+      "target": "http_error",
+      "weight": 1
+    },
+    {
+      "source": "indexed_graph",
+      "target": "bucket_map",
+      "weight": 1
+    },
+    {
+      "source": "indexed_graph",
+      "target": "triple",
+      "weight": 1
+    },
+    {
+      "source": "iri_ref_span",
+      "target": "span",
+      "weight": 1
+    },
+    {
+      "source": "issuer_state",
+      "target": "bnode_id",
+      "weight": 1
+    },
+    {
+      "source": "lex_result",
+      "target": "pos",
+      "weight": 1
+    },
+    {
+      "source": "lex_result",
+      "target": "token",
+      "weight": 1
+    },
+    {
+      "source": "literal",
+      "target": "wf_iri",
+      "weight": 1
+    },
+    {
+      "source": "named_graph",
+      "target": "iri",
+      "weight": 1
+    },
+    {
+      "source": "named_graph",
+      "target": "rdf_graph",
+      "weight": 1
+    },
+    {
+      "source": "named_graph_backend",
+      "target": "graph_backend",
+      "weight": 1
+    },
+    {
+      "source": "named_graph_backend",
+      "target": "iri",
+      "weight": 1
+    },
+    {
+      "source": "named_graph_store",
+      "target": "graph_store",
+      "weight": 1
+    },
+    {
+      "source": "named_graph_store",
+      "target": "iri",
+      "weight": 1
+    },
+    {
+      "source": "nquad",
+      "target": "iri",
+      "weight": 1
+    },
+    {
+      "source": "nquad",
+      "target": "triple",
+      "weight": 1
+    },
+    {
+      "source": "object_result",
+      "target": "rdf_term",
+      "weight": 1
+    },
+    {
+      "source": "object_result",
+      "target": "triple",
+      "weight": 1
+    },
+    {
+      "source": "object_result",
+      "target": "turtle_state",
+      "weight": 1
+    },
+    {
+      "source": "offset_handle",
+      "target": "offset_header",
+      "weight": 1
+    },
+    {
+      "source": "page_cache",
+      "target": "pcache_entry",
+      "weight": 1
+    },
+    {
+      "source": "parse_result",
+      "target": "pos",
+      "weight": 1
+    },
+    {
+      "source": "parser",
+      "target": "parse_result",
+      "weight": 1
+    },
+    {
+      "source": "path",
+      "target": "wf_iri",
+      "weight": 1
+    },
+    {
+      "source": "path_result",
+      "target": "rdf_term",
+      "weight": 1
+    },
+    {
+      "source": "path_result_fwd",
+      "target": "rdf_term",
+      "weight": 1
+    },
+    {
+      "source": "pattern_subject",
+      "target": "subject",
+      "weight": 1
+    },
+    {
+      "source": "pattern_subject",
+      "target": "var_name",
+      "weight": 1
+    },
+    {
+      "source": "pattern_term",
+      "target": "rdf_term",
+      "weight": 1
+    },
+    {
+      "source": "pattern_term",
+      "target": "var_name",
+      "weight": 1
+    },
+    {
+      "source": "pcache_entry",
+      "target": "pcache_key",
+      "weight": 1
+    },
+    {
+      "source": "plan_form",
+      "target": "var_name",
+      "weight": 1
+    },
+    {
+      "source": "plan_node",
+      "target": "tp_explain",
+      "weight": 1
+    },
+    {
+      "source": "plan_node",
+      "target": "var_name",
+      "weight": 1
+    },
+    {
+      "source": "predicate_bloom",
+      "target": "bloom_bits",
+      "weight": 1
+    },
+    {
+      "source": "prefixed_name_span",
+      "target": "span",
+      "weight": 1
+    },
+    {
+      "source": "process_result",
+      "target": "rdfxml_state",
+      "weight": 1
+    },
+    {
+      "source": "process_result",
+      "target": "triple",
+      "weight": 1
+    },
+    {
+      "source": "qquad",
+      "target": "iri",
+      "weight": 1
+    },
+    {
+      "source": "qquad",
+      "target": "triple",
+      "weight": 1
+    },
+    {
+      "source": "query_group",
+      "target": "query_entry",
+      "weight": 1
+    },
+    {
+      "source": "query_plan",
+      "target": "plan_form",
+      "weight": 1
+    },
+    {
+      "source": "query_plan",
+      "target": "plan_node",
+      "weight": 1
+    },
+    {
+      "source": "rdf_dataset",
+      "target": "named_graph",
+      "weight": 1
+    },
+    {
+      "source": "rdf_dataset",
+      "target": "rdf_graph",
+      "weight": 1
+    },
+    {
+      "source": "rdf_dataset_store",
+      "target": "graph_store",
+      "weight": 1
+    },
+    {
+      "source": "rdf_dataset_store",
+      "target": "named_graph_store",
+      "weight": 1
+    },
+    {
+      "source": "rdf_graph",
+      "target": "triple",
+      "weight": 1
+    },
+    {
+      "source": "rdf_term",
+      "target": "bnode_id",
+      "weight": 1
+    },
+    {
+      "source": "rdf_term",
+      "target": "wf_iri",
+      "weight": 1
+    },
+    {
+      "source": "rdf_term",
+      "target": "wf_literal",
+      "weight": 1
+    },
+    {
+      "source": "resolved_quad",
+      "target": "triple",
+      "weight": 1
+    },
+    {
+      "source": "rif_atom",
+      "target": "rif_term",
+      "weight": 1
+    },
+    {
+      "source": "rif_body",
+      "target": "rif_atom",
+      "weight": 1
+    },
+    {
+      "source": "rif_program",
+      "target": "rif_rule",
+      "weight": 1
+    },
+    {
+      "source": "rif_rule",
+      "target": "rif_atom",
+      "weight": 1
+    },
+    {
+      "source": "rif_rule",
+      "target": "rif_body",
+      "weight": 1
+    },
+    {
+      "source": "rif_term",
+      "target": "rdf_term",
+      "weight": 1
+    },
+    {
+      "source": "rif_term",
+      "target": "rif_var",
+      "weight": 1
+    },
+    {
+      "source": "rif_var",
+      "target": "var_name",
+      "weight": 1
+    },
+    {
+      "source": "sandbox_result",
+      "target": "update_op",
+      "weight": 1
+    },
+    {
+      "source": "scanned_token",
+      "target": "span",
+      "weight": 1
+    },
+    {
+      "source": "scanned_token",
+      "target": "token_kind",
+      "weight": 1
+    },
+    {
+      "source": "scanner_state",
+      "target": "scan_mode",
+      "weight": 1
+    },
+    {
+      "source": "shape",
+      "target": "constraint_component",
+      "weight": 1
+    },
+    {
+      "source": "shape",
+      "target": "path",
+      "weight": 1
+    },
+    {
+      "source": "shape",
+      "target": "severity",
+      "weight": 1
+    },
+    {
+      "source": "shape",
+      "target": "shape_ref",
+      "weight": 1
+    },
+    {
+      "source": "shape",
+      "target": "target",
+      "weight": 1
+    },
+    {
+      "source": "shapes_graph",
+      "target": "shape",
+      "weight": 1
+    },
+    {
+      "source": "short_string_span",
+      "target": "span",
+      "weight": 1
+    },
+    {
+      "source": "solution_mapping",
+      "target": "rdf_term",
+      "weight": 1
+    },
+    {
+      "source": "solution_mapping",
+      "target": "var_name",
+      "weight": 1
+    },
+    {
+      "source": "solution_multiset",
+      "target": "solution_mapping",
+      "weight": 1
+    },
+    {
+      "source": "sparql_update",
+      "target": "update_op",
+      "weight": 1
+    },
+    {
+      "source": "sparql_update",
+      "target": "wf_iri",
+      "weight": 1
+    },
+    {
+      "source": "sparql_value",
+      "target": "bnode_id",
+      "weight": 1
+    },
+    {
+      "source": "sparql_value",
+      "target": "numeric_type",
+      "weight": 1
+    },
+    {
+      "source": "sparql_value",
+      "target": "wf_iri",
+      "weight": 1
+    },
+    {
+      "source": "subject",
+      "target": "bnode_id",
+      "weight": 1
+    },
+    {
+      "source": "subject",
+      "target": "wf_iri",
+      "weight": 1
+    },
+    {
+      "source": "subject_result",
+      "target": "subject",
+      "weight": 1
+    },
+    {
+      "source": "subject_result",
+      "target": "triple",
+      "weight": 1
+    },
+    {
+      "source": "subject_result",
+      "target": "turtle_state",
+      "weight": 1
+    },
+    {
+      "source": "tab_branch",
+      "target": "tab_node",
+      "weight": 1
+    },
+    {
+      "source": "tab_branch",
+      "target": "tab_status",
+      "weight": 1
+    },
+    {
+      "source": "tab_individual",
+      "target": "bnode_id",
+      "weight": 1
+    },
+    {
+      "source": "tab_individual",
+      "target": "wf_iri",
+      "weight": 1
+    },
+    {
+      "source": "tab_link",
+      "target": "rdf_term",
+      "weight": 1
+    },
+    {
+      "source": "tab_link",
+      "target": "wf_iri",
+      "weight": 1
+    },
+    {
+      "source": "tab_node",
+      "target": "tab_individual",
+      "weight": 1
+    },
+    {
+      "source": "tab_node",
+      "target": "tab_link",
+      "weight": 1
+    },
+    {
+      "source": "tab_node",
+      "target": "wf_iri",
+      "weight": 1
+    },
+    {
+      "source": "tab_obligation",
+      "target": "tab_individual",
+      "weight": 1
+    },
+    {
+      "source": "tableau_state",
+      "target": "tab_branch",
+      "weight": 1
+    },
+    {
+      "source": "tableau_state",
+      "target": "tab_obligation",
+      "weight": 1
+    },
+    {
+      "source": "target",
+      "target": "rdf_term",
+      "weight": 1
+    },
+    {
+      "source": "target",
+      "target": "wf_iri",
+      "weight": 1
+    },
+    {
+      "source": "token_stream",
+      "target": "token",
+      "weight": 1
+    },
+    {
+      "source": "tp_explain",
+      "target": "bound_status",
+      "weight": 1
+    },
+    {
+      "source": "tp_explain",
+      "target": "triple_pattern",
+      "weight": 1
+    },
+    {
+      "source": "trig_parse_state",
+      "target": "turtle_state",
+      "weight": 1
+    },
+    {
+      "source": "triple",
+      "target": "rdf_term",
+      "weight": 1
+    },
+    {
+      "source": "triple",
+      "target": "subject",
+      "weight": 1
+    },
+    {
+      "source": "triple",
+      "target": "wf_iri",
+      "weight": 1
+    },
+    {
+      "source": "triple_pattern",
+      "target": "pattern_subject",
+      "weight": 1
+    },
+    {
+      "source": "triple_pattern",
+      "target": "pattern_term",
+      "weight": 1
+    },
+    {
+      "source": "triple_pattern",
+      "target": "wf_iri",
+      "weight": 1
+    },
+    {
+      "source": "triple_pattern_bound",
+      "target": "rdf_term",
+      "weight": 1
+    },
+    {
+      "source": "triple_pattern_bound",
+      "target": "subject",
+      "weight": 1
+    },
+    {
+      "source": "triple_pattern_bound",
+      "target": "wf_iri",
+      "weight": 1
+    },
+    {
+      "source": "turtle_doc_result",
+      "target": "triple",
+      "weight": 1
+    },
+    {
+      "source": "turtle_doc_result",
+      "target": "turtle_state",
+      "weight": 1
+    },
+    {
+      "source": "update_op",
+      "target": "graph_ref",
+      "weight": 1
+    },
+    {
+      "source": "update_op",
+      "target": "wf_iri",
+      "weight": 1
+    },
+    {
+      "source": "update_sandbox_result",
+      "target": "sparql_update",
+      "weight": 1
+    },
+    {
+      "source": "validation_report",
+      "target": "violation",
+      "weight": 1
+    },
+    {
+      "source": "verb_or_path",
+      "target": "pattern_term",
+      "weight": 1
+    },
+    {
+      "source": "violation",
+      "target": "constraint_component",
+      "weight": 1
+    },
+    {
+      "source": "violation",
+      "target": "path",
+      "weight": 1
+    },
+    {
+      "source": "violation",
+      "target": "rdf_term",
+      "weight": 1
+    },
+    {
+      "source": "violation",
+      "target": "severity",
+      "weight": 1
+    },
+    {
+      "source": "violation",
+      "target": "shape_ref",
+      "weight": 1
+    },
+    {
+      "source": "wf_iri",
+      "target": "iri",
+      "weight": 1
+    },
+    {
+      "source": "wf_literal",
+      "target": "literal",
+      "weight": 1
+    },
+    {
+      "source": "xml_node",
+      "target": "xml_attribute",
+      "weight": 1
+    }
+  ]
+}

--- a/scripts/fstar_terms_to_json.py
+++ b/scripts/fstar_terms_to_json.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""Extract F* type-level dependency graph: which types reference which
+other types in their body.
+
+Each `type Foo = ...` / `noeq type Foo = ...` / `unopteq type Foo = ...`
+declaration becomes a node. Edge A -> B is emitted whenever B's name
+appears as a bare identifier inside A's body.
+
+Limitations (intentional, called out in the SPA):
+- regex-based, no real F* parser; doesn't track shadowing, doesn't
+  follow `module M = X.Y` aliases.
+- bodies are captured up to the next top-level declaration, so
+  multi-line records with deeply nested types are fine, but anything
+  that spans into a comment or pre-condition might over-count.
+- only top-level types are nodes. fields and constructors are NOT
+  separate nodes (they're listed inside the type they belong to).
+
+Output: docs/web/demos/dep-graph/terms.json
+  { "nodes": [{"id", "namespace", "module", "kind", "fields"|"ctors"?,
+               "deps", "rdeps"} ...],
+    "links": [{"source", "target", "weight": 1} ...] }
+
+Run after fstar_dep_to_json.py (or stand-alone — they're independent).
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+FSTAR_DIR = ROOT / "formal" / "fstar"
+OUT = ROOT / "docs" / "web" / "demos" / "dep-graph" / "terms.json"
+
+TOP_LEVEL_KEYWORDS = (
+    "let", "val", "type", "module", "open", "include", "effect",
+    "assume", "private", "abstract",
+)
+TYPE_DECL_RE = re.compile(
+    r"^\s*(?:\[@@?[^\]]+\]\s*)?"
+    r"(?:(?:noeq|unopteq|inline_for_extraction|irreducible|private|abstract|new_effect|unfold)\s+)*"
+    r"type\s+([a-z_][\w']*)\b"
+)
+ANY_TOP_RE = re.compile(
+    r"^\s*(?:\[@@?[^\]]+\]\s*)?"
+    r"(?:(?:noeq|unopteq|inline_for_extraction|irreducible|private|abstract|"
+    r"new_effect|unfold|assume)\s+)*"
+    r"(let|val|type|module|open|include|effect)\b"
+)
+TOKEN_RE = re.compile(r"[A-Za-z_][\w']*")
+RECORD_FIELD_RE = re.compile(r"^\s*([a-z_][\w']*)\s*:\s*(.+?)\s*;?\s*$")
+CTOR_RE = re.compile(r"^\s*\|\s*([A-Z][\w']*)\b\s*:?\s*(.*)$")
+
+FSTAR_KEYWORDS = {
+    "let", "in", "rec", "and", "fun", "match", "with", "if", "then", "else",
+    "val", "type", "module", "open", "include", "begin", "end",
+    "true", "false", "Tot", "Lemma", "ST", "Stack", "Pure", "GTot",
+    "requires", "ensures", "modifies", "decreases", "by", "of",
+    "list", "option", "string", "int", "nat", "bool", "unit", "char", "Type", "prop",
+    "Some", "None", "exists", "forall", "fst", "snd", "Cons", "Nil",
+    "function", "noeq", "unopteq", "inline_for_extraction", "irreducible",
+    "private", "abstract", "assume", "unfold", "new_effect",
+}
+
+
+def strip_block_comments(src: str) -> str:
+    """Remove F* (* ... *) comments (nesting-aware) and // line comments."""
+    out = []
+    i, n, depth = 0, len(src), 0
+    while i < n:
+        if depth == 0 and src.startswith("//", i):
+            j = src.find("\n", i)
+            if j == -1:
+                break
+            i = j
+            continue
+        if src.startswith("(*", i):
+            depth += 1; i += 2; continue
+        if depth > 0 and src.startswith("*)", i):
+            depth -= 1; i += 2; continue
+        if depth == 0:
+            out.append(src[i])
+        i += 1
+    return "".join(out)
+
+
+def parse_module(path: Path):
+    """Return list of (type_name, body_lines, kind, fields_or_ctors)."""
+    src = strip_block_comments(path.read_text(encoding="utf-8", errors="replace"))
+    lines = src.split("\n")
+    decls = []
+    i = 0
+    while i < len(lines):
+        m = TYPE_DECL_RE.match(lines[i])
+        if not m:
+            i += 1
+            continue
+        name = m.group(1)
+        body_lines = [lines[i]]
+        j = i + 1
+        while j < len(lines):
+            ln = lines[j]
+            if ln.strip() and ANY_TOP_RE.match(ln):
+                break
+            body_lines.append(ln)
+            j += 1
+        body = "\n".join(body_lines)
+        # Classify and extract fields / ctors
+        if "{" in body and "}" in body:
+            kind = "record"
+            members = []
+            for ln in body_lines[1:]:
+                fm = RECORD_FIELD_RE.match(ln)
+                if fm and fm.group(1) not in FSTAR_KEYWORDS:
+                    members.append(fm.group(1))
+            fields_or_ctors = members
+        elif any(CTOR_RE.match(ln) for ln in body_lines):
+            kind = "variant"
+            ctors = [m.group(1) for ln in body_lines for m in [CTOR_RE.match(ln)] if m]
+            fields_or_ctors = ctors
+        else:
+            kind = "alias"
+            fields_or_ctors = []
+        decls.append((name, body, kind, fields_or_ctors))
+        i = j
+    return decls
+
+
+def main() -> int:
+    files = sorted(FSTAR_DIR.glob("*.fst")) + sorted(FSTAR_DIR.glob("*.fsti"))
+    by_name: dict[str, dict] = {}
+    by_module: dict[str, list[str]] = defaultdict(list)
+    bodies: dict[str, str] = {}
+    for f in files:
+        mod = f.stem
+        for name, body, kind, members in parse_module(f):
+            if name in by_name:
+                # Same name in multiple modules — keep first, log dup
+                continue
+            by_name[name] = {
+                "id": name, "module": mod, "namespace": mod.split(".", 1)[0],
+                "kind": kind, "members": members,
+            }
+            by_module[mod].append(name)
+            bodies[name] = body
+
+    # Build edges by tokenizing each body and matching against known type names
+    edges: list[tuple[str, str]] = []
+    for src_name, body in bodies.items():
+        # Skip the head "type X =" line — we want the RHS only
+        first_eq = body.find("=")
+        rhs = body[first_eq + 1:] if first_eq != -1 else body
+        seen_targets = set()
+        for tok in TOKEN_RE.findall(rhs):
+            if tok in FSTAR_KEYWORDS or tok == src_name:
+                continue
+            if tok in by_name and tok not in seen_targets:
+                edges.append((src_name, tok))
+                seen_targets.add(tok)
+
+    deg_in: dict[str, int] = defaultdict(int)
+    deg_out: dict[str, int] = defaultdict(int)
+    for a, b in edges:
+        deg_out[a] += 1
+        deg_in[b] += 1
+
+    nodes_out = []
+    for name, info in sorted(by_name.items()):
+        nodes_out.append({
+            "id": name,
+            "namespace": info["namespace"],
+            "module": info["module"],
+            "kind": info["kind"],
+            "members": info["members"],
+            "deps": deg_out.get(name, 0),
+            "rdeps": deg_in.get(name, 0),
+            "inProject": True,
+        })
+    out = {
+        "nodes": nodes_out,
+        "links": [{"source": a, "target": b, "weight": 1} for a, b in sorted(set(edges))],
+    }
+    OUT.parent.mkdir(parents=True, exist_ok=True)
+    OUT.write_text(json.dumps(out, indent=2) + "\n")
+    print(f"types: {len(nodes_out)} nodes, {len(out['links'])} edges")
+    print(f"top referenced: " + ", ".join(
+        f"{n['id']}({n['rdeps']})"
+        for n in sorted(nodes_out, key=lambda n: -n["rdeps"])[:8]
+    ))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Follow-up to #255. Two commits:

- **Mobile / narrow-viewport responsive layout** (`de08eab`).
  The 280px sidebar + 320px details panel ate the entire iPhone width and the graph column collapsed to zero (reproduced on iOS Safari). Below 900px viewport width, the side panels become slide-in drawers (`☰` opens namespace/search/view, `ⓘ` opens details), the graph fills the viewport, selecting a node auto-opens the details drawer, and picking a namespace auto-closes the sidebar so the filter result is visible. Wide viewports keep the original 3-column layout. `100dvh` avoids the iOS URL-bar resize jitter; `touch-action: none` lets d3-zoom capture pinch/drag.

- **Types & terms view + fullscreen toggle** (`93442ad`).
  Adds a third option in the View dropdown alongside per-module / by-namespace: every F\* type declaration as a node (record / variant / alias), with edges where one type's body references another. Captures the domain vocabulary — `triple`, `rdf_term`, `rdf_graph`, `subject`, `iri`, `graph_backend`, `dataset_backend`, etc. — at **207 nodes / 228 edges**. Top hubs match intuition: `wf_iri` (19 importers), `rdf_term` (18), `iri` (15), `triple` (11). Different node shape per kind (square / diamond / circle); details panel lists fields and constructors. New `⛶` fullscreen button on the toolbar (also `F` key when not focused in an input) — re-centers the simulation on enter/exit.

Adds `scripts/fstar_terms_to_json.py` (regex-based, no real F\* parser — limitations called out in the docstring) and `docs/web/demos/dep-graph/terms.json` (80 kB). Eleventy gains a passthrough rule for `terms.json`.

Public URL after deploy: https://danbri.github.io/factoidal/web/demos/dep-graph/

## Test plan

- [x] Eleventy build clean: `_site/web/demos/dep-graph/` contains `index.html`, `modules.json`, `namespaces.json`, `terms.json`, plus all the static .dot/.svg/.png/.mmd/.txt renders.
- [x] Local serve: all four assets return 200 with correct content-types; `terms.json` parses to 207 nodes / 228 edges with the expected hub set.
- [x] Spot-checked node shape: `triple` → record (s/p/o), `rdf_term` → variant (T_IRI/T_BNode/T_Literal), `rdf_graph` → alias.
- [ ] After merge, retest on iPhone Safari — confirm drawers slide in, graph fills viewport, types view renders, fullscreen toggle works on desktop.

## Caveats

- **Term graph is heuristic.** Regex-based — doesn't track let-shadowing, doesn't follow `module M = X.Y` aliases, treats every type-name token in a body as a reference (will over-count when the same identifier is shadowed locally). The module-level graph from `fstar.exe --dep` remains the authoritative source for build dependencies. The term graph is for navigation / "where is `triple` defined and used?" — not a soundness claim.
- Only top-level `type` declarations become nodes. `val` and `let` bindings are not in scope yet — easy follow-up if useful.

https://claude.ai/code/session_01E5hkR24d7DrsNjZHEtSwaV

---
_Generated by [Claude Code](https://claude.ai/code/session_01E5hkR24d7DrsNjZHEtSwaV)_