### PR TITLE
dep-graph: type names readable by default in terms view

### DIFF
--- a/docs/web/demos/dep-graph/index.html
+++ b/docs/web/demos/dep-graph/index.html
@@ -260,8 +260,8 @@ function render() {
     ? 8 + Math.sqrt(d.modules || 1) * 3
     : 4 + Math.sqrt((d.deps || 0) + (d.rdeps || 0)) * 1.6;
 
-  const linkDist = isNs ? 130 : (view === "terms" ? 50 : 55);
-  const charge = isNs ? -600 : (view === "terms" ? -120 : -90);
+  const linkDist = isNs ? 130 : (view === "terms" ? 80 : 55);
+  const charge = isNs ? -600 : (view === "terms" ? -260 : -90);
   const sim = d3.forceSimulation(nodes)
     .force("link", d3.forceLink(links).id(d => d.id).distance(linkDist).strength(0.6))
     .force("charge", d3.forceManyBody().strength(charge))
@@ -323,12 +323,15 @@ function render() {
     view === "terms"
       ? `${d.id}  (${d.kind})\nin ${d.module}\nuses ${d.deps || 0}\nused by ${d.rdeps || 0}`
       : `${d.id}\nimports ${d.deps || 0}\nimported by ${d.rdeps || 0}`);
-  node.append("text").attr("x", d => radius(d) + 4).attr("y", 3)
+  node.append("text")
+      .attr("x", d => radius(d) + 4).attr("y", 3)
+      .style("font-size", view === "terms" ? "12px" : "10px")
       .text(d => view === "modules" ? d.id.split(".").slice(-1)[0] : d.id);
 
   state.graph = { nodes, links, link, node };
   toggleLabels(state.showLabels);
   toggleLeaves(state.showLeaves);
+  refreshLabels();
 
   sim.on("tick", () => {
     link.attr("x1", d => d.source.x).attr("y1", d => d.source.y)
@@ -418,12 +421,29 @@ function refreshHighlight() {
     (focusId && l.source.id !== focusId && l.target.id !== focusId) ||
     (focusNs && l.source.namespace !== focusNs && l.target.namespace !== focusNs && !focusId)
   ).classed("hi", l => focusId && (l.source.id === focusId || l.target.id === focusId));
+  refreshLabels();
 }
 
 function toggleLabels(on) {
   state.showLabels = on;
   d3.select("#btn-labels").classed("on", on);
-  if (state.graph) state.graph.node.selectAll("text").style("display", on ? "" : "none");
+  refreshLabels();
+}
+function labelVisible(d) {
+  if (!state.showLabels) return false;
+  if (state.view !== "terms") return true;
+  // Terms view has 200+ nodes; only show labels for hubs by default to
+  // avoid an unreadable jumble. Hover/select always reveals the label.
+  if (state.selected && state.selected.id === d.id) return true;
+  if (state.hover    && state.hover.id    === d.id) return true;
+  if (state.hoverNs  && d.namespace === state.hoverNs) return true;
+  if (state.pinnedNs && d.namespace === state.pinnedNs) return true;
+  return ((d.deps || 0) + (d.rdeps || 0)) >= 3;
+}
+function refreshLabels() {
+  if (!state.graph) return;
+  state.graph.node.selectAll("text")
+    .style("display", d => labelVisible(d) ? "" : "none");
 }
 function toggleLeaves(on) {
   state.showLeaves = on;


### PR DESCRIPTION
## Summary

Follow-up to #256. In the types view, 207 nodes packed at default zoom made labels collide into illegible noise — "where are the type names?". Three fixes:

- **Default-on labels for the 60 hub types** (deps+rdeps ≥ 3). Covers the canonical vocabulary on load: `rdf_term, wf_iri, iri, triple, expr, bnode_id, graph_backend, subject, var_name, rdf_graph, triple_pattern, graph_store, solution_mapping, ...`
- **Hover or select reveals the rest** — leaf type labels appear on mouseover. Pinning a namespace from the legend reveals every label in that namespace.
- **Spread nodes apart** (link distance 50→80, charge -120→-260) so the always-on labels have room to breathe; terms-view font bumped from 10 to 12 px.

The `Labels` toolbar button still toggles all labels off/on as a hard override. Modules and namespaces views are unchanged (every node already had a visible label there — only the dense types view was affected).

## Test plan

- [x] Local: 60 of 207 type nodes meet the deg≥3 threshold and label by default; rest reveal on hover.
- [x] Top labels seen on first paint match the canonical RDF/SPARQL vocabulary.
- [ ] After deploy, retest on desktop + iPhone — confirm labels readable at default zoom and the Labels toggle still works.

https://claude.ai/code/session_01E5hkR24d7DrsNjZHEtSwaV

---
_Generated by [Claude Code](https://claude.ai/code/session_01E5hkR24d7DrsNjZHEtSwaV)_